### PR TITLE
kiln can pre-process tile repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,21 @@ kiln
 kiln helps you build ops manager compatible tiles
 
 Usage: kiln [options] <command> [<args>]
-  --help, -h                                               bool    prints this usage information (default: false)
-  --pivotal-network-token, -pt, PIVOTAL_NETWORK_API_TOKEN  string  uaa access token for network.pivotal.io
-  --version, -v                                            bool    prints the kiln release version (default: false)
+  --help, -h     bool  prints this usage information (default: false)
+  --version, -v  bool  prints the kiln release version (default: false)
 
 Commands:
-  bake     bakes a tile
-  fetch    fetches releases
-  help     prints this usage information
-  update   updates stemcell_criteria and releases
-  version  prints the kiln release version
+  bake                    bakes a tile
+  compile-built-releases  compiles built releases and uploads them
+  fetch                   fetches releases
+  find-release-version    prints a json string of a remote release satisfying the Kilnfile version and stemcell constraints
+  help                    prints this usage information
+  publish                 publish tile on Pivnet
+  sync-with-local         update the Kilnfile.lock based on local releases
+  update-release          bumps a release to a new version
+  update-stemcell         updates Kilnfile.lock with stemcell info
+  upload-release          uploads a BOSH release to an s3 release_source
+  version                 prints the kiln release version
 ```
 
 ### `fetch`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Commands:
   fetch                   fetches releases
   find-release-version    prints a json string of a remote release satisfying the Kilnfile version and stemcell constraints
   help                    prints this usage information
+  pre-process             preprocess yaml files
   publish                 publish tile on Pivnet
   sync-with-local         update the Kilnfile.lock based on local releases
   update-release          bumps a release to a new version

--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -22,6 +22,7 @@ Commands:
   fetch                   fetches releases
   find-release-version    prints a json string of a remote release satisfying the Kilnfile version and stemcell constraints
   help                    prints this usage information
+  pre-process             preprocess yaml files
   publish                 publish tile on Pivnet
   sync-with-local         update the Kilnfile.lock based on local releases
   update-release          bumps a release to a new version

--- a/commands/pre_process.go
+++ b/commands/pre_process.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pivotal-cf/jhanda"
+	"github.com/pivotal-cf/kiln/internal/cargo"
+	"github.com/pivotal-cf/kiln/internal/preprocess"
+	"gopkg.in/src-d/go-billy.v4/osfs"
+	"gopkg.in/yaml.v2"
+)
+
+type PreProcess struct {
+	Options struct {
+		Kilnfile string `short:"kf" long:"kilnfile" default:"Kilnfile" description:"path to Kilnfile"`
+
+		TileName   string `short:"n" long:"tile-name" description:"name of tile to pre-process"`
+		InputPath  string `short:"i" long:"input-path" default:"." description:"path to metadata parts directory"`
+		OutputPath string `short:"o" long:"output-path" default:"." description:"path to output directory"`
+
+		TileNames string `short:"tn" long:"tile-names" description:"a comma separated list of tile names"`
+	}
+}
+
+func (cmd PreProcess) Execute(_ []string) error {
+	kilnFile, err := os.Open(cmd.Options.Kilnfile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = kilnFile.Close()
+	}()
+
+	var kilnfile cargo.Kilnfile
+	if err := yaml.NewDecoder(kilnFile).Decode(&kilnfile); err != nil {
+		return fmt.Errorf("could not parse Kilnfile: %s", err)
+	}
+	if len(kilnfile.TileNames) == 0 {
+		kilnfile.TileNames = strings.Split(cmd.Options.TileNames, ",")
+	}
+	for i := range kilnfile.TileNames {
+		kilnfile.TileNames[i] = strings.TrimSpace(kilnfile.TileNames[i])
+	}
+
+	err = preprocess.Run(osfs.New(cmd.Options.OutputPath), osfs.New(cmd.Options.InputPath), cmd.Options.TileName, kilnfile.TileNames)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd PreProcess) Usage() jhanda.Usage {
+	return jhanda.Usage{
+		Description:      "Preprocesses yaml files using Go template and adds some helper functions.",
+		ShortDescription: "preprocess yaml files",
+		Flags:            cmd.Options,
+	}
+}

--- a/commands/pre_process.go
+++ b/commands/pre_process.go
@@ -24,7 +24,12 @@ type PreProcess struct {
 	}
 }
 
-func (cmd PreProcess) Execute(_ []string) error {
+func (cmd PreProcess) Execute(args []string) error {
+	_, err := jhanda.Parse(&cmd.Options, args)
+	if err != nil {
+		return err
+	}
+
 	kilnFile, err := os.Open(cmd.Options.Kilnfile)
 	if err != nil {
 		return err
@@ -39,9 +44,6 @@ func (cmd PreProcess) Execute(_ []string) error {
 	}
 	if len(kilnfile.TileNames) == 0 {
 		kilnfile.TileNames = strings.Split(cmd.Options.TileNames, ",")
-	}
-	for i := range kilnfile.TileNames {
-		kilnfile.TileNames[i] = strings.TrimSpace(kilnfile.TileNames[i])
 	}
 
 	err = preprocess.Run(osfs.New(cmd.Options.OutputPath), osfs.New(cmd.Options.InputPath), cmd.Options.TileName, kilnfile.TileNames)

--- a/internal/cargo/kilnfile.go
+++ b/internal/cargo/kilnfile.go
@@ -15,6 +15,7 @@ type Kilnfile struct {
 	Slug            string                `yaml:"slug"`
 	PreGaUserGroups []string              `yaml:"pre_ga_user_groups"`
 	Releases        []ReleaseKiln         `yaml:"releases"`
+	TileNames       []string              `yaml:"tile_names"`
 }
 
 type ReleaseSourceConfig struct {

--- a/internal/preprocess/init_test.go
+++ b/internal/preprocess/init_test.go
@@ -1,0 +1,26 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"testing"
+)
+
+func TestPreprocessMetadata(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "preprocess-metadata")
+}
+
+var pathToMain string
+
+var _ = BeforeSuite(func() {
+	var err error
+	pathToMain, err = gexec.Build("github.com/pivotal-cf/kiln/internal/preprocess")
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	gexec.CleanupBuildArtifacts()
+})

--- a/internal/preprocess/init_test.go
+++ b/internal/preprocess/init_test.go
@@ -1,10 +1,8 @@
-package main_test
+package preprocess_test
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
-
 	"testing"
 )
 
@@ -12,15 +10,3 @@ func TestPreprocessMetadata(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "preprocess-metadata")
 }
-
-var pathToMain string
-
-var _ = BeforeSuite(func() {
-	var err error
-	pathToMain, err = gexec.Build("github.com/pivotal-cf/kiln/internal/preprocess")
-	Expect(err).NotTo(HaveOccurred())
-})
-
-var _ = AfterSuite(func() {
-	gexec.CleanupBuildArtifacts()
-})

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -36,6 +36,8 @@ func Run(out, in billy.Filesystem, currentTileName string, tileNames []string) e
 
 	var outBuf bytes.Buffer
 	return Walk(in, "", func(path string, info os.FileInfo, err error) error {
+		defer outBuf.Reset()
+
 		if err != nil {
 			return err
 		}

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"text/template"
+)
+
+func main() {
+	var flags struct {
+		tileName   string
+		inputPath  string
+		outputPath string
+	}
+
+	flag.StringVar(&flags.tileName, "tile-name", "", "name of tile product")
+	flag.StringVar(&flags.inputPath, "input-path", "", "path to metadata parts directory")
+	flag.StringVar(&flags.outputPath, "output-path", "", "path to output directory")
+	flag.Parse()
+
+	if flags.tileName == "" {
+		log.Fatalln("please provide a tile name using the --tile-name option")
+	}
+
+	if flags.inputPath == "" {
+		log.Fatalln("please provide a metadata parts directory path using the --input-path option")
+	}
+
+	if flags.outputPath == "" {
+		log.Fatalln("please provide an output directory path using the --output-path option")
+	}
+
+	err := filepath.Walk(flags.inputPath, filepath.WalkFunc(func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() && (info.Name() == "vendor" || info.Name() == "fixtures") {
+			return filepath.SkipDir
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != ".yml" {
+			return nil
+		}
+
+		outputFile, err := filepath.Rel(flags.inputPath, path)
+		if err != nil {
+			return err // Not tested
+		}
+
+		err = processTemplateFile(path, filepath.Join(flags.outputPath, outputFile), flags.tileName)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}))
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func processTemplateFile(inputFilePath, outputFilePath, tileName string) error {
+	metadataFile, err := ioutil.ReadFile(inputFilePath)
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("tile-preprocess").
+		Funcs(template.FuncMap(map[string]interface{}{
+			"tile": func() (interface{}, error) {
+				if tileName != "ert" && tileName != "srt" {
+					return "", fmt.Errorf("unsupported tile name: %s\n", tileName)
+				}
+				return tileName, nil
+			},
+			"ert": func(value interface{}, tile interface{}) interface{} {
+				if tile == "ert" {
+					return value
+				}
+
+				return tile
+			},
+			"srt": func(value interface{}, tile interface{}) interface{} {
+				if tile == "srt" {
+					return value
+				}
+
+				return tile
+			},
+		})).
+		Option("missingkey=error").
+		Parse(string(metadataFile))
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(outputFilePath)
+	err = os.MkdirAll(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(outputFilePath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			log.Fatalln(err) // Not tested
+		}
+	}()
+
+	err = tmpl.Execute(file, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -109,7 +109,7 @@ func isValidTemplateFunctionIdentifier(str string) (err error) {
 		}
 	}()
 
-	_, err = template.New("test " + str).Funcs(map[string]interface{}{str: func() string { return "" }}).Parse(fmt.Sprintf("{{%s}}", str))
+	_, err = template.New("").Funcs(map[string]interface{}{str: func() string { return "" }}).Parse(fmt.Sprintf("{{%s}}", str))
 	return err
 }
 

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -1,48 +1,15 @@
-package main
+package preprocess
 
 import (
-	"flag"
 	"fmt"
-	"gopkg.in/src-d/go-billy.v4/osfs"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"text/template"
 
 	"gopkg.in/src-d/go-billy.v4"
 )
-
-func main() {
-	var flags struct {
-		tileName   string
-		inputPath  string
-		outputPath string
-	}
-
-	flag.StringVar(&flags.tileName, "tile-name", "", "name of tile product")
-	flag.StringVar(&flags.inputPath, "input-path", "", "path to metadata parts directory")
-	flag.StringVar(&flags.outputPath, "output-path", "", "path to output directory")
-	flag.Parse()
-
-	if flags.tileName == "" {
-		log.Fatalln("please provide a tile name using the --tile-name option")
-	}
-
-	if flags.inputPath == "" {
-		log.Fatalln("please provide a metadata parts directory path using the --input-path option")
-	}
-
-	if flags.outputPath == "" {
-		log.Fatalln("please provide an output directory path using the --output-path option")
-	}
-
-	err := Run(osfs.New(flags.outputPath), osfs.New(flags.inputPath), flags.tileName, []string{"ert", "srt"})
-	if err != nil {
-		log.Fatalln(err)
-	}
-}
 
 func Run(out, in billy.Filesystem, currentTileName string, tileNames []string) error {
 	return Walk(in, "", func(path string, info os.FileInfo, err error) error {

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -34,7 +34,8 @@ func Run(out, in billy.Filesystem, currentTileName string, tileNames []string) e
 		return fmt.Errorf("%q is not provided in tile names list %v", currentTileName, tileNames)
 	}
 
-	var outBuf bytes.Buffer
+	outBuf := new(bytes.Buffer)
+
 	return Walk(in, "", func(path string, info os.FileInfo, err error) error {
 		defer outBuf.Reset()
 
@@ -67,7 +68,7 @@ func Run(out, in billy.Filesystem, currentTileName string, tileNames []string) e
 			return err
 		}
 
-		err = processTemplateFile(&outBuf, inFile, currentTileName, tileNames)
+		err = processTemplateFile(outBuf, inFile, currentTileName, tileNames)
 		if err != nil {
 			return err
 		}
@@ -80,7 +81,7 @@ func Run(out, in billy.Filesystem, currentTileName string, tileNames []string) e
 			_ = outFile.Close()
 		}()
 
-		_, err = io.Copy(outFile, &outBuf)
+		_, err = outBuf.WriteTo(outFile)
 		if err != nil {
 			return err
 		}

--- a/internal/preprocess/preprocess_test.go
+++ b/internal/preprocess/preprocess_test.go
@@ -113,6 +113,27 @@ templates:
 `))
 	})
 
