### PR TITLE
Set zip modified time to Now

### DIFF
--- a/builder/zipper.go
+++ b/builder/zipper.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 type Zipper struct {
@@ -29,6 +30,7 @@ func (z Zipper) Add(path string, file io.Reader) error {
 	return z.add(&zip.FileHeader{
 		Name:   path,
 		Method: zip.Deflate,
+		Modified: time.Now(),
 	}, file)
 }
 
@@ -40,6 +42,7 @@ func (z Zipper) AddWithMode(path string, file io.Reader, mode os.FileMode) error
 	fh := &zip.FileHeader{
 		Name:   path,
 		Method: zip.Deflate,
+		Modified: time.Now(),
 	}
 	fh.SetMode(mode)
 
@@ -71,7 +74,11 @@ func (z Zipper) CreateFolder(path string) error {
 
 	path = fmt.Sprintf("%s%c", filepath.Clean(path), filepath.Separator)
 
-	_, err := z.writer.Create(path)
+	fh := &zip.FileHeader{
+		Name:   path,
+		Modified: time.Now(),
+	}
+	_, err := z.writer.CreateHeader(fh)
 	if err != nil {
 		return err
 	}

--- a/builder/zipper_test.go
+++ b/builder/zipper_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("Zipper", func() {
@@ -54,6 +55,7 @@ var _ = Describe("Zipper", func() {
 			Expect(reader.File).To(HaveLen(1))
 			Expect(reader.File[0].Name).To(Equal("some/path/to/folder/"))
 			Expect(reader.File[0].Mode().IsDir()).To(BeTrue())
+			Expect(reader.File[0].FileHeader.Modified).To(BeTemporally("~", time.Now(), time.Minute))
 		})
 
 		It("does not append separator if already given to the input", func() {
@@ -111,6 +113,7 @@ var _ = Describe("Zipper", func() {
 
 			Expect(contents).To(Equal([]byte("file contents")))
 			Expect(reader.File[0].FileHeader.Mode()).To(Equal(os.FileMode(0666)))
+			Expect(reader.File[0].FileHeader.Modified).To(BeTemporally("~", time.Now(), time.Minute))
 		})
 
 		Context("failure cases", func() {
@@ -163,6 +166,7 @@ var _ = Describe("Zipper", func() {
 
 			Expect(contents).To(Equal([]byte("file contents")))
 			Expect(reader.File[0].FileHeader.Mode()).To(Equal(os.FileMode(0644)))
+			Expect(reader.File[0].FileHeader.Modified).To(BeTemporally("~", time.Now(), time.Minute))
 		})
 
 		Context("failure cases", func() {


### PR DESCRIPTION
When zipping files, their modified time header is set to now rather than
defaulting to 29 November 1979.

This was causing the ruby zip library used by OM to produce a pesky warning: "Invalid date/time in zip entry"

Signed-off-by: Panagiotis Xynos <panagiotis.xynos@engineerbetter.com>