### PR TITLE
Bug/173968315 find release version runtime error

### DIFF
--- a/fetcher/s3_release_source.go
+++ b/fetcher/s3_release_source.go
@@ -156,7 +156,7 @@ func (src S3ReleaseSource) FindReleaseVersion(requirement release.Requirement) (
 		return release.Remote{}, false, err
 	}
 
-	semverPattern, err := regexp.Compile("-\\d+(.\\d+)*")
+	semverPattern, err := regexp.Compile("(-|v)\\d+(.\\d+)*")
 	if err != nil {
 		return release.Remote{}, false, err
 	}
@@ -173,6 +173,7 @@ func (src S3ReleaseSource) FindReleaseVersion(requirement release.Requirement) (
 		version := versions[0]
 		stemcellVersion := versions[len(versions)-1]
 		version = strings.Replace(version, "-", "", -1)
+		version = strings.Replace(version, "v", "", -1)
 		stemcellVersion = strings.Replace(stemcellVersion, "-", "", -1)
 		if len(versions) > 1 && stemcellVersion != requirement.StemcellVersion {
 			continue

--- a/fetcher/s3_release_source.go
+++ b/fetcher/s3_release_source.go
@@ -138,32 +138,6 @@ func (src S3ReleaseSource) GetMatchedRelease(requirement release.Requirement) (r
 	}, true, nil
 }
 
-type ByVersion []release.Remote
-
-func (a ByVersion) Len() int      { return len(a) }
-func (a ByVersion) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a ByVersion) Less(i, j int) bool {
-	v1, _ := semver.NewVersion(a[i].ID.Version)
-	v2, _ := semver.NewVersion(a[j].ID.Version)
-	if v1.Equal(v2) {
-		// we have two files with the same version, so compare the stemcell versions
-		s1 := getStemcellVersion(a[i].RemotePath)
-		s2 := getStemcellVersion(a[j].RemotePath)
-		return s1.LessThan(s2)
-	}
-	return v1.LessThan(v2)
-}
-
-func getStemcellVersion(path string) *semver.Version {
-	stemcellVersion, _ := regexp.Compile(`-(\d+\.\d+).tgz`)
-	matchedVersions := stemcellVersion.FindStringSubmatch(path)
-	version := "0.0.0"
-	if matchedVersions != nil {
-		version = matchedVersions[1]
-	}
-	retVersion, _ := semver.NewVersion(version)
-	return retVersion
-}
 
 func (src S3ReleaseSource) FindReleaseVersion(requirement release.Requirement) (release.Remote, bool, error) {
 	pathTemplatePattern, _ := regexp.Compile(`^\d+\.\d+`)


### PR DESCRIPTION
References issue #92.

Modified regex for matching the versions of `find-release-version` to include versions with initial 'v' (ex. v1.2.3).

Also took the opportunity to clean up some unused code.