### PR TITLE
Remove regex from assets.yml

### DIFF
--- a/commands/fetch_test.go
+++ b/commands/fetch_test.go
@@ -25,7 +25,6 @@ compiled_releases:
   region: us-west-1
   access_key_id: mykey
   secret_access_key: mysecret
-  regex: ^2.5/.+/(?P<release_name>[a-z-_]+)-(?P<release_version>[0-9\.]+)-(?P<stemcell_os>[a-z-_]+)-(?P<stemcell_version>[\d\.]+)\.tgz$
 `
 
 const MinimalAssetsLockContents = `
@@ -100,7 +99,6 @@ var _ = Describe("Fetch", func() {
 					Region:          "us-west-1",
 					AccessKeyId:     "mykey",
 					SecretAccessKey: "mysecret",
-					Regex:           `^2.5/.+/(?P<release_name>[a-z-_]+)-(?P<release_version>[0-9\.]+)-(?P<stemcell_os>[a-z-_]+)-(?P<stemcell_version>[\d\.]+)\.tgz$`,
 				}
 				Expect(fakeReleaseMatcher.GetMatchedReleasesCallCount()).To(Equal(1))
 				compiledReleases, assetsLock := fakeReleaseMatcher.GetMatchedReleasesArgsForCall(0)
@@ -238,7 +236,6 @@ compiled_releases:
   region: $( variable "region" )
   access_key_id: $( variable "access_key" )
   secret_access_key: $( variable "secret_key" )
-  regex: $( variable "regex" )
 `
 
 				BeforeEach(func() {
@@ -268,7 +265,6 @@ compiled_releases:
 					variables = map[string]string{
 						"access_key": "newkey",
 						"secret_key": "newsecret",
-						"regex":      `^2.5/.+/(?P<release_name>[a-z-_]+)-(?P<release_version>[0-9\.]+)-(?P<stemcell_os>[a-z-_]+)-(?P<stemcell_version>[\d\.]+)\.tgz$`,
 					}
 					data, err = yaml.Marshal(&variables)
 					Expect(err).NotTo(HaveOccurred())
@@ -296,7 +292,6 @@ compiled_releases:
 						Region:          "north-east-1",
 						AccessKeyId:     "newkey",
 						SecretAccessKey: "newsecret",
-						Regex:           `^2.5/.+/(?P<release_name>[a-z-_]+)-(?P<release_version>[0-9\.]+)-(?P<stemcell_os>[a-z-_]+)-(?P<stemcell_version>[\d\.]+)\.tgz$`,
 					}))
 				})
 			})

--- a/fetcher/compiled_releases_regexp_test.go
+++ b/fetcher/compiled_releases_regexp_test.go
@@ -15,7 +15,7 @@ var _ = Describe("CompiledReleasesRegexp", func() {
 	)
 
 	It("takes a regex string and converts it to a CompiledRelease", func() {
-		regex, err = fetcher.NewCompiledReleasesRegexp(`^2.5/.+/(?P<release_name>[a-z-_]+)-(?P<release_version>[0-9\.]+)-(?P<stemcell_os>[a-z-_]+)-(?P<stemcell_version>[\d\.]+)\.tgz$`)
+		regex, err = fetcher.NewCompiledReleasesRegexp(`(?P<release_name>uaa)-(?P<release_version>1\.2\.3)-(?P<stemcell_os>ubuntu-trusty)-(?P<stemcell_version>123)`)
 		Expect(err).NotTo(HaveOccurred())
 
 		compiledRelease, err = regex.Convert("2.5/uaa/uaa-1.2.3-ubuntu-trusty-123.tgz")
@@ -24,16 +24,16 @@ var _ = Describe("CompiledReleasesRegexp", func() {
 	})
 
 	It("returns an error if s3 key does not match the regex", func() {
-		regex, err = fetcher.NewCompiledReleasesRegexp(`^2.5/.+/(?P<release_name>[a-z-_]+)-(?P<release_version>[0-9\.]+)-(?P<stemcell_os>[a-z-_]+)-(?P<stemcell_version>[\d\.]+)\.tgz$`)
+		regex, err = fetcher.NewCompiledReleasesRegexp(`(?P<release_name>uaa)-(?P<release_version>1\.2\.3)-(?P<stemcell_os>ubuntu-trusty)-(?P<stemcell_version>123)`)
 		Expect(err).NotTo(HaveOccurred())
 
-		compiledRelease, err = regex.Convert("2.5/uaa/uaa-1.2.3-123.tgz")
+		compiledRelease, err = regex.Convert("total nonsense")
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError("s3 key does not match regex"))
 	})
 
 	It("returns an error if a capture is missing", func() {
-		regex, err = fetcher.NewCompiledReleasesRegexp(`^2.5/.+/([a-z-_]+)-(?P<release_version>[0-9\.]+)-(?P<stemcell_os>[a-z-_]+)-(?P<stemcell_version>[\d\.]+)\.tgz$`)
+		regex, err = fetcher.NewCompiledReleasesRegexp(`(?P<release_name>uaa)`)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(ContainSubstring("release_name, release_version, stemcell_os, stemcell_version")))
 	})

--- a/fetcher/release_matcher.go
+++ b/fetcher/release_matcher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pivotal-cf/kiln/internal/cargo"
 )
 
-const baseRegex = `^.+/.+/(?P<release_name>[a-z-_0-9]+)-(?P<release_version>v?[0-9\.]+(-\w+)??)-(?P<stemcell_os>([a-z_]*-?){1,2})-(?P<stemcell_version>\d+\.\d+)(\.0)?\.tgz$`
+const baseRegex = `^.+/(?P<release_name>[a-z-_0-9]+)-(?P<release_version>v?[0-9\.]+(-\w+)??)-(?P<stemcell_os>([a-z_]*-?){1,2})-(?P<stemcell_version>\d+\.\d+)(\.0)?\.tgz$`
 
 type ReleaseMatcher struct {
 	s3Provider s3Provider

--- a/fetcher/release_matcher.go
+++ b/fetcher/release_matcher.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pivotal-cf/kiln/internal/cargo"
 )
 
+const baseRegex = `^%s/.+/(?P<release_name>[a-z-_0-9]+)-(?P<release_version>v?[0-9\.]+(-\w+)??)-(?P<stemcell_os>([a-z_]*-?){1,2})-(?P<stemcell_version>\d+\.\d+)(\.0)?\.tgz$`
+
 type ReleaseMatcher struct {
 	s3Provider s3Provider
 }
@@ -23,7 +25,7 @@ func NewReleaseMatcher(s3Provider s3Provider) ReleaseMatcher {
 func (r ReleaseMatcher) GetMatchedReleases(compiledReleases cargo.CompiledReleases, assetsLock cargo.AssetsLock) (map[cargo.CompiledRelease]string, error) {
 	matchedS3Objects := make(map[cargo.CompiledRelease]string)
 
-	regex, err := NewCompiledReleasesRegexp(compiledReleases.Regex)
+	regex, err := NewCompiledReleasesRegexp(fmt.Sprintf(baseRegex, compiledReleases.PASVersion))
 	if err != nil {
 		return nil, err
 	}

--- a/fetcher/release_matcher.go
+++ b/fetcher/release_matcher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pivotal-cf/kiln/internal/cargo"
 )
 
-const baseRegex = `^%s/.+/(?P<release_name>[a-z-_0-9]+)-(?P<release_version>v?[0-9\.]+(-\w+)??)-(?P<stemcell_os>([a-z_]*-?){1,2})-(?P<stemcell_version>\d+\.\d+)(\.0)?\.tgz$`
+const baseRegex = `^.+/.+/(?P<release_name>[a-z-_0-9]+)-(?P<release_version>v?[0-9\.]+(-\w+)??)-(?P<stemcell_os>([a-z_]*-?){1,2})-(?P<stemcell_version>\d+\.\d+)(\.0)?\.tgz$`
 
 type ReleaseMatcher struct {
 	s3Provider s3Provider
@@ -25,7 +25,7 @@ func NewReleaseMatcher(s3Provider s3Provider) ReleaseMatcher {
 func (r ReleaseMatcher) GetMatchedReleases(compiledReleases cargo.CompiledReleases, assetsLock cargo.AssetsLock) (map[cargo.CompiledRelease]string, error) {
 	matchedS3Objects := make(map[cargo.CompiledRelease]string)
 
-	regex, err := NewCompiledReleasesRegexp(fmt.Sprintf(baseRegex, compiledReleases.PASVersion))
+	regex, err := NewCompiledReleasesRegexp(baseRegex)
 	if err != nil {
 		return nil, err
 	}

--- a/fetcher/release_matcher.go
+++ b/fetcher/release_matcher.go
@@ -82,7 +82,7 @@ func (r ReleaseMatcher) GetMatchedReleases(compiledReleases cargo.CompiledReleas
 			))
 
 		}
-		return nil, fmt.Errorf("Expected releases were not matched by the regex:\n%s", strings.Join(formattedMissingReleases, "\n"))
+		return nil, fmt.Errorf("Expected releases were not matched by the regex\n Regex: %q\n Releases: %s", baseRegex, strings.Join(formattedMissingReleases, "\n"))
 	}
 
 	return matchingReleases, nil

--- a/fetcher/release_matcher_test.go
+++ b/fetcher/release_matcher_test.go
@@ -28,7 +28,7 @@ var _ = Describe("GetMatchedReleases", func() {
 			},
 			Stemcell: cargo.Stemcell{
 				OS:      "ubuntu-xenial",
-				Version: "190.0.0",
+				Version: "190.0",
 			},
 		}
 
@@ -78,7 +78,7 @@ var _ = Describe("GetMatchedReleases", func() {
 		Expect(input.Bucket).To(Equal(aws.String("some-bucket")))
 
 		Expect(matchedS3Objects).To(HaveLen(1))
-		Expect(matchedS3Objects).To(HaveKeyWithValue(cargo.CompiledRelease{Name: "bpm", Version: "1.2.3-lts", StemcellOS: "ubuntu-xenial", StemcellVersion: "190.0.0"}, bpmKey))
+		Expect(matchedS3Objects).To(HaveKeyWithValue(cargo.CompiledRelease{Name: "bpm", Version: "1.2.3-lts", StemcellOS: "ubuntu-xenial", StemcellVersion: "190.0"}, bpmKey))
 	})
 
 	Context("if any objects in S3 do not match a release specified in assets.lock", func() {
@@ -104,7 +104,7 @@ var _ = Describe("GetMatchedReleases", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(matchedS3Objects).To(HaveLen(1))
-			Expect(matchedS3Objects).To(HaveKeyWithValue(cargo.CompiledRelease{Name: "bpm", Version: "1.2.3-lts", StemcellOS: "ubuntu-xenial", StemcellVersion: "190.0.0"}, bpmKey))
+			Expect(matchedS3Objects).To(HaveKeyWithValue(cargo.CompiledRelease{Name: "bpm", Version: "1.2.3-lts", StemcellOS: "ubuntu-xenial", StemcellVersion: "190.0"}, bpmKey))
 		})
 	})
 
@@ -131,7 +131,7 @@ var _ = Describe("GetMatchedReleases", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(matchedS3Objects).To(HaveLen(1))
-			Expect(matchedS3Objects).To(HaveKeyWithValue(cargo.CompiledRelease{Name: "bpm", Version: "1.2.3-lts", StemcellOS: "ubuntu-xenial", StemcellVersion: "190.0.0"}, bpmKey))
+			Expect(matchedS3Objects).To(HaveKeyWithValue(cargo.CompiledRelease{Name: "bpm", Version: "1.2.3-lts", StemcellOS: "ubuntu-xenial", StemcellVersion: "190.0"}, bpmKey))
 		})
 	})
 
@@ -146,9 +146,9 @@ var _ = Describe("GetMatchedReleases", func() {
 
 		It("returns an error", func() {
 			_, err = releaseMatcher.GetMatchedReleases(compiledReleases, assetsLock)
-			Expect(err).To(MatchError(`Expected releases were not matched by the regex:
-{Name:some-release Version:1.2.3 StemcellOS:ubuntu-xenial StemcellVersion:190.0.0}
-{Name:another-missing-release Version:4.5.6 StemcellOS:ubuntu-xenial StemcellVersion:190.0.0}`))
+			Expect(err.Error()).To(ContainSubstring("Expected releases were not matched by the regex"))
+			Expect(err.Error()).To(ContainSubstring("{Name:some-release Version:1.2.3 StemcellOS:ubuntu-xenial StemcellVersion:190.0}"))
+			Expect(err.Error()).To(ContainSubstring("{Name:another-missing-release Version:4.5.6 StemcellOS:ubuntu-xenial StemcellVersion:190.0}"))
 
 			input, _ := fakeS3Client.ListObjectsPagesArgsForCall(0)
 			Expect(input.Bucket).To(Equal(aws.String("some-bucket")))

--- a/fetcher/release_matcher_test.go
+++ b/fetcher/release_matcher_test.go
@@ -37,7 +37,6 @@ var _ = Describe("GetMatchedReleases", func() {
 			Region:          "north-east-1",
 			AccessKeyId:     "newkey",
 			SecretAccessKey: "newsecret",
-			PASVersion:      "2.5",
 		}
 		fakeS3Client = new(fakes.S3Client)
 

--- a/fetcher/release_matcher_test.go
+++ b/fetcher/release_matcher_test.go
@@ -37,7 +37,7 @@ var _ = Describe("GetMatchedReleases", func() {
 			Region:          "north-east-1",
 			AccessKeyId:     "newkey",
 			SecretAccessKey: "newsecret",
-			Regex:           `^2.5/.+/(?P<release_name>[a-z-_]+)-(?P<release_version>[0-9\.]+(-\w+(\.[0-9]+)?)?)-(?P<stemcell_os>[a-z-_]+)-(?P<stemcell_version>[\d\.]+)\.tgz$`,
+			PASVersion:      "2.5",
 		}
 		fakeS3Client = new(fakes.S3Client)
 

--- a/internal/cargo/manifest.go
+++ b/internal/cargo/manifest.go
@@ -41,7 +41,7 @@ type CompiledReleases struct {
 	Region          string `yaml:"region"`
 	AccessKeyId     string `yaml:"access_key_id"`
 	SecretAccessKey string `yaml:"secret_access_key"`
-	Regex           string `yaml:"regex"`
+	PASVersion      string `yaml:"pas_version"`
 }
 
 type CompiledRelease struct {

--- a/internal/cargo/manifest.go
+++ b/internal/cargo/manifest.go
@@ -41,7 +41,6 @@ type CompiledReleases struct {
 	Region          string `yaml:"region"`
 	AccessKeyId     string `yaml:"access_key_id"`
 	SecretAccessKey string `yaml:"secret_access_key"`
-	PASVersion      string `yaml:"pas_version"`
 }
 
 type CompiledRelease struct {


### PR DESCRIPTION
In lieu of using a configurable regex in `assets.yml`, this PR hard-codes the regex.

The new hard-coded regex is `^.+/(?P<release_name>[a-z-_0-9]+)-(?P<release_version>v?[0-9\.]+(-\w+)??)-(?P<stemcell_os>([a-z_]*-?){1,2})-(?P<stemcell_version>\d+\.\d+)(\.0)?\.tgz$`. In particular, this matches `-lts` release versions, and is agnostic as to S3 directory structure.

There are future improvements that can be made to configurability, some of which might involve removing the regex now that it's an internal implementation detail.

We're making this change because seriously, look at that regex, it's awful, are we really asking users to configure and understand it? 🙀