### PR TITLE
refactor: move bake setup func to bake.go command file

### DIFF
--- a/internal/commands/bake_test.go
+++ b/internal/commands/bake_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Bake", func() {
 
 		fakeInterpolator.InterpolateReturns([]byte("some-interpolated-metadata"), nil)
 
-		bake = commands.NewBake(
+		bake = commands.NewBakeWithInterfaces(
 			fakeInterpolator,
 			fakeTileWriter,
 			fakeLogger,


### PR DESCRIPTION
this makes bake more like the other commands and hides the service configuration