### PR TITLE
run goimports on all files

### DIFF
--- a/acceptance/integration/integration_suite_test.go
+++ b/acceptance/integration/integration_suite_test.go
@@ -1,10 +1,11 @@
 package integration_test
 
 import (
-	"github.com/matt-royal/biloba"
-	"github.com/onsi/gomega/gexec"
 	"os"
 	"testing"
+
+	"github.com/matt-royal/biloba"
+	"github.com/onsi/gomega/gexec"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/acceptance/integration/update_stemcell_test.go
+++ b/acceptance/integration/update_stemcell_test.go
@@ -1,13 +1,14 @@
 package integration_test
 
 import (
-	test_helpers "github.com/pivotal-cf/kiln/internal/test-helpers"
-	"gopkg.in/src-d/go-billy.v4/osfs"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	test_helpers "github.com/pivotal-cf/kiln/internal/test-helpers"
+	"gopkg.in/src-d/go-billy.v4/osfs"
 
 	"github.com/pivotal-cf/kiln/internal/cargo"
 	"gopkg.in/yaml.v2"

--- a/acceptance/sync_with_local_test.go
+++ b/acceptance/sync_with_local_test.go
@@ -2,13 +2,14 @@ package acceptance_test
 
 import (
 	"fmt"
-	test_helpers "github.com/pivotal-cf/kiln/internal/test-helpers"
-	"gopkg.in/src-d/go-billy.v4/osfs"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	test_helpers "github.com/pivotal-cf/kiln/internal/test-helpers"
+	"gopkg.in/src-d/go-billy.v4/osfs"
 
 	"github.com/pivotal-cf/kiln/internal/cargo"
 	"gopkg.in/yaml.v2"

--- a/builder/init_test.go
+++ b/builder/init_test.go
@@ -2,8 +2,9 @@ package builder_test
 
 import (
 	"bytes"
-	"github.com/matt-royal/biloba"
 	"testing"
+
+	"github.com/matt-royal/biloba"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/builder/tile_writer.go
+++ b/builder/tile_writer.go
@@ -2,13 +2,14 @@ package builder
 
 import (
 	"bytes"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 )
 
 type TileWriter struct {

--- a/builder/zipper_test.go
+++ b/builder/zipper_test.go
@@ -11,9 +11,10 @@ import (
 
 	. "github.com/pivotal-cf/kiln/builder"
 
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"time"
 )
 
 var _ = Describe("Zipper", func() {

--- a/commands/compile_built_releases.go
+++ b/commands/compile_built_releases.go
@@ -4,13 +4,14 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"
-	boshsystem "github.com/cloudfoundry/bosh-utils/system"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"sync"
+
+	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"
+	boshsystem "github.com/cloudfoundry/bosh-utils/system"
 
 	"github.com/pivotal-cf/kiln/builder"
 	"github.com/pivotal-cf/kiln/helper"

--- a/commands/compile_built_releases_test.go
+++ b/commands/compile_built_releases_test.go
@@ -5,13 +5,14 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"
 
 	"github.com/onsi/gomega/gbytes"
 

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -2,10 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/kiln/release"
-	"gopkg.in/src-d/go-billy.v4/osfs"
 	"log"
 	"os"
+
+	"github.com/pivotal-cf/kiln/release"
+	"gopkg.in/src-d/go-billy.v4/osfs"
 
 	"github.com/pivotal-cf/kiln/fetcher"
 

--- a/commands/fetch_test.go
+++ b/commands/fetch_test.go
@@ -3,11 +3,12 @@ package commands_test
 import (
 	"errors"
 	"fmt"
-	"github.com/pivotal-cf/kiln/internal/cargo"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/pivotal-cf/kiln/internal/cargo"
 
 	"github.com/pivotal-cf/kiln/release"
 

--- a/commands/find_release_version.go
+++ b/commands/find_release_version.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"encoding/json"
+	"log"
+
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/kiln/internal/cargo"
 	"github.com/pivotal-cf/kiln/release"
 	"gopkg.in/src-d/go-billy.v4/osfs"
-	"log"
 )
 
 type FindReleaseVersion struct {

--- a/commands/find_release_version_test.go
+++ b/commands/find_release_version_test.go
@@ -1,14 +1,15 @@
 package commands_test
 
 import (
-	"github.com/pivotal-cf/kiln/commands"
-	"github.com/pivotal-cf/kiln/fetcher"
-	"github.com/pivotal-cf/kiln/internal/cargo"
-	"github.com/pivotal-cf/kiln/release"
 	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strings"
+
+	"github.com/pivotal-cf/kiln/commands"
+	"github.com/pivotal-cf/kiln/fetcher"
+	"github.com/pivotal-cf/kiln/internal/cargo"
+	"github.com/pivotal-cf/kiln/release"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/commands/sync_with_local.go
+++ b/commands/sync_with_local.go
@@ -2,12 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/kiln/fetcher"
 	"github.com/pivotal-cf/kiln/internal/cargo"
 	"github.com/pivotal-cf/kiln/release"
 	"gopkg.in/src-d/go-billy.v4"
-	"log"
 )
 
 type SyncWithLocal struct {

--- a/commands/sync_with_local_test.go
+++ b/commands/sync_with_local_test.go
@@ -2,6 +2,8 @@ package commands_test
 
 import (
 	"errors"
+	"log"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/pivotal-cf/kiln/commands"
@@ -11,7 +13,6 @@ import (
 	"github.com/pivotal-cf/kiln/release"
 	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/memfs"
-	"log"
 )
 
 var _ = Describe("sync-with-local", func() {

--- a/commands/update_release_test.go
+++ b/commands/update_release_test.go
@@ -3,10 +3,11 @@ package commands_test
 import (
 	"errors"
 	"fmt"
-	"github.com/onsi/gomega/gbytes"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/onsi/gomega/gbytes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/commands/update_stemcell.go
+++ b/commands/update_stemcell.go
@@ -2,13 +2,14 @@ package commands
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/kiln/builder"
 	"github.com/pivotal-cf/kiln/fetcher"
 	"github.com/pivotal-cf/kiln/helper"
 	"github.com/pivotal-cf/kiln/release"
 	"gopkg.in/src-d/go-billy.v4/osfs"
-	"log"
 )
 
 type UpdateStemcell struct {

--- a/commands/update_stemcell_test.go
+++ b/commands/update_stemcell_test.go
@@ -2,6 +2,11 @@ package commands_test
 
 import (
 	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
 	"github.com/onsi/gomega/gbytes"
 	"github.com/pivotal-cf/kiln/commands/fakes"
 	fetcherFakes "github.com/pivotal-cf/kiln/fetcher/fakes"
@@ -9,10 +14,6 @@ import (
 	test_helpers "github.com/pivotal-cf/kiln/internal/test-helpers"
 	"github.com/pivotal-cf/kiln/release"
 	"gopkg.in/src-d/go-billy.v4/osfs"
-	"io/ioutil"
-	"log"
-	"os"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/fetcher/bosh_io_release_source.go
+++ b/fetcher/bosh_io_release_source.go
@@ -5,13 +5,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/Masterminds/semver"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/pivotal-cf/kiln/internal/cargo"
 	"github.com/pivotal-cf/kiln/release"

--- a/fetcher/fetcher_suite_test.go
+++ b/fetcher/fetcher_suite_test.go
@@ -1,8 +1,9 @@
 package fetcher_test
 
 import (
-	"github.com/matt-royal/biloba"
 	"testing"
+
+	"github.com/matt-royal/biloba"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/fetcher/local_release_directory.go
+++ b/fetcher/local_release_directory.go
@@ -4,15 +4,16 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+
 	"github.com/pivotal-cf/kiln/builder"
 	"github.com/pivotal-cf/kiln/internal/baking"
 	release "github.com/pivotal-cf/kiln/release"
 	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/osfs"
-	"io"
-	"log"
-	"os"
-	"sort"
 )
 
 type LocalReleaseDirectory struct {

--- a/fetcher/local_release_directory_test.go
+++ b/fetcher/local_release_directory_test.go
@@ -2,11 +2,12 @@ package fetcher_test
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/gbytes"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/onsi/gomega/gbytes"
 
 	"gopkg.in/src-d/go-billy.v4/osfs"
 

--- a/fetcher/multi_release_source.go
+++ b/fetcher/multi_release_source.go
@@ -2,6 +2,7 @@ package fetcher
 
 import (
 	"fmt"
+
 	"github.com/Masterminds/semver"
 	"github.com/pivotal-cf/kiln/release"
 )

--- a/fetcher/s3_release_source.go
+++ b/fetcher/s3_release_source.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"github.com/Masterminds/semver"
 	"io"
 	"log"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/pivotal-cf/kiln/release"
 

--- a/fetcher/s3_release_source_test.go
+++ b/fetcher/s3_release_source_test.go
@@ -3,14 +3,15 @@ package fetcher_test
 import (
 	"errors"
 	"fmt"
-	. "github.com/onsi/ginkgo/extensions/table"
-	"github.com/pivotal-cf/kiln/internal/cargo"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+	"github.com/pivotal-cf/kiln/internal/cargo"
 
 	. "github.com/onsi/gomega/gstruct"
 	"gopkg.in/src-d/go-billy.v4/osfs"

--- a/helper/init_test.go
+++ b/helper/init_test.go
@@ -2,6 +2,7 @@ package helper_test
 
 import (
 	"bytes"
+
 	"github.com/matt-royal/biloba"
 
 	. "github.com/onsi/ginkgo"

--- a/internal/baking/releases_service.go
+++ b/internal/baking/releases_service.go
@@ -1,10 +1,11 @@
 package baking
 
 import (
-	"github.com/pivotal-cf/kiln/builder"
 	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/pivotal-cf/kiln/builder"
 )
 
 type ReleasesService struct {

--- a/internal/baking/stemcell_service_test.go
+++ b/internal/baking/stemcell_service_test.go
@@ -2,12 +2,13 @@ package baking_test
 
 import (
 	"errors"
-	"github.com/pivotal-cf/kiln/builder"
-	. "github.com/pivotal-cf/kiln/internal/baking"
-	"github.com/pivotal-cf/kiln/internal/baking/fakes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/pivotal-cf/kiln/builder"
+	. "github.com/pivotal-cf/kiln/internal/baking"
+	"github.com/pivotal-cf/kiln/internal/baking/fakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/internal/baking/template_variables_service.go
+++ b/internal/baking/template_variables_service.go
@@ -2,8 +2,9 @@ package baking
 
 import (
 	"fmt"
-	"gopkg.in/src-d/go-billy.v4"
 	"strings"
+
+	"gopkg.in/src-d/go-billy.v4"
 
 	"gopkg.in/yaml.v2"
 )

--- a/internal/baking/template_variables_service_test.go
+++ b/internal/baking/template_variables_service_test.go
@@ -1,9 +1,10 @@
 package baking_test
 
 import (
-	"gopkg.in/src-d/go-billy.v4/osfs"
 	"io/ioutil"
 	"os"
+
+	"gopkg.in/src-d/go-billy.v4/osfs"
 
 	. "github.com/pivotal-cf/kiln/internal/baking"
 

--- a/internal/cargo/init_test.go
+++ b/internal/cargo/init_test.go
@@ -1,8 +1,9 @@
 package cargo_test
 
 import (
-	"github.com/matt-royal/biloba"
 	"testing"
+
+	"github.com/matt-royal/biloba"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/internal/cargo/load_kilnfiles_test.go
+++ b/internal/cargo/load_kilnfiles_test.go
@@ -2,6 +2,7 @@ package cargo_test
 
 import (
 	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/pivotal-cf/kiln/internal/cargo"

--- a/internal/preprocess/init_test.go
+++ b/internal/preprocess/init_test.go
@@ -1,9 +1,10 @@
 package preprocess_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestPreprocessMetadata(t *testing.T) {

--- a/internal/preprocess/preprocess_test.go
+++ b/internal/preprocess/preprocess_test.go
@@ -1,10 +1,11 @@
 package preprocess_test
 
 import (
-	"github.com/pivotal-cf/kiln/internal/preprocess"
-	"gopkg.in/src-d/go-billy.v4/osfs"
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/pivotal-cf/kiln/internal/preprocess"
+	"gopkg.in/src-d/go-billy.v4/osfs"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/internal/test-helpers/tgz_helpers.go
+++ b/internal/test-helpers/tgz_helpers.go
@@ -5,11 +5,12 @@ import (
 	"compress/gzip"
 	"crypto/sha1"
 	"fmt"
-	"gopkg.in/src-d/go-billy.v4"
 	"io"
 	"os"
 	"strings"
 	"time"
+
+	"gopkg.in/src-d/go-billy.v4"
 )
 
 func WriteReleaseTarball(path, name, version string, fs billy.Filesystem) (string, error) {

--- a/proofing/init_test.go
+++ b/proofing/init_test.go
@@ -1,8 +1,9 @@
 package proofing_test
 
 import (
-	"github.com/matt-royal/biloba"
 	"testing"
+
+	"github.com/matt-royal/biloba"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/release/release_suite_test.go
+++ b/release/release_suite_test.go
@@ -1,8 +1,9 @@
 package release_test
 
 import (
-	"github.com/matt-royal/biloba"
 	"testing"
+
+	"github.com/matt-royal/biloba"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
This standardizes import declarations. In particular, separates stdlib from dependency import paths.

```sh
find . -path vendor -prune -o -name '*.go' | xargs goimports -l -w
```