### PR TITLE
🐞 Homewbrew: fix `:unneeded is deprecated!`

### DIFF
--- a/HomebrewFormula/kiln.rb
+++ b/HomebrewFormula/kiln.rb
@@ -6,7 +6,6 @@ class Kiln < Formula
   desc ""
   homepage ""
   version "0.0.0-dev-pr265.5"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
fixes, on `brew upgrade`:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the pivotal-cf/kiln tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/pivotal-cf/homebrew-kiln/HomebrewFormula/kiln.rb:9
```