### PR TITLE
fix: bake fails in tmp dir

### DIFF
--- a/internal/commands/bake.go
+++ b/internal/commands/bake.go
@@ -215,7 +215,10 @@ func (b *Bake) loadFlags(args []string, stat flags.StatFunc, readFile func(strin
 	}
 
 	if shouldGenerateTileFileName(b, args) {
-		b.Options.OutputFile = "tile-" + b.Options.Version + ".pivotal"
+		b.Options.OutputFile = "tile.pivotal"
+		if b.Options.Version != "" {
+			b.Options.OutputFile = "tile-" + b.Options.Version + ".pivotal"
+		}
 	}
 
 	if shouldNotUseDefaultKilnfileFlag(args) {


### PR DESCRIPTION
The constructor for the ReleaseNotes command expected to be called when the current directory is in a git repo. This is not always true and some existing scripts expect to run kiln from a temporary directory. To not break those scripts, the repository field on release notes is not set in the Execute method and not the constructor.

When testing the issue, I noticed the file name is a bit weird when there is no version set. So I also made the default output file name not have a dash when the version is not configured.