+	Context("when tile names contain spaces", func() {
+		It("prints an error message", func() {
+			err := preprocess.Run(osfs.New(outputPath), osfs.New(metadataPartsPath), "ert", []string{" ert ", "\tsrt"})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("when tile name is an strings", func() {
+		It("prints an error message", func() {
+			err := preprocess.Run(osfs.New(outputPath), osfs.New("test_data/nothing-to-pre-process"), "", []string{})
+			Expect(err).To(MatchError(ContainSubstring("empty")))
+		})
+	})
+
+	Context("when tile name is invalid identifier", func() {
+		It("prints an error message", func() {
+			err := preprocess.Run(osfs.New(outputPath), osfs.New("test_data/nothing-to-pre-process"), "bad-tile-name", []string{"bad-tile-name"})
+			Expect(err).To(MatchError(ContainSubstring("is not a valid identifier")))
+		})
+	})
+
 	Context("failure cases", func() {
 		Context("when the metadata file references a missing key", func() {
 			It("errors", func() {
@@ -133,11 +154,11 @@ templates:
 			})
 		})
 
-		Context("when an unsupported tile name is specified", func() {
+		Context("when an unlisted tile name is used", func() {
 			It("prints an error message", func() {
 				err := preprocess.Run(osfs.New(outputPath), osfs.New(metadataPartsPath), "some-other-tile", []string{"ert", "srt"})
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("unsupported tile name: some-other-tile")))
+				Expect(err).To(MatchError(And(ContainSubstring("not provided"), ContainSubstring("some-other-tile"))))
 			})
 		})
 	})

--- a/internal/preprocess/preprocess_test.go
+++ b/internal/preprocess/preprocess_test.go
@@ -1,0 +1,249 @@
+package main_test
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("preprocess", func() {
+	var (
+		outputPath        string
+		metadataPartsPath string
+	)
+
+	BeforeEach(func() {
+		var err error
+		outputPath, err = ioutil.TempDir("", "")
+		Expect(err).NotTo(HaveOccurred())
+
+		metadataPartsPath = filepath.Join("test_data", "valid")
+	})
+
+	It("processes the templates files for the ERT", func() {
+		command := exec.Command(pathToMain,
+			"--tile-name", "ert",
+			"--input-path", metadataPartsPath,
+			"--output-path", outputPath,
+		)
+
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(0))
+
+		baseFilePath := filepath.Join(outputPath, "base.yml")
+		contents, err := ioutil.ReadFile(baseFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(MatchYAML(`---
+metadata_version: some-metadata-version
+name: ert
+provides_product_versions:
+- name: ert-product
+requires_product_versions:
+- name: some-other-product
+  version: 1.2.3.4
+product_version: some-product-version
+minimum_version_for_upgrade: some-minimum-version
+label: some-label
+description: some-description
+icon_image: some-icon
+rank: 90
+serial: false
+job_types:
+- $( instance_group "some_instance_group" )
+post_deploy_errands:
+  - name: some-errand
+variables:
+- name: root-ca
+  type: rsa
+  options:
+    is_ca: true
+`))
+
+		instanceGroupPath := filepath.Join(outputPath, "instance_groups", "some_instance_group.yml")
+		contents, err = ioutil.ReadFile(instanceGroupPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(MatchYAML(`---
+name: some_instance_group
+label: Some Instance Group
+templates:
+- $( job "some_job" )
+- $( job "some_other_job" )
+`))
+	})
+
+	It("processes the templates files for the SRT", func() {
+		command := exec.Command(pathToMain,
+			"--tile-name", "srt",
+			"--input-path", metadataPartsPath,
+			"--output-path", outputPath,
+		)
+
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(0))
+
+		baseFilePath := filepath.Join(outputPath, "base.yml")
+		contents, err := ioutil.ReadFile(baseFilePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(MatchYAML(`---
+metadata_version: some-metadata-version
+name: srt
+provides_product_versions:
+- name: srt-product
+requires_product_versions:
+- name: some-other-product
+  version: 1.2.3.4
+product_version: some-product-version
+minimum_version_for_upgrade: some-minimum-version
+label: some-label
+description: some-description
+icon_image: some-icon
+rank: 90
+serial: false
+job_types:
+- $( instance_group "some_instance_group" )
+post_deploy_errands:
+  - name: some-errand
+variables:
+- name: root-ca
+  type: rsa
+  options:
+    is_ca: true
+`))
+
+		instanceGroupPath := filepath.Join(outputPath, "instance_groups", "some_instance_group.yml")
+		contents, err = ioutil.ReadFile(instanceGroupPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(MatchYAML(`---
+name: some_instance_group
+label: Some Instance Group
+templates:
+- $( job "placeholder" )
+`))
+	})
+
+	Context("failure cases", func() {
+		Context("when the metadata file references a missing key", func() {
+			It("errors", func() {
+				command := exec.Command(pathToMain,
+					"--tile-name", "ert",
+					"--input-path", filepath.Join("test_data", "missing-key"),
+					"--output-path", outputPath,
+				)
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(string(session.Err.Contents())).To(ContainSubstring("some_missing_key"))
+			})
+		})
+
+		Context("when the metadata file contains a malformed expression", func() {
+			It("prints an error message", func() {
+				command := exec.Command(pathToMain,
+					"--tile-name", "ert",
+					"--input-path", filepath.Join("test_data", "malformed-expression"),
+					"--output-path", outputPath,
+				)
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Err.Contents()).To(ContainSubstring("unclosed action"))
+			})
+		})
+
+		Context("when the --tile-name flag is not provided", func() {
+			It("prints an error message", func() {
+				command := exec.Command(pathToMain,
+					"--input-path", metadataPartsPath,
+					"--output-path", outputPath,
+				)
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Err.Contents()).To(ContainSubstring("please provide a tile name using the --tile-name option"))
+			})
+		})
+
+		Context("when the --input-path flag is not provided", func() {
+			It("prints an error message", func() {
+				command := exec.Command(pathToMain,
+					"--tile-name", "ert",
+					"--output-path", outputPath,
+				)
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Err.Contents()).To(ContainSubstring("please provide a metadata parts directory path using the --input-path option"))
+			})
+		})
+
+		Context("when the --output-path flag is not provided", func() {
+			It("prints an error message", func() {
+				command := exec.Command(pathToMain,
+					"--tile-name", "ert",
+					"--input-path", metadataPartsPath,
+				)
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Err.Contents()).To(ContainSubstring("please provide an output directory path using the --output-path option"))
+			})
+		})
+
+		Context("when the output directory path is actually a file", func() {
+			var existingFilePath string
+
+			BeforeEach(func() {
+				existingFile, err := ioutil.TempFile("", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				existingFilePath = existingFile.Name()
+			})
+
+			It("prints an error message", func() {
+				command := exec.Command(pathToMain,
+					"--tile-name", "ert",
+					"--input-path", metadataPartsPath,
+					"--output-path", existingFilePath,
+				)
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Err.Contents()).To(ContainSubstring("not a directory"))
+			})
+		})
+
+		Context("when an unsupported tile name is specified", func() {
+			It("prints an error message", func() {
+				command := exec.Command(pathToMain,
+					"--tile-name", "some-other-tile",
+					"--input-path", metadataPartsPath,
+					"--output-path", outputPath,
+				)
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Err.Contents()).To(ContainSubstring("unsupported tile name: some-other-tile"))
+			})
+		})
+	})
+})

--- a/internal/preprocess/test_data/malformed-expression/base.yml
+++ b/internal/preprocess/test_data/malformed-expression/base.yml
@@ -1,0 +1,4 @@
+---
+metadata_version: some-metadata-version
+provides_product_versions:
+- name: Malformed template expression {{ tile | ert "ERT" | srt "SRT"

--- a/internal/preprocess/test_data/missing-key/base.yml
+++ b/internal/preprocess/test_data/missing-key/base.yml
@@ -1,0 +1,3 @@
+---
+metadata_version: some-metadata-version
+name: {{.some_missing_key}}

--- a/internal/preprocess/test_data/nothing-to-pre-process/base.yml
+++ b/internal/preprocess/test_data/nothing-to-pre-process/base.yml
@@ -1,0 +1,3 @@
+---
+metadata_version: some-metadata-version
+name: hello

--- a/internal/preprocess/test_data/valid/base.yml
+++ b/internal/preprocess/test_data/valid/base.yml
@@ -1,0 +1,28 @@
+---
+metadata_version: some-metadata-version
+{{if eq tile "srt"}}
+name: srt
+{{else}}
+name: ert
+{{end}}
+provides_product_versions:
+- name: {{ tile | ert "ert" | srt "srt" }}-product
+requires_product_versions:
+- name: some-other-product
+  version: 1.2.3.4
+product_version: some-product-version
+minimum_version_for_upgrade: some-minimum-version
+label: some-label
+description: some-description
+icon_image: some-icon
+rank: 90
+serial: false
+job_types:
+- $( instance_group "some_instance_group" )
+post_deploy_errands:
+  - name: some-errand
+variables:
+- name: root-ca
+  type: rsa
+  options:
+    is_ca: true

--- a/internal/preprocess/test_data/valid/instance_groups/some_instance_group.yml
+++ b/internal/preprocess/test_data/valid/instance_groups/some_instance_group.yml
@@ -1,0 +1,10 @@
+---
+name: some_instance_group
+label: Some Instance Group
+templates:
+{{if eq tile "ert"}}
+- $( job "some_job" )
+- $( job "some_other_job" )
+{{else}}
+- $( job "placeholder" )
+{{end}}

--- a/internal/preprocess/walk.go
+++ b/internal/preprocess/walk.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"gopkg.in/src-d/go-billy.v4"
+)
+
+func Walk(fs billy.Filesystem, root string, walkFn filepath.WalkFunc) error {
+	info, err := fs.Lstat(root)
+	if err != nil {
+		err = walkFn(root, nil, err)
+	} else {
+		err = walk(fs, root, info, walkFn)
+	}
+	if err == filepath.SkipDir {
+		return nil
+	}
+	return err
+}
+
+func walk(fs billy.Filesystem, path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
+	if !info.IsDir() {
+		return walkFn(path, info, nil)
+	}
+
+	names, err := readDirNames(fs, path)
+	err1 := walkFn(path, info, err)
+	// If err != nil, walk can't walk into this directory.
+	// err1 != nil means walkFn want walk to skip this directory or stop walking.
+	// Therefore, if one of err and err1 isn't nil, walk will return.
+	if err != nil || err1 != nil {
+		// The caller's behavior is controlled by the return value, which is decided
+		// by walkFn. walkFn may ignore err and return nil.
+		// If walkFn returns SkipDir, it will be handled by the caller.
+		// So walk should return whatever walkFn returns.
+		return err1
+	}
+
+	for _, name := range names {
+		filename := filepath.Join(path, name)
+		fileInfo, err := fs.Lstat(filename)
+		if err != nil {
+			if err := walkFn(filename, fileInfo, err); err != nil && err != filepath.SkipDir {
+				return err
+			}
+		} else {
+			err = walk(fs, filename, fileInfo, walkFn)
+			if err != nil {
+				if !fileInfo.IsDir() || err != filepath.SkipDir {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func readDirNames(fs billy.Filesystem, dirname string) ([]string, error) {
+	infos, err := fs.ReadDir(dirname)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, info := range infos {
+		names = append(names, info.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}

--- a/internal/preprocess/walk.go
+++ b/internal/preprocess/walk.go
@@ -1,4 +1,4 @@
-package main
+package preprocess
 
 import (
 	"os"

--- a/main.go
+++ b/main.go
@@ -105,6 +105,8 @@ func main() {
 		ReleaseUploaderFinder:      ruFinder,
 	}
 
+	commandSet["pre-process"] = commands.PreProcess{}
+
 	err = commandSet.Execute(command, args)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
We do this with a large internal tile. Having this work is the first step in improving kiln's ability to lint our tile repos more effectively.

I would appreciate feedback on the user experience and code review :)

To try this out locally
- clone kiln
- run ./install.sh
- cd to some large tile that has templating (ahem p-runtime)
- run something like `kiln pre-process --name ert --tile-names=ert,srt` or `kiln pre-process -n ert -tn=ert,srt`
- see the tile's files after executing the templates, the instance_groups directory is probably the most interesting