### PR TITLE
trim build machine specific directory path from binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sha256
 .idea
 *debug.test
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,11 @@ builds:
   - amd64
   ldflags:
   - -X "main.version={{.Version}}"
+  gcflags:
+  - all=-trimpath={{.Env.PWD}}
+  asmflags:
+  - all=-trimpath={{.Env.PWD}}
+  main: ./cmd/kiln
 archives:
   - id: github
     format: binary

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,11 @@ function main() {
   cwd="${1}"
 
   pushd "${cwd}" > /dev/null
-    go install -ldflags "-X main.version=$(git rev-parse HEAD)"
+    go install \
+      -ldflags "-X main.version=$(git rev-parse HEAD)" \
+      -gcflags=-trimpath="${cwd}" \
+      -asmflags=-trimpath="${cwd}" \
+      ./
   popd > /dev/null
 }
 


### PR DESCRIPTION
This makes it so debug lines in stack traces no longer contain the path of the directory where the binary was built.