### PR TITLE
tools: use faster go:generate configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
+	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/onsi/ginkgo v1.15.2
 	github.com/onsi/gomega v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1 h1:hZD/8vBuw7x1WqRXD/WGjVjipbbo/HcDBgySYYbrUSk=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1/go.mod h1:DK1Cjkc0E49ShgRVs5jy5ASrM15svSnem3K/hiSGD8o=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -152,6 +154,7 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robdimsdale/sanitizer v0.0.0-20160522134901-ab2334cb7539/go.mod h1:tqCODtkKV+9Tfvt9JURvKCTxJ69bA/OU/QhsaQLK/rc=
+github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -182,6 +185,7 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180712202826-d0887baf81f4/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -194,6 +198,7 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
+golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -220,9 +225,11 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -233,11 +240,14 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -254,6 +264,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.26/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=

--- a/internal/baking/init_test.go
+++ b/internal/baking/init_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 func TestBaking(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "internal/baking")

--- a/internal/baking/interfaces.go
+++ b/internal/baking/interfaces.go
@@ -2,17 +2,17 @@ package baking
 
 import "github.com/pivotal-cf/kiln/internal/builder"
 
-//go:generate counterfeiter -o ./fakes/logger.go --fake-name Logger . logger
+//counterfeiter:generate -o ./fakes/logger.go --fake-name Logger . logger
 type logger interface {
 	Println(v ...interface{})
 }
 
-//go:generate counterfeiter -o ./fakes/part_reader.go --fake-name PartReader . partReader
+//counterfeiter:generate -o ./fakes/part_reader.go --fake-name PartReader . partReader
 type partReader interface {
 	Read(path string) (builder.Part, error)
 }
 
-//go:generate counterfeiter -o ./fakes/directory_reader.go --fake-name DirectoryReader . directoryReader
+//counterfeiter:generate -o ./fakes/directory_reader.go --fake-name DirectoryReader . directoryReader
 type directoryReader interface {
 	Read(path string) ([]builder.Part, error)
 }

