### PR TITLE
feat: stricter Kilnfile validation - release version in lockfile must be valid and match constraint

### DIFF
--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/pivotal-cf/kiln/pkg/cargo"
 	"testing"
 
 	"github.com/go-git/go-billy/v5/osfs"
@@ -55,4 +56,81 @@ func TestValidate_PinnedRelease(t *testing.T) {
 	}
 	err := validate.Execute(nil)
 	please.Expect(err).NotTo(Ω.HaveOccurred())
+}
+
+func TestValidate_validateRelease(t *testing.T) {
+	t.Run("missing name", func(t *testing.T) {
+		please := Ω.NewWithT(t)
+		r := cargo.ReleaseKiln{}
+		l := cargo.ReleaseLock{}
+		err := validateRelease(r, l, 0)
+		please.Expect(err).To(Ω.And(
+			Ω.HaveOccurred(),
+			Ω.MatchError(Ω.ContainSubstring("missing name")),
+		))
+	})
+
+	t.Run("no version", func(t *testing.T) {
+		please := Ω.NewWithT(t)
+		r := cargo.ReleaseKiln{
+			Name: "capi",
+		}
+		l := cargo.ReleaseLock{
+			Name: "capi",
+			Version: "2.3.4",
+		}
+		err := validateRelease(r, l, 0)
+		please.Expect(err).NotTo(Ω.HaveOccurred())
+	})
+
+	t.Run("invalid version constraint", func(t *testing.T) {
+		please := Ω.NewWithT(t)
+		r := cargo.ReleaseKiln{
+			Name: "capi",
+			Version: "meh",
+		}
+		l := cargo.ReleaseLock{
+			Name: "capi",
+			Version: "2.3.4",
+		}
+		err := validateRelease(r, l, 0)
+		please.Expect(err).To(Ω.And(
+			Ω.HaveOccurred(),
+			Ω.MatchError(Ω.ContainSubstring("invalid version constraint")),
+		))
+	})
+
+	t.Run("version does not match constraint", func(t *testing.T) {
+		please := Ω.NewWithT(t)
+		r := cargo.ReleaseKiln{
+			Name: "capi",
+			Version: "~2",
+		}
+		l := cargo.ReleaseLock{
+			Name: "capi",
+			Version: "3.0.5",
+		}
+		err := validateRelease(r, l, 0)
+		please.Expect(err).To(Ω.And(
+			Ω.HaveOccurred(),
+			Ω.MatchError(Ω.ContainSubstring("match constraint")),
+		))
+	})
+
+	t.Run("invalid lock version", func(t *testing.T) {
+		please := Ω.NewWithT(t)
+		r := cargo.ReleaseKiln{
+			Name: "capi",
+			Version: "~2",
+		}
+		l := cargo.ReleaseLock{
+			Name: "capi",
+			Version: "BAD",
+		}
+		err := validateRelease(r, l, 0)
+		please.Expect(err).To(Ω.And(
+			Ω.HaveOccurred(),
+			Ω.MatchError(Ω.ContainSubstring("invalid lock version")),
+		))
+	})
 }


### PR DESCRIPTION
When this is not true, a descriptive error is output. This change will make it more likely that at any given time, the repository is fetch-able and bake-able.

## Contributor Impact
This will require contributors to run `kiln update-release` when unpinning. This will make it so we reduce the number of PRs and simplify the process of getting a release note for unlocking releases.