### PR TITLE
Create stub metadata when no tgz file exists

### DIFF
--- a/builder/interpolator.go
+++ b/builder/interpolator.go
@@ -100,6 +100,8 @@ func (i Interpolator) interpolate(input InterpolateInput, templateYAML []byte) (
 					val = map[string]interface{}{
 						"name":    name,
 						"version": "UNKNOWN",
+						"file":    fmt.Sprintf("%s-UNKNOWN.tgz", name),
+						"sha1":    "dead8e1ea5e00dead8e1ea5ed00ead8e1ea5e000",
 					}
 				} else {
 					return "", fmt.Errorf("could not find release with name '%s'", name)

--- a/builder/interpolator_test.go
+++ b/builder/interpolator_test.go
@@ -376,7 +376,7 @@ some_runtime_configs:
 	})
 
 	Context("when release tgz file does not exist and stub releases is true", func() {
-		It("sets version to unknown", func() {
+		It("creates stub values for file, sha1, and version", func() {
 
 			interpolator := NewInterpolator()
 			input.StubReleases = true
@@ -385,6 +385,8 @@ some_runtime_configs:
 			Expect(err).NotTo(HaveOccurred())
 			Expect(interpolatedYAML).To(HelpfullyMatchYAML(`releases:
 - name: stub-release
+  file: stub-release-UNKNOWN.tgz
+  sha1: dead8e1ea5e00dead8e1ea5ed00ead8e1ea5e000
   version: UNKNOWN`))
 		})
 	})


### PR DESCRIPTION
Prior to this change, tiles created with --stub-releases would often
fail to upload properly to Ops Manager.

This is problematic since the --stub-releases
feature exists primarily to aid tile developers in iterating more
quickly on UI changes with a real Ops Manager.

https://github.com/pivotal-cf/kiln/issues/43
https://www.pivotaltracker.com/story/show/172467082