--- a/internal/builder/init_test.go
+++ b/internal/builder/init_test.go
@@ -8,7 +8,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//go:generate counterfeiter -o ./fakes/read_closer.go --fake-name ReadCloser io.ReadCloser
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate -o ./fakes/read_closer.go --fake-name ReadCloser io.ReadCloser
 
 func TestBuilder(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/builder/tile_writer.go
+++ b/internal/builder/tile_writer.go
@@ -18,7 +18,7 @@ type TileWriter struct {
 	logger     logger
 }
 
-//go:generate counterfeiter -o ./fakes/filesystem.go --fake-name Filesystem . filesystem
+//counterfeiter:generate -o ./fakes/filesystem.go --fake-name Filesystem . filesystem
 type filesystem interface {
 	Create(path string) (io.WriteCloser, error)
 	Open(path string) (io.ReadCloser, error)
@@ -26,7 +26,7 @@ type filesystem interface {
 	Remove(path string) error
 }
 
-//go:generate counterfeiter -o ./fakes/zipper.go --fake-name Zipper . zipper
+//counterfeiter:generate -o ./fakes/zipper.go --fake-name Zipper . zipper
 
 type zipper interface {
 	SetWriter(writer io.Writer)
@@ -36,7 +36,7 @@ type zipper interface {
 	Close() error
 }
 
-//go:generate counterfeiter -o ./fakes/file_info.go --fake-name FileInfo os.FileInfo
+//counterfeiter:generate -o ./fakes/file_info.go --fake-name FileInfo os.FileInfo
 
 func NewTileWriter(filesystem filesystem, zipper zipper, logger logger) TileWriter {
 	return TileWriter{

--- a/internal/commands/bake.go
+++ b/internal/commands/bake.go
@@ -17,74 +17,74 @@ import (
 	"github.com/pivotal-cf/kiln/internal/helper"
 )
 
-//go:generate counterfeiter -o ./fakes/interpolator.go --fake-name Interpolator . interpolator
+//counterfeiter:generate -o ./fakes/interpolator.go --fake-name Interpolator . interpolator
 type interpolator interface {
 	Interpolate(input builder.InterpolateInput, templateYAML []byte) ([]byte, error)
 }
 
-//go:generate counterfeiter -o ./fakes/tile_writer.go --fake-name TileWriter . tileWriter
+//counterfeiter:generate -o ./fakes/tile_writer.go --fake-name TileWriter . tileWriter
 type tileWriter interface {
 	Write(generatedMetadataContents []byte, input builder.WriteInput) error
 }
 
-//go:generate counterfeiter -o ./fakes/bosh_variables_service.go --fake-name BOSHVariablesService . boshVariablesService
+//counterfeiter:generate -o ./fakes/bosh_variables_service.go --fake-name BOSHVariablesService . boshVariablesService
 type boshVariablesService interface {
 	FromDirectories(directories []string) (boshVariables map[string]interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/releases_service.go --fake-name ReleasesService . releasesService
+//counterfeiter:generate -o ./fakes/releases_service.go --fake-name ReleasesService . releasesService
 type releasesService interface {
 	FromDirectories(directories []string) (releases map[string]interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/stemcell_service.go --fake-name StemcellService . stemcellService
+//counterfeiter:generate -o ./fakes/stemcell_service.go --fake-name StemcellService . stemcellService
 type stemcellService interface {
 	FromDirectories(directories []string) (stemcell map[string]interface{}, err error)
 	FromKilnfile(path string) (stemcell map[string]interface{}, err error)
 	FromTarball(path string) (stemcell interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/template_variables_service.go --fake-name TemplateVariablesService . templateVariablesService
+//counterfeiter:generate -o ./fakes/template_variables_service.go --fake-name TemplateVariablesService . templateVariablesService
 type templateVariablesService interface {
 	FromPathsAndPairs(paths []string, pairs []string) (templateVariables map[string]interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/forms_service.go --fake-name FormsService . formsService
+//counterfeiter:generate -o ./fakes/forms_service.go --fake-name FormsService . formsService
 type formsService interface {
 	FromDirectories(directories []string) (forms map[string]interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/instance_groups_service.go --fake-name InstanceGroupsService . instanceGroupsService
+//counterfeiter:generate -o ./fakes/instance_groups_service.go --fake-name InstanceGroupsService . instanceGroupsService
 type instanceGroupsService interface {
 	FromDirectories(directories []string) (instanceGroups map[string]interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/jobs_service.go --fake-name JobsService . jobsService
+//counterfeiter:generate -o ./fakes/jobs_service.go --fake-name JobsService . jobsService
 type jobsService interface {
 	FromDirectories(directories []string) (jobs map[string]interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/properties_service.go --fake-name PropertiesService . propertiesService
+//counterfeiter:generate -o ./fakes/properties_service.go --fake-name PropertiesService . propertiesService
 type propertiesService interface {
 	FromDirectories(directories []string) (properties map[string]interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/runtime_configs_service.go --fake-name RuntimeConfigsService . runtimeConfigsService
+//counterfeiter:generate -o ./fakes/runtime_configs_service.go --fake-name RuntimeConfigsService . runtimeConfigsService
 type runtimeConfigsService interface {
 	FromDirectories(directories []string) (runtimeConfigs map[string]interface{}, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/icon_service.go --fake-name IconService . iconService
+//counterfeiter:generate -o ./fakes/icon_service.go --fake-name IconService . iconService
 type iconService interface {
 	Encode(path string) (encodedIcon string, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/metadata_service.go --fake-name MetadataService . metadataService
+//counterfeiter:generate -o ./fakes/metadata_service.go --fake-name MetadataService . metadataService
 type metadataService interface {
 	Read(path string) (metadata []byte, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/checksummer.go --fake-name Checksummer . checksummer
+//counterfeiter:generate -o ./fakes/checksummer.go --fake-name Checksummer . checksummer
 type checksummer interface {
 	Sum(path string) error
 }

--- a/internal/commands/compile_built_releases.go
+++ b/internal/commands/compile_built_releases.go
@@ -43,9 +43,9 @@ type CompileBuiltReleases struct {
 	}
 }
 
-//go:generate counterfeiter -o ./fakes/bosh_deployment.go --fake-name BoshDeployment github.com/cloudfoundry/bosh-cli/director.Deployment
+//counterfeiter:generate -o ./fakes/bosh_deployment.go --fake-name BoshDeployment github.com/cloudfoundry/bosh-cli/director.Deployment
 
-//go:generate counterfeiter -o ./fakes/bosh_director.go --fake-name BoshDirector . BoshDirector
+//counterfeiter:generate -o ./fakes/bosh_director.go --fake-name BoshDirector . BoshDirector
 type BoshDirector interface {
 	UploadStemcellFile(file boshdir.UploadFile, fix bool) error
 	UploadReleaseFile(file boshdir.UploadFile, rebase, fix bool) error

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -30,7 +30,7 @@ type Fetch struct {
 	}
 }
 
-//go:generate counterfeiter -o ./fakes/multi_release_source_provider.go --fake-name MultiReleaseSourceProvider . MultiReleaseSourceProvider
+//counterfeiter:generate -o ./fakes/multi_release_source_provider.go --fake-name MultiReleaseSourceProvider . MultiReleaseSourceProvider
 type MultiReleaseSourceProvider func(cargo.Kilnfile, bool) fetcher.MultiReleaseSource
 
 func NewFetch(logger *log.Logger, multiReleaseSourceProvider MultiReleaseSourceProvider, localReleaseDirectory LocalReleaseDirectory) Fetch {
@@ -41,7 +41,7 @@ func NewFetch(logger *log.Logger, multiReleaseSourceProvider MultiReleaseSourceP
 	}
 }
 
-//go:generate counterfeiter -o ./fakes/local_release_directory.go --fake-name LocalReleaseDirectory . LocalReleaseDirectory
+//counterfeiter:generate -o ./fakes/local_release_directory.go --fake-name LocalReleaseDirectory . LocalReleaseDirectory
 type LocalReleaseDirectory interface {
 	GetLocalReleases(releasesDir string) ([]release.Local, error)
 	DeleteExtraReleases(extraReleases []release.Local, noConfirm bool) error

--- a/internal/commands/init_test.go
+++ b/internal/commands/init_test.go
@@ -19,7 +19,9 @@ func TestCommands(t *testing.T) {
 	RunSpecs(t, "commands")
 }
 
-//go:generate counterfeiter -o ./fakes/command.go --fake-name Command . command
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate -o ./fakes/command.go --fake-name Command . command
 type command interface {
 	jhanda.Command
 }

--- a/internal/commands/publish.go
+++ b/internal/commands/publish.go
@@ -26,30 +26,30 @@ const (
 	oslFileType       = "Open Source License"
 )
 
-//go:generate counterfeiter -o ./fakes/pivnet_releases_service.go --fake-name PivnetReleasesService . PivnetReleasesService
+//counterfeiter:generate -o ./fakes/pivnet_releases_service.go --fake-name PivnetReleasesService . PivnetReleasesService
 type PivnetReleasesService interface {
 	List(productSlug string) ([]pivnet.Release, error)
 	Update(productSlug string, release pivnet.Release) (pivnet.Release, error)
 }
 
-//go:generate counterfeiter -o ./fakes/pivnet_product_files_service.go --fake-name PivnetProductFilesService . PivnetProductFilesService
+//counterfeiter:generate -o ./fakes/pivnet_product_files_service.go --fake-name PivnetProductFilesService . PivnetProductFilesService
 type PivnetProductFilesService interface {
 	List(productSlug string) ([]pivnet.ProductFile, error)
 	AddToRelease(productSlug string, releaseID int, productFileID int) error
 }
 
-//go:generate counterfeiter -o ./fakes/pivnet_user_groups_service.go --fake-name PivnetUserGroupsService . PivnetUserGroupsService
+//counterfeiter:generate -o ./fakes/pivnet_user_groups_service.go --fake-name PivnetUserGroupsService . PivnetUserGroupsService
 type PivnetUserGroupsService interface {
 	List() ([]pivnet.UserGroup, error)
 	AddToRelease(productSlug string, releaseID int, userGroupID int) error
 }
 
-//go:generate counterfeiter -o ./fakes/pivnet_release_upgrade_paths_service.go --fake-name PivnetReleaseUpgradePathsService . PivnetReleaseUpgradePathsService
+//counterfeiter:generate -o ./fakes/pivnet_release_upgrade_paths_service.go --fake-name PivnetReleaseUpgradePathsService . PivnetReleaseUpgradePathsService
 type PivnetReleaseUpgradePathsService interface {
 	Get(productSlug string, releaseID int) ([]pivnet.ReleaseUpgradePath, error)
 }
 
-//go:generate counterfeiter -o ./fakes/pivnet_release_dependencies_service.go --fake-name PivnetReleaseDependenciesService . PivnetReleaseDependenciesService
+//counterfeiter:generate -o ./fakes/pivnet_release_dependencies_service.go --fake-name PivnetReleaseDependenciesService . PivnetReleaseDependenciesService
 type PivnetReleaseDependenciesService interface {
 	List(productSlug string, releaseID int) ([]pivnet.ReleaseDependency, error)
 }

--- a/internal/commands/sync_with_local.go
+++ b/internal/commands/sync_with_local.go
@@ -36,7 +36,7 @@ func NewSyncWithLocal(fs billy.Filesystem, localReleaseDirectory LocalReleaseDir
 	}
 }
 
-//go:generate counterfeiter -o ./fakes/remote_pather_finder.go --fake-name RemotePatherFinder . RemotePatherFinder
+//counterfeiter:generate -o ./fakes/remote_pather_finder.go --fake-name RemotePatherFinder . RemotePatherFinder
 type RemotePatherFinder func(cargo.Kilnfile, string) (fetcher.RemotePather, error)
 
 func (command SyncWithLocal) Execute(args []string) error {

--- a/internal/commands/upload_release.go
+++ b/internal/commands/upload_release.go
@@ -28,7 +28,7 @@ type UploadRelease struct {
 	}
 }
 
-//go:generate counterfeiter -o ./fakes/release_uploader_finder.go --fake-name ReleaseUploaderFinder . ReleaseUploaderFinder
+//counterfeiter:generate -o ./fakes/release_uploader_finder.go --fake-name ReleaseUploaderFinder . ReleaseUploaderFinder
 type ReleaseUploaderFinder func(cargo.Kilnfile, string) (fetcher.ReleaseUploader, error)
 
 func (command UploadRelease) Execute(args []string) error {

--- a/internal/fetcher/fetcher_suite_test.go
+++ b/internal/fetcher/fetcher_suite_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 func TestFetcher(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Fetcher Suite")

--- a/internal/fetcher/release_source_repo.go
+++ b/internal/fetcher/release_source_repo.go
@@ -16,7 +16,7 @@ const (
 	DefaultDownloadThreadCount = 0
 )
 
-//go:generate counterfeiter -o ./fakes/release_source.go --fake-name ReleaseSource . ReleaseSource
+//counterfeiter:generate -o ./fakes/release_source.go --fake-name ReleaseSource . ReleaseSource
 type ReleaseSource interface {
 	GetMatchedRelease(release.Requirement) (release.Remote, bool, error)
 	FindReleaseVersion(release.Requirement) (release.Remote, bool, error)
@@ -25,7 +25,7 @@ type ReleaseSource interface {
 	Publishable() bool
 }
 
-//go:generate counterfeiter -o ./fakes/multi_release_source.go --fake-name MultiReleaseSource . MultiReleaseSource
+//counterfeiter:generate -o ./fakes/multi_release_source.go --fake-name MultiReleaseSource . MultiReleaseSource
 type MultiReleaseSource interface {
 	GetMatchedRelease(release.Requirement) (release.Remote, bool, error)
 	FindReleaseVersion(release.Requirement) (release.Remote, bool, error)
@@ -33,13 +33,13 @@ type MultiReleaseSource interface {
 	FindByID(string) (ReleaseSource, error)
 }
 
-//go:generate counterfeiter -o ./fakes/release_uploader.go --fake-name ReleaseUploader . ReleaseUploader
+//counterfeiter:generate -o ./fakes/release_uploader.go --fake-name ReleaseUploader . ReleaseUploader
 type ReleaseUploader interface {
 	GetMatchedRelease(release.Requirement) (release.Remote, bool, error)
 	UploadRelease(spec release.Requirement, file io.Reader) (release.Remote, error)
 }
 
-//go:generate counterfeiter -o ./fakes/remote_pather.go --fake-name RemotePather . RemotePather
+//counterfeiter:generate -o ./fakes/remote_pather.go --fake-name RemotePather . RemotePather
 type RemotePather interface {
 	RemotePath(release.Requirement) (string, error)
 }

--- a/internal/fetcher/s3_release_source.go
+++ b/internal/fetcher/s3_release_source.go
@@ -25,17 +25,17 @@ import (
 	"github.com/pivotal-cf/kiln/pkg/release"
 )
 
-//go:generate counterfeiter -o ./fakes/s3_downloader.go --fake-name S3Downloader . S3Downloader
+//counterfeiter:generate -o ./fakes/s3_downloader.go --fake-name S3Downloader . S3Downloader
 type S3Downloader interface {
 	Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (n int64, err error)
 }
 
-//go:generate counterfeiter -o ./fakes/s3_uploader.go --fake-name S3Uploader . S3Uploader
+//counterfeiter:generate -o ./fakes/s3_uploader.go --fake-name S3Uploader . S3Uploader
 type S3Uploader interface {
 	Upload(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 }
 
-//go:generate counterfeiter -o ./fakes/s3_client.go --fake-name S3Client . S3Client
+//counterfeiter:generate -o ./fakes/s3_client.go --fake-name S3Client . S3Client
 type S3Client interface {
 	HeadObject(input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 	ListObjectsV2(input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
@@ -112,7 +112,7 @@ func (src S3ReleaseSource) Publishable() bool {
 	return src.publishable
 }
 
-//go:generate counterfeiter -o ./fakes/s3_request_failure.go --fake-name S3RequestFailure github.com/aws/aws-sdk-go/service/s3.RequestFailure
+//counterfeiter:generate -o ./fakes/s3_request_failure.go --fake-name S3RequestFailure github.com/aws/aws-sdk-go/service/s3.RequestFailure
 func (src S3ReleaseSource) GetMatchedRelease(requirement release.Requirement) (release.Remote, bool, error) {
 	remotePath, err := src.RemotePath(requirement)
 	if err != nil {

--- a/internal/manifest_generator/manifest_generator.go
+++ b/internal/manifest_generator/manifest_generator.go
@@ -35,8 +35,6 @@ type ManifestUpdate struct {
 	UpdateWatchTime string `yaml:"update_watch_time"`
 }
 
-// }
-
 func New() ManifestGenerator {
 	return ManifestGenerator{}
 }

--- a/internal/tools/import.go
+++ b/internal/tools/import.go
@@ -1,0 +1,7 @@
+//+build tools
+
+package tools
+
+import (
+	_ "github.com/maxbrunsfeld/counterfeiter/v6"
+)


### PR DESCRIPTION
This change also adds counterfeiter to the dependency tree
so it can be run after fetching the code.

Counterfeiter supports a faster way to generate fakes

I ran `time go generate ./...` for before and after the change. These are the results:

Before
	real    2m42.406s
	user    3m47.054s
	sys     1m45.666s

After
	real    0m31.922s
	user    0m38.489s
	sys     0m20.565s