### PR TITLE
refactor: fix Goland linter warnings and run stricter formatter (gofumpt)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contributing to the docs
 
-The Kiln project team welcomes contributions from the community. If you wish to contribute code 
+The Kiln project team welcomes contributions from the community. If you wish to contribute code. 
 and you have not signed our [contributor license agreement](https://cla.vmware.com/cla/1/preview), our bot will update the issue when 
 you open a Pull Request. For any questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq).
 
-## Start with a github issue
+## Start with a GitHub issue
 
 In all cases, following this workflow will help all contributors to docs to
 participate more equitably:
 
-1. Search existing github issues that may already describe the idea you have.
+1. Search existing GitHub issues that may already describe the idea you have.
    If you find one, consider adding a comment that adds additional context 
    about your use case, 
    the exact problem you need solved and why, 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the docs
 
-The Kiln project team welcomes contributions from the community. If you wish to contribute code. 
+The Kiln project team welcomes contributions from the community. If you wish to contribute code
 and you have not signed our [contributor license agreement](https://cla.vmware.com/cla/1/preview), our bot will update the issue when 
 you open a Pull Request. For any questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq).
 

--- a/internal/acceptance/bake_test.go
+++ b/internal/acceptance/bake_test.go
@@ -9,11 +9,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
-
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -312,7 +311,6 @@ var _ = Describe("bake command", func() {
 	})
 
 	Context("when the --kilnfile flag is provided", func() {
-
 		It("generates a tile with the correct metadata including the stemcell criteria from the Kilnfile.lock", func() {
 			commandWithArgs = []string{
 				"bake",
@@ -584,10 +582,10 @@ var _ = Describe("bake command", func() {
 				someFileToEmbed := filepath.Join(tmpDir, "some-file-to-embed")
 				otherFileToEmbed := filepath.Join(tmpDir, "other-file-to-embed")
 
-				err := ioutil.WriteFile(someFileToEmbed, []byte("content-of-some-file"), 0600)
+				err := ioutil.WriteFile(someFileToEmbed, []byte("content-of-some-file"), 0o600)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(otherFileToEmbed, []byte("content-of-other-file"), 0755)
+				err = ioutil.WriteFile(otherFileToEmbed, []byte("content-of-other-file"), 0o755)
 				Expect(err).NotTo(HaveOccurred())
 
 				commandWithArgs = append(commandWithArgs,
@@ -636,7 +634,7 @@ var _ = Describe("bake command", func() {
 						Expect(err).NotTo(HaveOccurred())
 
 						mode := f.FileHeader.Mode()
-						Expect(mode).To(Equal(os.FileMode(0755)))
+						Expect(mode).To(Equal(os.FileMode(0o755)))
 
 						Expect(content).To(Equal([]byte("content-of-other-file")))
 					}
@@ -655,10 +653,10 @@ var _ = Describe("bake command", func() {
 				nestedDir := filepath.Join(dirToAdd, "some-nested-dir")
 				someFileToEmbed := filepath.Join(nestedDir, "some-file-to-embed")
 
-				err := os.MkdirAll(nestedDir, 0700)
+				err := os.MkdirAll(nestedDir, 0o700)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(someFileToEmbed, []byte("content-of-some-file"), 0600)
+				err = ioutil.WriteFile(someFileToEmbed, []byte("content-of-some-file"), 0o600)
 				Expect(err).NotTo(HaveOccurred())
 
 				commandWithArgs = append(commandWithArgs,
@@ -771,7 +769,8 @@ var _ = Describe("bake command", func() {
 
 		Context("when a Kilnfile.lock does not exist", func() {
 			It("prints an error and exits 1", func() {
-				commandWithArgs := []string{"bake",
+				commandWithArgs := []string{
+					"bake",
 					"--bosh-variables-directory", someBOSHVariablesDirectory,
 					"--forms-directory", someFormsDirectory,
 					"--forms-directory", someOtherFormsDirectory,
@@ -829,7 +828,7 @@ var _ = Describe("bake command", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(session).Should(gexec.Exit(1))
-				Expect(string(string(session.Err.Contents()))).To(ContainSubstring("no such file or directory"))
+				Expect(session.Err.Contents()).To(ContainSubstring("no such file or directory"))
 			})
 		})
 	})

--- a/internal/acceptance/init_test.go
+++ b/internal/acceptance/init_test.go
@@ -1,12 +1,12 @@
 package acceptance_test
 
 import (
+	"testing"
+
 	"github.com/onsi/gomega/gexec"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 var pathToMain string

--- a/internal/acceptance/integration/fetch_release_test.go
+++ b/internal/acceptance/integration/fetch_release_test.go
@@ -36,7 +36,7 @@ var _ = Describe("fetch", func() {
 
 		varsFilePath = filepath.Join(tmpDir, "variables.yml")
 		Expect(
-			ioutil.WriteFile(varsFilePath, []byte(varsFileContents), 0600),
+			ioutil.WriteFile(varsFilePath, []byte(varsFileContents), 0o600),
 		).To(Succeed())
 	})
 

--- a/internal/acceptance/integration/publish_test.go
+++ b/internal/acceptance/integration/publish_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/gstruct"
-	pivnet "github.com/pivotal-cf/go-pivnet/v2"
+	"github.com/pivotal-cf/go-pivnet/v2"
 	"github.com/pivotal-cf/go-pivnet/v2/logshim"
 )
 
@@ -88,8 +88,8 @@ pre_ga_user_groups:
 		initialDir, _ = os.Getwd()
 		err = os.Chdir(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
-		_ = ioutil.WriteFile("version", []byte(releaseVersion), 0777)
-		_ = ioutil.WriteFile("Kilnfile", []byte(kilnfileBody), 0777)
+		_ = ioutil.WriteFile("version", []byte(releaseVersion), 0o777)
+		_ = ioutil.WriteFile("Kilnfile", []byte(kilnfileBody), 0o777)
 	})
 
 	AfterEach(func() {

--- a/internal/acceptance/integration/update_release_test.go
+++ b/internal/acceptance/integration/update_release_test.go
@@ -40,7 +40,7 @@ var _ = Context("Updating a release to a specific version", func() {
 		releasesPath = filepath.Join(tmpDir, "releases")
 
 		Expect(
-			os.Mkdir(releasesPath, 0700),
+			os.Mkdir(releasesPath, 0o700),
 		).To(Succeed())
 	})
 
@@ -52,11 +52,11 @@ var _ = Context("Updating a release to a specific version", func() {
 
 	JustBeforeEach(func() {
 		Expect(
-			ioutil.WriteFile(kilnfilePath, []byte(kilnfileContents), 0600),
+			ioutil.WriteFile(kilnfilePath, []byte(kilnfileContents), 0o600),
 		).To(Succeed())
 
 		Expect(
-			ioutil.WriteFile(kilnfileLockPath, []byte(previousKilnfileLock), 0600),
+			ioutil.WriteFile(kilnfileLockPath, []byte(previousKilnfileLock), 0o600),
 		).To(Succeed())
 	})
 
@@ -184,7 +184,7 @@ stemcell_criteria:
 			varsFilePath = filepath.Join(tmpDir, "variables.yml")
 
 			Expect(
-				ioutil.WriteFile(varsFilePath, []byte(varsFileContents), 0600),
+				ioutil.WriteFile(varsFilePath, []byte(varsFileContents), 0o600),
 			).To(Succeed())
 		})
 

--- a/internal/acceptance/integration/update_stemcell_test.go
+++ b/internal/acceptance/integration/update_stemcell_test.go
@@ -81,19 +81,19 @@ stemcell_criteria:
 		varsFilePath = filepath.Join(tmpDir, "variables.yml")
 
 		Expect(
-			ioutil.WriteFile(kilnfilePath, []byte(kilnfileContents), 0600),
+			ioutil.WriteFile(kilnfilePath, []byte(kilnfileContents), 0o600),
 		).To(Succeed())
 
 		Expect(
-			ioutil.WriteFile(kilnfileLockPath, []byte(previousKilnfileLock), 0600),
+			ioutil.WriteFile(kilnfileLockPath, []byte(previousKilnfileLock), 0o600),
 		).To(Succeed())
 
 		Expect(
-			ioutil.WriteFile(varsFilePath, []byte(varsFileContents), 0600),
+			ioutil.WriteFile(varsFilePath, []byte(varsFileContents), 0o600),
 		).To(Succeed())
 
 		Expect(
-			os.Mkdir(releasesPath, 0700),
+			os.Mkdir(releasesPath, 0o700),
 		).To(Succeed())
 	})
 

--- a/internal/acceptance/match_sha_sum_of_matcher_test.go
+++ b/internal/acceptance/match_sha_sum_of_matcher_test.go
@@ -25,10 +25,10 @@ var _ = Describe("MatchSHASumOfMatcher", func() {
 				file1 := filepath.Join(tempDir, "file-1")
 				file2 := filepath.Join(tempDir, "file-2")
 
-				err = ioutil.WriteFile(file1, []byte("file contents"), 0644)
+				err = ioutil.WriteFile(file1, []byte("file contents"), 0o644)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(file2, []byte("file contents"), 0644)
+				err = ioutil.WriteFile(file2, []byte("file contents"), 0o644)
 				Expect(err).NotTo(HaveOccurred())
 
 				matcher := MatchSHASumOf(file1)
@@ -46,10 +46,10 @@ var _ = Describe("MatchSHASumOfMatcher", func() {
 				file1 := filepath.Join(tempDir, "file-1")
 				file2 := filepath.Join(tempDir, "file-2")
 
-				err = ioutil.WriteFile(file1, []byte("some contents"), 0644)
+				err = ioutil.WriteFile(file1, []byte("some contents"), 0o644)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(file2, []byte("other contents"), 0644)
+				err = ioutil.WriteFile(file2, []byte("other contents"), 0o644)
 				Expect(err).NotTo(HaveOccurred())
 
 				matcher := MatchSHASumOf(file1)

--- a/internal/acceptance/sync_with_local_test.go
+++ b/internal/acceptance/sync_with_local_test.go
@@ -30,8 +30,8 @@ var _ = Context("Syncing the Kilnfile.lock to releases on disk", func() {
 	)
 
 	const (
-		_readOnly      = 0600
-		_readExecWrite = 0700
+		_readOnly      = 0o600
+		_readExecWrite = 0o700
 	)
 
 	BeforeEach(func() {

--- a/internal/baking/checksummer.go
+++ b/internal/baking/checksummer.go
@@ -35,7 +35,7 @@ func (c Checksummer) Sum(path string) error {
 
 	hexsum := fmt.Sprintf("%x", hash.Sum(nil))
 
-	err = ioutil.WriteFile(fmt.Sprintf("%s.sha256", path), []byte(hexsum), 0644)
+	err = ioutil.WriteFile(fmt.Sprintf("%s.sha256", path), []byte(hexsum), 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/baking/checksummer.go
+++ b/internal/baking/checksummer.go
@@ -26,7 +26,7 @@ func (c Checksummer) Sum(path string) error {
 		return err
 	}
 
-	defer func() { _ = file.Close() }()
+	defer closeAndIgnoreError(file)
 
 	_, err = io.Copy(hash, file)
 	if err != nil {

--- a/internal/baking/checksummer_test.go
+++ b/internal/baking/checksummer_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Checksummer", func() {
 	})
 
 	AfterEach(func() {
-		err := os.Chmod(tmpdir, 0777)
+		err := os.Chmod(tmpdir, 0o777)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.RemoveAll(tmpdir)).To(Succeed())
 	})
@@ -74,7 +74,7 @@ var _ = Describe("Checksummer", func() {
 
 	Context("when the directory does not have write permissions", func() {
 		It("returns an error", func() {
-			err := os.Chmod(tmpdir, 0544)
+			err := os.Chmod(tmpdir, 0o544)
 			Expect(err).NotTo(HaveOccurred())
 
 			path := filepath.Join(tmpdir, "fixture")

--- a/internal/baking/init_test.go
+++ b/internal/baking/init_test.go
@@ -1,10 +1,10 @@
 package baking_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate

--- a/internal/baking/interfaces.go
+++ b/internal/baking/interfaces.go
@@ -1,6 +1,10 @@
 package baking
 
-import "github.com/pivotal-cf/kiln/internal/builder"
+import (
+	"io"
+
+	"github.com/pivotal-cf/kiln/internal/builder"
+)
 
 //counterfeiter:generate -o ./fakes/logger.go --fake-name Logger . logger
 type logger interface {
@@ -11,3 +15,5 @@ type logger interface {
 type partReader interface {
 	Read(path string) (builder.Part, error)
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/baking/releases_service.go
+++ b/internal/baking/releases_service.go
@@ -55,7 +55,6 @@ func (s ReleasesService) ReleasesInDirectory(directoryPath string) ([]builder.Pa
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/baking/releases_service_test.go
+++ b/internal/baking/releases_service_test.go
@@ -117,7 +117,7 @@ var _ = Describe("ReleasesService", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			nestedDir = filepath.Join(tempDir, "nested")
-			Expect(os.Mkdir(nestedDir, 0700)).To(Succeed())
+			Expect(os.Mkdir(nestedDir, 0o700)).To(Succeed())
 
 			file, err := ioutil.TempFile("", "")
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/baking/stemcell_service.go
+++ b/internal/baking/stemcell_service.go
@@ -31,7 +31,7 @@ func (ss StemcellService) FromDirectories(directories []string) (stemcell map[st
 
 	var tarballs []string
 	for _, directory := range directories {
-		err := filepath.Walk(directory, filepath.WalkFunc(func(path string, _ os.FileInfo, err error) error {
+		err := filepath.Walk(directory, func(path string, _ os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
@@ -41,8 +41,7 @@ func (ss StemcellService) FromDirectories(directories []string) (stemcell map[st
 			}
 
 			return nil
-		}))
-
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/baking/template_variables_service.go
+++ b/internal/baking/template_variables_service.go
@@ -47,9 +47,7 @@ func parseVariablesFromFile(fs billy.Basic, path string, variables map[string]in
 	}
 
 	err = yaml.NewDecoder(file).Decode(&variables)
-	defer func() {
-		_ = file.Close()
-	}()
+	defer closeAndIgnoreError(file)
 	if err != nil {
 		return fmt.Errorf("unable to YAML parse %q: %w", path, err)
 	}

--- a/internal/baking/template_variables_service_test.go
+++ b/internal/baking/template_variables_service_test.go
@@ -83,7 +83,7 @@ key-3: value-3
 
 			Context("when the variable file contents cannot be unmarshalled", func() {
 				It("returns an error", func() {
-					err := ioutil.WriteFile(path, []byte("\t\t\t"), 0644)
+					err := ioutil.WriteFile(path, []byte("\t\t\t"), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = service.FromPathsAndPairs([]string{path}, nil)

--- a/internal/builder/init_test.go
+++ b/internal/builder/init_test.go
@@ -44,6 +44,6 @@ func (b Buffer) Close() error {
 	return nil
 }
 
-func (b Buffer) Seek(offset int64, whence int) (int64, error) {
+func (b Buffer) Seek(_ int64, _ int) (int64, error) {
 	return 0, nil
 }

--- a/internal/builder/interfaces.go
+++ b/internal/builder/interfaces.go
@@ -1,8 +1,12 @@
 package builder
 
+import "io"
+
 type logger interface {
 	Printf(format string, v ...interface{})
 	Println(v ...interface{})
 }
 
 type Metadata map[string]interface{}
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/builder/interpolator_test.go
+++ b/internal/builder/interpolator_test.go
@@ -115,7 +115,6 @@ selected_value: $( release "some-release" | select "version" )
 	})
 
 	It("interpolates yaml correctly", func() {
-
 		type namedThing struct {
 			Name string `yaml:"name"`
 		}
@@ -317,7 +316,6 @@ stemcell_criteria:
 `,
 			))
 		})
-
 	})
 
 	Context("when the runtime config is provided", func() {
@@ -392,7 +390,6 @@ some_runtime_configs:
 
 	Context("when release tgz file does not exist and stub releases is true", func() {
 		It("creates stub values for file, sha1, and version", func() {
-
 			interpolator := builder.NewInterpolator()
 			input.StubReleases = true
 			interpolatedYAML, err := interpolator.Interpolate(input, "", []byte(`releases: [$(release "stub-release")]`))
@@ -457,7 +454,6 @@ some_runtime_configs:
 
 		Context("when template parsing fails", func() {
 			It("returns an error", func() {
-
 				interpolator := builder.NewInterpolator()
 				_, err := interpolator.Interpolate(input, "", []byte("$(variable"))
 				Expect(err).To(HaveOccurred())
@@ -467,7 +463,6 @@ some_runtime_configs:
 
 		Context("when template execution fails", func() {
 			It("returns an error", func() {
-
 				interpolator := builder.NewInterpolator()
 				_, err := interpolator.Interpolate(input, "", []byte(`name: $( variable "some-missing-variable" )`))
 
@@ -479,7 +474,6 @@ some_runtime_configs:
 
 		Context("when release tgz file does not exist but is provided", func() {
 			It("returns an error", func() {
-
 				interpolator := builder.NewInterpolator()
 				_, err := interpolator.Interpolate(input, "", []byte(`releases: [$(release "some-release-does-not-exist")]`))
 

--- a/internal/builder/metadata_parts_directory_reader.go
+++ b/internal/builder/metadata_parts_directory_reader.go
@@ -187,7 +187,7 @@ func (r MetadataPartsDirectoryReader) orderWithOrderFromFile(path string, parts 
 	if err != nil {
 		return []Part{}, err
 	}
-	defer func() { _ = f.Close() }()
+	defer closeAndIgnoreError(f)
 
 	data, err := ioutil.ReadAll(f)
 	if err != nil {

--- a/internal/builder/metadata_parts_directory_reader_test.go
+++ b/internal/builder/metadata_parts_directory_reader_test.go
@@ -36,14 +36,14 @@ var _ = Describe("MetadataPartsDirectoryReader", func() {
 - name: variable-2
   alias: variable-2-alias
   type: user
-`), 0755)
+`), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 			err = ioutil.WriteFile(filepath.Join(tempDir, "vars-file-2.yml"), []byte(`---
 name: variable-3
 type: password
-`), 0755)
+`), 0o755)
 			Expect(err).ToNot(HaveOccurred())
-			err = ioutil.WriteFile(filepath.Join(tempDir, "ignores.any-other-extension"), []byte("not-yaml"), 0755)
+			err = ioutil.WriteFile(filepath.Join(tempDir, "ignores.any-other-extension"), []byte("not-yaml"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			reader = builder.NewMetadataPartsDirectoryReader()
@@ -90,7 +90,7 @@ type: password
 
 		Context("when there is an error reading from a file", func() {
 			It("errors", func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "unreadable-file.yml"), []byte(`unused`), 0000)
+				err := ioutil.WriteFile(filepath.Join(tempDir, "unreadable-file.yml"), []byte(`unused`), 0o000)
 				Expect(err).ToNot(HaveOccurred())
 				_, err = reader.Read(tempDir)
 				Expect(err).To(HaveOccurred())
@@ -100,7 +100,7 @@ type: password
 
 		Context("when a yaml file is malformed", func() {
 			It("errors", func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "not-valid-yaml.yml"), []byte(`{{`), 0755)
+				err := ioutil.WriteFile(filepath.Join(tempDir, "not-valid-yaml.yml"), []byte(`{{`), 0o755)
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = reader.Read(tempDir)
@@ -110,7 +110,7 @@ type: password
 
 		Context("when file contains an array item without a name", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`[{foo: bar}]`), 0755)
+				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`[{foo: bar}]`), 0o755)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -123,7 +123,7 @@ type: password
 
 		Context("when variable file contains a map item without a name", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`{foo: bar}`), 0755)
+				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`{foo: bar}`), 0o755)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -142,7 +142,7 @@ variable_order:
 - variable-3
 - variable-2
 - variable-1
-`), 0755)
+`), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 			err = ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`---
 variables:
@@ -150,15 +150,15 @@ variables:
   type: certificate
 - name: variable-2
   type: user
-`), 0755)
+`), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 			err = ioutil.WriteFile(filepath.Join(tempDir, "vars-file-2.yml"), []byte(`---
 variables:
 - name: variable-3
   type: password
-`), 0755)
+`), 0o755)
 			Expect(err).ToNot(HaveOccurred())
-			err = ioutil.WriteFile(filepath.Join(tempDir, "ignores.any-other-extension"), []byte("not-yaml"), 0755)
+			err = ioutil.WriteFile(filepath.Join(tempDir, "ignores.any-other-extension"), []byte("not-yaml"), 0o755)
 			Expect(err).ToNot(HaveOccurred())
 
 			reader = builder.NewMetadataPartsDirectoryReaderWithTopLevelKey("variables")
@@ -200,7 +200,7 @@ variables:
 		Context("failure cases", func() {
 			Context("when a yaml file does not contain the top-level key", func() {
 				It("errors", func() {
-					err := ioutil.WriteFile(filepath.Join(tempDir, "not-a-vars-file.yml"), []byte(`constants: []`), 0755)
+					err := ioutil.WriteFile(filepath.Join(tempDir, "not-a-vars-file.yml"), []byte(`constants: []`), 0o755)
 					Expect(err).ToNot(HaveOccurred())
 
 					_, err = reader.Read(tempDir)
@@ -212,7 +212,7 @@ variables:
 
 		Context("when variable file is neither a slice or a map", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`variables: foo`), 0755)
+				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`variables: foo`), 0o755)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -225,7 +225,7 @@ variables:
 
 		Context("when variable file contains an invalid item", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`variables: [foo]`), 0755)
+				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`variables: [foo]`), 0o755)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -238,7 +238,7 @@ variables:
 
 		Context("when variable file contains an array item without a name", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`variables: [{foo: bar}]`), 0755)
+				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`variables: [{foo: bar}]`), 0o755)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -251,7 +251,7 @@ variables:
 
 		Context("when variable file contains a map item without a name", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`variables: {foo: bar}`), 0755)
+				err := ioutil.WriteFile(filepath.Join(tempDir, "vars-file-1.yml"), []byte(`variables: {foo: bar}`), 0o755)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -314,7 +314,7 @@ variables:
 
 				Context("when _order.yml file is not in valid format", func() {
 					BeforeEach(func() {
-						err := ioutil.WriteFile(filepath.Join(tempDir, "_order.yml"), []byte(`variable_order: foo`), 0755)
+						err := ioutil.WriteFile(filepath.Join(tempDir, "_order.yml"), []byte(`variable_order: foo`), 0o755)
 						Expect(err).ToNot(HaveOccurred())
 					})
 
@@ -337,7 +337,7 @@ variables:
 
 				Context("when _order.yml file contains a name that does not exist", func() {
 					BeforeEach(func() {
-						err := ioutil.WriteFile(filepath.Join(tempDir, "_order.yml"), []byte(`variable_order: [some-file]`), 0755)
+						err := ioutil.WriteFile(filepath.Join(tempDir, "_order.yml"), []byte(`variable_order: [some-file]`), 0o755)
 						Expect(err).ToNot(HaveOccurred())
 					})
 

--- a/internal/builder/release_manifest_reader.go
+++ b/internal/builder/release_manifest_reader.go
@@ -52,13 +52,13 @@ func (r ReleaseManifestReader) Read(releaseTarball string) (Part, error) {
 	if err != nil {
 		return Part{}, err
 	}
-	defer func() { _ = file.Close() }()
+	defer closeAndIgnoreError(file)
 
 	gr, err := gzip.NewReader(file)
 	if err != nil {
 		return Part{}, err
 	}
-	defer func() { _ = gr.Close() }()
+	defer closeAndIgnoreError(gr)
 
 	tr := tar.NewReader(gr)
 

--- a/internal/builder/release_manifest_reader_test.go
+++ b/internal/builder/release_manifest_reader_test.go
@@ -33,7 +33,7 @@ func createReleaseTarball(releaseMetadata string) (*os.File, string) {
 	header := &tar.Header{
 		Name:    "./release.MF",
 		Size:    int64(releaseManifest.Len()),
-		Mode:    int64(0644),
+		Mode:    int64(0o644),
 		ModTime: time.Now(),
 	}
 
@@ -148,7 +148,7 @@ version: 1.2.3
 
 			Context("when the input is not a valid gzip", func() {
 				It("returns an error", func() {
-					tarball, err = os.OpenFile(tarball.Name(), os.O_RDWR, 0666)
+					tarball, err = os.OpenFile(tarball.Name(), os.O_RDWR, 0o666)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = tarball.WriteAt([]byte{}, 10)
@@ -163,7 +163,7 @@ version: 1.2.3
 
 					By("corrupting the gzip header contents", func() {
 						contents[0] = 0
-						err = ioutil.WriteFile(tarball.Name(), contents, 0666)
+						err = ioutil.WriteFile(tarball.Name(), contents, 0o666)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -204,7 +204,7 @@ version: 1.2.3
 					header := &tar.Header{
 						Name:    "./someotherfile.MF",
 						Size:    int64(releaseManifest.Len()),
-						Mode:    int64(0644),
+						Mode:    int64(0o644),
 						ModTime: time.Now(),
 					}
 
@@ -260,7 +260,7 @@ version: 1.2.3
 					header := &tar.Header{
 						Name:    "./release.MF",
 						Size:    int64(releaseManifest.Len()),
-						Mode:    int64(0644),
+						Mode:    int64(0o644),
 						ModTime: time.Now(),
 					}
 

--- a/internal/builder/stemcell_manifest_reader.go
+++ b/internal/builder/stemcell_manifest_reader.go
@@ -43,13 +43,13 @@ func (r StemcellManifestReader) Read(stemcellTarball string) (Part, error) {
 	if err != nil {
 		return Part{}, err
 	}
-	defer func() { _ = file.Close() }()
+	defer closeAndIgnoreError(file)
 
 	gr, err := gzip.NewReader(file)
 	if err != nil {
 		return Part{}, err
 	}
-	defer func() { _ = gr.Close() }()
+	defer closeAndIgnoreError(gr)
 
 	tr := tar.NewReader(gr)
 

--- a/internal/builder/stemcell_manifest_reader_test.go
+++ b/internal/builder/stemcell_manifest_reader_test.go
@@ -38,7 +38,7 @@ operating_system: centOS
 		header := &tar.Header{
 			Name:    "./stemcell.MF",
 			Size:    int64(stemcellManifest.Len()),
-			Mode:    int64(0644),
+			Mode:    int64(0o644),
 			ModTime: time.Now(),
 		}
 
@@ -136,7 +136,7 @@ operating_system: centOS
 					header := &tar.Header{
 						Name:    "./someotherfile.MF",
 						Size:    int64(stemcellManifest.Len()),
-						Mode:    int64(0644),
+						Mode:    int64(0o644),
 						ModTime: time.Now(),
 					}
 
@@ -190,7 +190,7 @@ operating_system: centOS
 					header := &tar.Header{
 						Name:    "./stemcell.MF",
 						Size:    int64(stemcellManifest.Len()),
-						Mode:    int64(0644),
+						Mode:    int64(0o644),
 						ModTime: time.Now(),
 					}
 

--- a/internal/builder/tile_writer.go
+++ b/internal/builder/tile_writer.go
@@ -192,7 +192,7 @@ func (w TileWriter) addEmbeddedPath(pathToEmbed, outputFile string) error {
 
 		relativePath, err := filepath.Rel(pathToEmbed, filePath)
 		if err != nil {
-			return err //not tested
+			return err // not tested
 		}
 
 		entryPath := filepath.Join("embed", filepath.Join(filepath.Base(pathToEmbed), relativePath))
@@ -205,8 +205,8 @@ func (w TileWriter) addMigrations(migrationsDir []string, outputFile string) err
 
 	for _, migrationDir := range migrationsDir {
 		err := w.filesystem.Walk(migrationDir, func(filePath string, info os.FileInfo, err error) error {
-			isNodeFile, _ := regexp.MatchString(`node_modules\/`, filePath)
-			isTest, _ := regexp.MatchString(`tests\/`, filePath)
+			isNodeFile, _ := regexp.MatchString(`node_modules/`, filePath)
+			isTest, _ := regexp.MatchString(`tests/`, filePath)
 			isJsFile, _ := regexp.MatchString(`.js$`, filePath)
 
 			if isNodeFile || isTest || !isJsFile {
@@ -231,7 +231,6 @@ func (w TileWriter) addMigrations(migrationsDir []string, outputFile string) err
 
 			return w.addToZipper(filepath.Join("migrations", "v1", filepath.Base(filePath)), file, outputFile)
 		})
-
 		if err != nil {
 			return err
 		}

--- a/internal/builder/tile_writer.go
+++ b/internal/builder/tile_writer.go
@@ -69,7 +69,7 @@ func (w TileWriter) Write(generatedMetadataContents []byte, input WriteInput) er
 	if err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
+	defer closeAndIgnoreError(f)
 
 	w.zipper.SetWriter(f)
 
@@ -157,7 +157,7 @@ func (w TileWriter) addReleaseTarballs(releasesDir string, outputFile string) er
 		if err != nil {
 			return err
 		}
-		defer func() { _ = file.Close() }()
+		defer closeAndIgnoreError(file)
 
 		return w.addToZipper(filepath.Join("releases", filepath.Base(filePath)), file, outputFile)
 	})
@@ -188,7 +188,7 @@ func (w TileWriter) addEmbeddedPath(pathToEmbed, outputFile string) error {
 		if err != nil {
 			return err
 		}
-		defer func() { _ = file.Close() }()
+		defer closeAndIgnoreError(file)
 
 		relativePath, err := filepath.Rel(pathToEmbed, filePath)
 		if err != nil {
@@ -227,7 +227,7 @@ func (w TileWriter) addMigrations(migrationsDir []string, outputFile string) err
 			if err != nil {
 				return err
 			}
-			defer func() { _ = file.Close() }()
+			defer closeAndIgnoreError(file)
 
 			return w.addToZipper(filepath.Join("migrations", "v1", filepath.Base(filePath)), file, outputFile)
 		})

--- a/internal/builder/tile_writer_test.go
+++ b/internal/builder/tile_writer_test.go
@@ -118,7 +118,7 @@ var _ = Describe("TileWriter", func() {
 				}
 			}
 
-			var metadata = `---
+			metadata := `---
 releases:
 - file: release-1.tgz
 - file: release-2.tgz
@@ -180,7 +180,6 @@ releases:
 				fmt.Sprintf("Adding releases/release-3.tgz to %s...", outputFile),
 				fmt.Sprintf("Adding releases/release-4.tgz to %s...", outputFile),
 			}))
-
 		},
 			Entry("without stubbing releases", false, nil),
 			Entry("with stubbed releases", true, errors.New("don't open release")),
@@ -719,7 +718,6 @@ releases:
 						Expect(logger.PrintfCall.Receives.LogLines).To(
 							ContainElement(expectedLogLine),
 						)
-
 					})
 				})
 			})

--- a/internal/builder/zipper_test.go
+++ b/internal/builder/zipper_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Zipper", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(contents).To(Equal([]byte("file contents")))
-			Expect(reader.File[0].FileHeader.Mode()).To(Equal(os.FileMode(0666)))
+			Expect(reader.File[0].FileHeader.Mode()).To(Equal(os.FileMode(0o666)))
 			Expect(reader.File[0].FileHeader.Modified).To(BeTemporally("~", time.Now(), time.Minute))
 		})
 
@@ -146,7 +146,7 @@ var _ = Describe("Zipper", func() {
 			zipper := builder.NewZipper()
 			zipper.SetWriter(tileFile)
 
-			err := zipper.AddWithMode("some/path/to/file.txt", strings.NewReader("file contents"), 0644)
+			err := zipper.AddWithMode("some/path/to/file.txt", strings.NewReader("file contents"), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = zipper.Close()
@@ -165,7 +165,7 @@ var _ = Describe("Zipper", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(contents).To(Equal([]byte("file contents")))
-			Expect(reader.File[0].FileHeader.Mode()).To(Equal(os.FileMode(0644)))
+			Expect(reader.File[0].FileHeader.Mode()).To(Equal(os.FileMode(0o644)))
 			Expect(reader.File[0].FileHeader.Modified).To(BeTemporally("~", time.Now(), time.Minute))
 		})
 

--- a/internal/commands/bake.go
+++ b/internal/commands/bake.go
@@ -166,7 +166,6 @@ func NewBakeWithInterfaces(
 	metadataService metadataService,
 	checksummer checksummer,
 ) Bake {
-
 	return Bake{
 		interpolator:      interpolator,
 		tileWriter:        tileWriter,
@@ -333,7 +332,7 @@ func (b Bake) Execute(args []string) error {
 		BOSHVariables:      boshVariables,
 		ReleaseManifests:   releaseManifests,
 		StemcellManifests:  stemcellManifests,
-		StemcellManifest:   stemcellManifest, //TODO Remove when --stemcell-tarball is deprecated
+		StemcellManifest:   stemcellManifest, // TODO Remove when --stemcell-tarball is deprecated
 		FormTypes:          forms,
 		IconImage:          icon,
 		InstanceGroups:     instanceGroups,

--- a/internal/commands/bake_test.go
+++ b/internal/commands/bake_test.go
@@ -393,7 +393,7 @@ var _ = Describe("Bake", func() {
 				var err error
 				otherVariableFile, err = ioutil.TempFile(tmpDir, "variables-file")
 				Expect(err).NotTo(HaveOccurred())
-				defer func() { _ = otherVariableFile.Close() }()
+				defer closeAndIgnoreError(otherVariableFile)
 
 				variables := map[string]string{
 					"some-variable-from-file":       "override-variable-from-other-file",

--- a/internal/commands/bake_test.go
+++ b/internal/commands/bake_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Bake", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		nonTarballRelease := filepath.Join(someReleasesDirectory, "some-broken-release")
-		err = ioutil.WriteFile(nonTarballRelease, []byte(""), 0644)
+		err = ioutil.WriteFile(nonTarballRelease, []byte(""), 0o644)
 		Expect(err).NotTo(HaveOccurred())
 
 		fakeTileWriter = &fakes.TileWriter{}
@@ -729,7 +729,7 @@ var _ = Describe("Bake", func() {
 				})
 			})
 
-			//todo: When --stemcell-tarball is removed, delete this test
+			// todo: When --stemcell-tarball is removed, delete this test
 			Context("when both the --stemcell-tarball and --kilnfile are provided", func() {
 				It("returns an error", func() {
 					err := bake.Execute([]string{
@@ -742,7 +742,7 @@ var _ = Describe("Bake", func() {
 				})
 			})
 
-			//todo: When --stemcell-tarball is remove, delete this test
+			// todo: When --stemcell-tarball is remove, delete this test
 			Context("when both the --stemcell-tarball and --stemcells-directory are provided", func() {
 				It("returns an error", func() {
 					err := bake.Execute([]string{

--- a/internal/commands/cache_compiled_releases.go
+++ b/internal/commands/cache_compiled_releases.go
@@ -304,9 +304,7 @@ func (cmd *CacheCompiledReleases) uploadLocalRelease(spec component.Spec, fp str
 	if err != nil {
 		return component.Lock{}, err
 	}
-	defer func() {
-		_ = f.Close()
-	}()
+	defer closeAndIgnoreError(f)
 	return uploader.UploadRelease(spec, f)
 }
 
@@ -318,9 +316,7 @@ func (cmd *CacheCompiledReleases) saveReleaseLocally(director boshdir.Director, 
 	if err != nil {
 		return "", "", "", err
 	}
-	defer func() {
-		_ = f.Close()
-	}()
+	defer closeAndIgnoreError(f)
 
 	sha256sum := sha256.New()
 	sha1sum := sha1.New()

--- a/internal/commands/cache_compiled_releases.go
+++ b/internal/commands/cache_compiled_releases.go
@@ -282,9 +282,9 @@ func updateLock(lock cargo.KilnfileLock, release component.Lock, targetID string
 			continue
 		}
 
-		digest := release.SHA1
+		checksum := release.SHA1
 		if releaseLock.RemoteSource == targetID {
-			digest = releaseLock.SHA1
+			checksum = releaseLock.SHA1
 		}
 
 		lock.Releases[index] = cargo.ComponentLock{
@@ -292,7 +292,7 @@ func updateLock(lock cargo.KilnfileLock, release component.Lock, targetID string
 			Version:      release.Version,
 			RemoteSource: release.RemoteSource,
 			RemotePath:   release.RemotePath,
-			SHA1:         digest,
+			SHA1:         checksum,
 		}
 		return nil
 	}

--- a/internal/commands/cache_compiled_releases_test.go
+++ b/internal/commands/cache_compiled_releases_test.go
@@ -373,7 +373,7 @@ func TestCacheCompiledReleases_Execute_when_a_release_is_not_compiled_with_the_c
 	}), "it should not override the in-correct element in the Kilnfile.lock")
 }
 
-// this test ensures make it so the we don't have to iterate over all the releases
+// this test ensures make it so that we don't have to iterate over all the releases
 // before failing due to a stemcell mismatch
 func TestCacheCompiledReleases_Execute_staged_and_lock_stemcells_are_not_the_same(t *testing.T) {
 	please := Ω.NewWithT(t)

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1,0 +1,5 @@
+package commands
+
+import "io"
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -81,7 +81,7 @@ func (f *Fetch) setup(args []string) (cargo.Kilnfile, cargo.KilnfileLock, []comp
 	}
 	if _, err := os.Stat(f.Options.ReleasesDir); err != nil {
 		if os.IsNotExist(err) {
-			err = os.MkdirAll(f.Options.ReleasesDir, 0777)
+			err = os.MkdirAll(f.Options.ReleasesDir, 0o777)
 			if err != nil {
 				return cargo.Kilnfile{}, cargo.KilnfileLock{}, nil, err
 			}

--- a/internal/commands/fetch_test.go
+++ b/internal/commands/fetch_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Fetch", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			someKilnfilePath = filepath.Join(tmpDir, "Kilnfile")
-			err = ioutil.WriteFile(someKilnfilePath, []byte(""), 0644)
+			err = ioutil.WriteFile(someKilnfilePath, []byte(""), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			someKilnfileLockPath = filepath.Join(tmpDir, "Kilnfile.lock")
@@ -116,7 +116,7 @@ stemcell_criteria:
 				return fakeReleaseSources
 			}
 
-			err := ioutil.WriteFile(someKilnfileLockPath, []byte(lockContents), 0644)
+			err := ioutil.WriteFile(someKilnfileLockPath, []byte(lockContents), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			fetch = commands.NewFetch(logger, multiReleaseSourceProvider, fakeLocalReleaseDirectory)
 
@@ -398,9 +398,7 @@ stemcell_criteria:
 			})
 
 			Context("when download fails", func() {
-				var (
-					wrappedErr error
-				)
+				var wrappedErr error
 
 				BeforeEach(func() {
 					wrappedErr = errors.New("kaboom")
@@ -456,7 +454,6 @@ stemcell_criteria:
 				localReleaseID  = component.Spec{Name: "some-extra-release", Version: "1.2.3"}
 			)
 			BeforeEach(func() {
-
 				lockContents = `---
 releases:
 - name: some-release
@@ -474,7 +471,6 @@ stemcell_criteria:
 				fakeBoshIOReleaseSource.DownloadReleaseReturns(
 					component.Local{Lock: boshIOReleaseID.Lock().WithSHA1("correct-sha"), LocalPath: "local-path"},
 					nil)
-
 			})
 
 			Context("in non-interactive mode", func() {
@@ -518,15 +514,13 @@ release_sources:
     path_template: $( variable "path_template" )
 `
 
-				var (
-					someVariableFile, otherVariableFile *os.File
-				)
+				var someVariableFile, otherVariableFile *os.File
 
 				BeforeEach(func() {
 					var err error
 
 					someKilnfilePath = filepath.Join(tmpDir, "Kilnfile")
-					err = ioutil.WriteFile(someKilnfilePath, []byte(TemplatizedKilnfileYMLContents), 0644)
+					err = ioutil.WriteFile(someKilnfilePath, []byte(TemplatizedKilnfileYMLContents), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
 					someVariableFile, err = ioutil.TempFile(tmpDir, "variables-file1")
@@ -583,8 +577,8 @@ release_sources:
 
 				It("passes concurrency parameter to DownloadReleases", func() {
 					Expect(fetchExecuteErr).NotTo(HaveOccurred())
-					//Expect(fakeReleaseSources.SetDownloadThreadsCallCount()).To(Equal(1))
-					//Expect(fakeReleaseSources.SetDownloadThreadsArgsForCall(0)).To(Equal(50))
+					// Expect(fakeReleaseSources.SetDownloadThreadsCallCount()).To(Equal(1))
+					// Expect(fakeReleaseSources.SetDownloadThreadsArgsForCall(0)).To(Equal(50))
 					// TODO: add test back in
 				})
 			})
@@ -626,7 +620,6 @@ release_sources:
 				})
 			})
 		})
-
 	})
 
 	Describe("Usage", func() {

--- a/internal/commands/fetch_test.go
+++ b/internal/commands/fetch_test.go
@@ -424,9 +424,7 @@ stemcell_criteria:
 					fakeS3BuiltReleaseSource.DownloadReleaseCalls(func(string, component.Lock) (component.Local, error) {
 						f, err := os.Create(badReleasePath)
 						Expect(err).NotTo(HaveOccurred())
-						defer func() {
-							_ = f.Close()
-						}()
+						defer closeAndIgnoreError(f)
 
 						return component.Local{
 							Lock: missingReleaseS3BuiltID.Lock().WithSHA1("wrong-sha"), LocalPath: badReleasePath,
@@ -525,7 +523,7 @@ release_sources:
 
 					someVariableFile, err = ioutil.TempFile(tmpDir, "variables-file1")
 					Expect(err).NotTo(HaveOccurred())
-					defer func() { _ = someVariableFile.Close() }()
+					defer closeAndIgnoreError(someVariableFile)
 
 					variables := map[string]string{
 						"bucket": "my-releases",
@@ -538,7 +536,7 @@ release_sources:
 
 					otherVariableFile, err = ioutil.TempFile(tmpDir, "variables-file2")
 					Expect(err).NotTo(HaveOccurred())
-					defer func() { _ = otherVariableFile.Close() }()
+					defer closeAndIgnoreError(otherVariableFile)
 
 					variables = map[string]string{
 						"access_key":    "newkey",

--- a/internal/commands/find_release_version_test.go
+++ b/internal/commands/find_release_version_test.go
@@ -58,10 +58,10 @@ releases:
   source: bosh.io`
 
 			someKilnfilePath = filepath.Join(tmpDir, "Kilnfile")
-			err = ioutil.WriteFile(someKilnfilePath, []byte(kilnContents), 0644)
+			err = ioutil.WriteFile(someKilnfilePath, []byte(kilnContents), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			someKilnfileLockPath := filepath.Join(tmpDir, "Kilnfile.lock")
-			err = ioutil.WriteFile(someKilnfileLockPath, []byte(lockContents), 0644)
+			err = ioutil.WriteFile(someKilnfileLockPath, []byte(lockContents), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/internal/commands/find_stemcell_version.go
+++ b/internal/commands/find_stemcell_version.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	ErrStemcellOSInfoMustBeValid       = "Stemcell OS information is missing or invalid"
-	ErrStemcellMajorVersionMustBeValid = "Stemcell Major Version is missing or invalid"
-	TanzunetRemotePath                 = "network.pivotal.io"
+	ErrStemcellOSInfoMustBeValid       = "stemcell os information is missing or invalid"
+	ErrStemcellMajorVersionMustBeValid = "stemcell major Version is missing or invalid"
+	TanzuNetRemotePath                 = "network.pivotal.io"
 )
 
 type FindStemcellVersion struct {
@@ -50,14 +50,13 @@ func NewFindStemcellVersion(outLogger *log.Logger, pivnetService *component.Pivn
 
 func (cmd FindStemcellVersion) Execute(args []string) error {
 	kilnfile, err := cmd.setup(args)
-
 	if err != nil {
 		return err
 	}
 
-	var productSlug = ""
+	productSlug := ""
 
-	//Get Stemcell OS and major from Kilnfile
+	// Get Stemcell OS and major from Kilnfile
 	if kilnfile.Stemcell.OS == "ubuntu-xenial" {
 		productSlug = "stemcells-ubuntu-xenial"
 	} else if kilnfile.Stemcell.OS == "windows2019" {
@@ -73,14 +72,12 @@ func (cmd FindStemcellVersion) Execute(args []string) error {
 	}
 
 	majorVersion, err := ExtractMajorVersion(kilnfile.Stemcell.Version)
-
 	if err != nil {
 		return err
 	}
 
-	//Get stemcell version from pivnet
+	// Get stemcell version from pivnet
 	stemcellVersion, err := cmd.pivnetService.StemcellVersion(productSlug, majorVersion)
-
 	if err != nil {
 		return err
 	}
@@ -88,9 +85,8 @@ func (cmd FindStemcellVersion) Execute(args []string) error {
 	stemcellVersionJson, err := json.Marshal(stemcellVersionOutput{
 		Version:    stemcellVersion,
 		Source:     "Tanzunet",
-		RemotePath: TanzunetRemotePath,
+		RemotePath: TanzuNetRemotePath,
 	})
-
 	if err != nil {
 		return err
 	}
@@ -101,17 +97,14 @@ func (cmd FindStemcellVersion) Execute(args []string) error {
 }
 
 func ExtractMajorVersion(version string) (string, error) {
-
 	_, err := semver.NewConstraint(version)
-
 	if err != nil {
-		return "", fmt.Errorf("Invalid stemcell constraint in kilnfile: %w", err)
+		return "", fmt.Errorf("invalid stemcell constraint in kilnfile: %w", err)
 	}
 
 	semVer := strings.Split(version, ".")
 
 	reg, err := regexp.Compile(`[^0-9]+`)
-
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +116,6 @@ func ExtractMajorVersion(version string) (string, error) {
 	}
 
 	return majorVersion, nil
-
 }
 
 func (cmd *FindStemcellVersion) setup(args []string) (cargo.Kilnfile, error) {

--- a/internal/commands/find_stemcell_version_test.go
+++ b/internal/commands/find_stemcell_version_test.go
@@ -74,7 +74,6 @@ stemcell_criteria:
 		})
 
 		JustBeforeEach(func() {
-
 			_, requestErr = pivnet.Do(simpleRequest)
 			Expect(requestErr).NotTo(HaveOccurred())
 
@@ -83,11 +82,11 @@ stemcell_criteria:
 
 			someKilnfilePath = filepath.Join(tmpDir, "Kilnfile")
 
-			err = ioutil.WriteFile(someKilnfilePath, []byte(kilnfileContents), 0644)
+			err = ioutil.WriteFile(someKilnfilePath, []byte(kilnfileContents), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			someKilnfileLockPath = filepath.Join(tmpDir, "Kilnfile.lock")
-			err = ioutil.WriteFile(someKilnfileLockPath, []byte(lockContents), 0644)
+			err = ioutil.WriteFile(someKilnfileLockPath, []byte(lockContents), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			findStemcellVersion = commands.NewFindStemcellVersion(logger, &pivnet)
@@ -161,7 +160,7 @@ stemcell_criteria:
 		var (
 			stemcellVersionSpecifier string
 			majorVersion             string
-			error                    error
+			returnedErr              error
 		)
 
 		BeforeEach(func() {
@@ -169,7 +168,7 @@ stemcell_criteria:
 		})
 
 		JustBeforeEach(func() {
-			majorVersion, error = commands.ExtractMajorVersion(stemcellVersionSpecifier)
+			majorVersion, returnedErr = commands.ExtractMajorVersion(stemcellVersionSpecifier)
 		})
 
 		When("Invalid Stemcell Version Specifier is provided", func() {
@@ -179,8 +178,8 @@ stemcell_criteria:
 				})
 
 				It("returns the latest stemcell version", func() {
-					Expect(error).To(HaveOccurred())
-					Expect(error.Error()).To(Equal(commands.ErrStemcellMajorVersionMustBeValid))
+					Expect(returnedErr).To(HaveOccurred())
+					Expect(returnedErr.Error()).To(Equal(commands.ErrStemcellMajorVersionMustBeValid))
 				})
 			})
 		})
@@ -192,7 +191,7 @@ stemcell_criteria:
 				})
 
 				It("returns the latest stemcell version", func() {
-					Expect(error).NotTo(HaveOccurred())
+					Expect(returnedErr).NotTo(HaveOccurred())
 					Expect(majorVersion).To(Equal("456"))
 				})
 			})
@@ -202,7 +201,7 @@ stemcell_criteria:
 				})
 
 				It("returns the latest stemcell version", func() {
-					Expect(error).NotTo(HaveOccurred())
+					Expect(returnedErr).NotTo(HaveOccurred())
 					Expect(majorVersion).To(Equal("777"))
 				})
 			})
@@ -213,7 +212,7 @@ stemcell_criteria:
 				})
 
 				It("returns the latest stemcell version", func() {
-					Expect(error).NotTo(HaveOccurred())
+					Expect(returnedErr).NotTo(HaveOccurred())
 					Expect(majorVersion).To(Equal("1234"))
 				})
 			})
@@ -224,7 +223,7 @@ stemcell_criteria:
 				})
 
 				It("returns the latest stemcell version", func() {
-					Expect(error).NotTo(HaveOccurred())
+					Expect(returnedErr).NotTo(HaveOccurred())
 					Expect(majorVersion).To(Equal("456"))
 				})
 			})
@@ -235,7 +234,7 @@ stemcell_criteria:
 				})
 
 				It("returns the latest stemcell version", func() {
-					Expect(error).NotTo(HaveOccurred())
+					Expect(returnedErr).NotTo(HaveOccurred())
 					Expect(majorVersion).To(Equal("333"))
 				})
 			})

--- a/internal/commands/flags/parse.go
+++ b/internal/commands/flags/parse.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"fmt"
 	"go/ast"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -58,9 +59,7 @@ func (options *Standard) LoadKilnfiles(fsOverride billy.Basic, variablesServiceO
 	if err != nil {
 		return cargo.Kilnfile{}, cargo.KilnfileLock{}, fmt.Errorf("failed to open Kilnfile: %w", err)
 	}
-	defer func() {
-		_ = kilnfileFP.Close()
-	}()
+	defer closeAndIgnoreError(kilnfileFP)
 
 	kilnfile, err := cargo.InterpolateAndParseKilnfile(kilnfileFP, templateVariables)
 	if err != nil {
@@ -71,9 +70,7 @@ func (options *Standard) LoadKilnfiles(fsOverride billy.Basic, variablesServiceO
 	if err != nil {
 		return cargo.Kilnfile{}, cargo.KilnfileLock{}, fmt.Errorf("failed to open Kilnfile.lock: %w", err)
 	}
-	defer func() {
-		_ = lockFP.Close()
-	}()
+	defer closeAndIgnoreError(lockFP)
 	lockBuf, err := ioutil.ReadAll(lockFP)
 	if err != nil {
 		return cargo.Kilnfile{}, cargo.KilnfileLock{}, err
@@ -277,3 +274,5 @@ func IsSet(short, long string, args []string) bool {
 
 	return false
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/commands/init_test.go
+++ b/internal/commands/init_test.go
@@ -1,6 +1,7 @@
 package commands_test
 
 import (
+	"io"
 	"io/ioutil"
 	"testing"
 
@@ -36,9 +37,7 @@ func fsWriteYAML(fs billy.Basic, path string, data interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = f.Close()
-	}()
+	defer closeAndIgnoreError(f)
 
 	_, err = f.Write(buf)
 	return err
@@ -49,9 +48,7 @@ func fsReadYAML(fs billy.Basic, path string, data interface{}) error {
 	if err != nil {
 		return nil
 	}
-	defer func() {
-		_ = f.Close()
-	}()
+	defer closeAndIgnoreError(f)
 
 	buf, err := ioutil.ReadAll(f)
 	if err != nil {
@@ -65,3 +62,5 @@ func fsReadYAML(fs billy.Basic, path string, data interface{}) error {
 
 	return err
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/commands/publish.go
+++ b/internal/commands/publish.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/go-git/go-billy/v5"
-	pivnet "github.com/pivotal-cf/go-pivnet/v2"
+	"github.com/pivotal-cf/go-pivnet/v2"
 	"github.com/pivotal-cf/go-pivnet/v2/logshim"
 	"github.com/pivotal-cf/jhanda"
 	"gopkg.in/yaml.v2"
@@ -94,7 +94,7 @@ func (p Publish) Execute(args []string) error {
 
 	err = p.updateReleaseOnPivnet(kilnfile, buildVersion)
 	if err != nil {
-		return fmt.Errorf("Failed to publish tile: %s", err)
+		return fmt.Errorf("failed to publish tile: %s", err)
 	} else {
 		p.OutLogger.Println("Successfully published tile.")
 	}
@@ -375,7 +375,6 @@ func endOfSupportFor(publishDate time.Time) string {
 }
 
 func (p Publish) attachLicenseFile(slug string, releaseID int, version *releaseVersion) (string, error) {
-
 	if version.IsGA() {
 		productFiles, err := p.PivnetProductFilesService.List(slug)
 		if err != nil {

--- a/internal/commands/publish.go
+++ b/internal/commands/publish.go
@@ -157,7 +157,7 @@ func (p *Publish) parseArgsAndSetup(args []string) (cargo.Kilnfile, *semver.Vers
 	if err != nil {
 		return cargo.Kilnfile{}, nil, err
 	}
-	defer func() { _ = versionFile.Close() }()
+	defer closeAndIgnoreError(versionFile)
 
 	versionBuf, err := ioutil.ReadAll(versionFile)
 	if err != nil {
@@ -173,7 +173,7 @@ func (p *Publish) parseArgsAndSetup(args []string) (cargo.Kilnfile, *semver.Vers
 	if err != nil {
 		return cargo.Kilnfile{}, nil, err
 	}
-	defer func() { _ = file.Close() }()
+	defer closeAndIgnoreError(file)
 
 	var kilnfile cargo.Kilnfile
 	if err := yaml.NewDecoder(file).Decode(&kilnfile); err != nil {

--- a/internal/commands/publish_test.go
+++ b/internal/commands/publish_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
-	pivnet "github.com/pivotal-cf/go-pivnet/v2"
+	"github.com/pivotal-cf/go-pivnet/v2"
 
 	"github.com/pivotal-cf/kiln/internal/commands"
 	commandsFakes "github.com/pivotal-cf/kiln/internal/commands/fakes"
@@ -91,7 +91,7 @@ pre_ga_user_groups:
 
 				kf, _ := fs.Create("Kilnfile")
 				_, _ = kf.Write([]byte(defaultKilnFileBody))
-				defer func() { kf.Close() }()
+				defer func() { _ = kf.Close() }()
 
 				publish = commands.Publish{
 					FS:                               fs,
@@ -169,7 +169,6 @@ pre_ga_user_groups:
 					Expect(outLoggerBuffer.String()).To(ContainSubstring(userGroup2Name))
 
 					Expect(outLoggerBuffer.String()).To(ContainSubstring("Successfully published tile."))
-
 				})
 
 				Context("when previous alphas have been published", func() {
@@ -622,7 +621,6 @@ pre_ga_user_groups:
 					})
 				})
 			})
-
 		})
 
 		When("the sad/unhappy case", func() {
@@ -672,13 +670,13 @@ pre_ga_user_groups:
 				if !noVersionFile {
 					version, _ := fs.Create("version")
 					_, _ = version.Write([]byte(versionFileBody))
-					defer func() { version.Close() }()
+					defer func() { _ = version.Close() }()
 				}
 
 				if !noKilnFile {
 					kilnFile, _ := fs.Create("Kilnfile")
 					_, _ = kilnFile.Write([]byte(kilnFileBody))
-					defer func() { kilnFile.Close() }()
+					defer func() { _ = kilnFile.Close() }()
 				}
 
 				publish.FS = fs
@@ -855,7 +853,7 @@ pre_ga_user_groups:
 					Expect(rs.UpdateCallCount()).To(Equal(0))
 					Expect(pfs.ListCallCount()).To(Equal(1))
 					Expect(pfs.AddToReleaseCallCount()).To(Equal(1))
-					Expect(err).To(MatchError(ContainSubstring("Failed to publish tile: more bad stuff happened")))
+					Expect(err).To(MatchError(ContainSubstring("failed to publish tile: more bad stuff happened")))
 				})
 			})
 
@@ -971,7 +969,6 @@ pre_ga_user_groups:
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(MatchError(ContainSubstring(userGroup1Name)))
 				})
-
 			})
 
 			When("upgrade path is empty", func() {

--- a/internal/commands/publish_test.go
+++ b/internal/commands/publish_test.go
@@ -87,11 +87,11 @@ pre_ga_user_groups:
 				fs := memfs.New()
 				vf, _ := fs.Create("version")
 				_, _ = vf.Write([]byte(versionStr))
-				defer func() { _ = vf.Close() }()
+				defer closeAndIgnoreError(vf)
 
 				kf, _ := fs.Create("Kilnfile")
 				_, _ = kf.Write([]byte(defaultKilnFileBody))
-				defer func() { _ = kf.Close() }()
+				defer closeAndIgnoreError(kf)
 
 				publish = commands.Publish{
 					FS:                               fs,
@@ -670,13 +670,13 @@ pre_ga_user_groups:
 				if !noVersionFile {
 					version, _ := fs.Create("version")
 					_, _ = version.Write([]byte(versionFileBody))
-					defer func() { _ = version.Close() }()
+					defer closeAndIgnoreError(version)
 				}
 
 				if !noKilnFile {
 					kilnFile, _ := fs.Create("Kilnfile")
 					_, _ = kilnFile.Write([]byte(kilnFileBody))
-					defer func() { _ = kilnFile.Close() }()
+					defer closeAndIgnoreError(kilnFile)
 				}
 
 				publish.FS = fs

--- a/internal/commands/release_notes_test.go
+++ b/internal/commands/release_notes_test.go
@@ -137,7 +137,6 @@ func TestReleaseNotes_Execute(t *testing.T) {
 	})
 
 	t.Run("when updating a docs file", func(t *testing.T) {
-
 	})
 }
 

--- a/internal/commands/update_release.go
+++ b/internal/commands/update_release.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/kiln/pkg/cargo"
 	"log"
 
 	"github.com/go-git/go-billy/v5"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/pivotal-cf/kiln/internal/commands/flags"
 	"github.com/pivotal-cf/kiln/internal/component"
+	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
 
 type UpdateRelease struct {

--- a/internal/commands/update_stemcell.go
+++ b/internal/commands/update_stemcell.go
@@ -42,14 +42,14 @@ func (update UpdateStemcell) Execute(args []string) error {
 
 	latestStemcellVersion, err := semver.NewVersion(trimmedInputVersion)
 	if err != nil {
-		return fmt.Errorf("Please enter a valid stemcell version to update: %w", err)
+		return fmt.Errorf("invalid stemcell version (please enter a valid version): %w", err)
 	}
 
 	kilnStemcellVersion := kilnfile.Stemcell.Version
 	releaseVersionConstraint, err = semver.NewConstraint(kilnStemcellVersion)
 
 	if err != nil {
-		return fmt.Errorf("Invalid stemcell constraint in kilnfile: %w", err)
+		return fmt.Errorf("invalid stemcell constraint in kilnfile: %w", err)
 	}
 
 	if !releaseVersionConstraint.Check(latestStemcellVersion) {

--- a/internal/commands/update_stemcell_test.go
+++ b/internal/commands/update_stemcell_test.go
@@ -429,8 +429,6 @@ func createYAMLFile(fs billy.Filesystem, fp string, data interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = f.Close()
-	}()
+	defer closeAndIgnoreError(f)
 	return yaml.NewEncoder(f).Encode(data)
 }

--- a/internal/commands/update_stemcell_test.go
+++ b/internal/commands/update_stemcell_test.go
@@ -249,8 +249,7 @@ var _ = Describe("UpdateStemcell", func() {
 			It("no-ops", func() {
 				err := update.Execute([]string{"--kilnfile", kilnfilePath, "--version", "34$5235.32235"})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Please enter a valid stemcell version to update"))
-
+				Expect(err.Error()).To(ContainSubstring("invalid stemcell version"))
 			})
 		})
 
@@ -265,7 +264,7 @@ var _ = Describe("UpdateStemcell", func() {
 			It("no-ops", func() {
 				err := update.Execute([]string{"--kilnfile", kilnfilePath, "--version", "2.100"})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Invalid stemcell constraint in kilnfile:"))
+				Expect(err.Error()).To(ContainSubstring("invalid stemcell constraint in kilnfile:"))
 			})
 		})
 

--- a/internal/commands/upload_release_test.go
+++ b/internal/commands/upload_release_test.go
@@ -177,9 +177,7 @@ compiled_packages:
 			BeforeEach(func() {
 				f, err := fs.Create("invalid-release.tgz")
 				_, _ = f.Write([]byte("invalid"))
-				defer func() {
-					_ = f.Close()
-				}()
+				defer closeAndIgnoreError(f)
 
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/internal/commands/upload_release_test.go
+++ b/internal/commands/upload_release_test.go
@@ -126,7 +126,7 @@ compiled_packages:
 
 			When("the release version is not a finalized release", func() {
 				var err error
-				var devReleases = []struct {
+				devReleases := []struct {
 					tarballName string
 					version     string
 				}{
@@ -177,7 +177,9 @@ compiled_packages:
 			BeforeEach(func() {
 				f, err := fs.Create("invalid-release.tgz")
 				_, _ = f.Write([]byte("invalid"))
-				defer func() { f.Close() }()
+				defer func() {
+					_ = f.Close()
+				}()
 
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -18,7 +18,7 @@ func NewVersion(logger *log.Logger, version string) Version {
 	}
 }
 
-func (v Version) Execute(args []string) error {
+func (v Version) Execute([]string) error {
 	v.logger.Printf("kiln version %s\n", v.version)
 
 	return nil

--- a/internal/component/artifactory_release_source.go
+++ b/internal/component/artifactory_release_source.go
@@ -6,8 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/Masterminds/semver"
-	"github.com/pivotal-cf/kiln/pkg/cargo"
 	"io"
 	"io/ioutil"
 	"log"
@@ -18,6 +16,9 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/Masterminds/semver"
+	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
 
 type ArtifactoryReleaseSource struct {
@@ -54,7 +55,7 @@ func NewArtifactoryReleaseSource(c cargo.ReleaseSourceConfig) *ArtifactoryReleas
 		panic(panicMessageWrongReleaseSourceType)
 	}
 
-	//ctx := context.TODO()
+	// ctx := context.TODO()
 
 	return &ArtifactoryReleaseSource{
 		ReleaseSourceConfig: c,
@@ -141,7 +142,6 @@ func (ars ArtifactoryReleaseSource) Configuration() cargo.ReleaseSourceConfig {
 // fields on Requirement to download a specific release.
 func (ars ArtifactoryReleaseSource) GetMatchedRelease(spec Spec) (Lock, error) {
 	remotePath, err := ars.RemotePath(spec)
-
 	if err != nil {
 		return Lock{}, err
 	}
@@ -175,14 +175,12 @@ func (ars ArtifactoryReleaseSource) GetMatchedRelease(spec Spec) (Lock, error) {
 		RemotePath:   remotePath,
 		RemoteSource: ars.ID,
 	}, nil
-
 }
 
 // FindReleaseVersion may use any of the fields on Requirement to return the best matching
 // release.
 func (ars ArtifactoryReleaseSource) FindReleaseVersion(spec Spec) (Lock, error) {
 	remotePath, err := ars.RemotePath(spec)
-
 	if err != nil {
 		return Lock{}, err
 	}
@@ -304,8 +302,8 @@ func (ars ArtifactoryReleaseSource) UploadRelease(spec Spec, file io.Reader) (Lo
 		return Lock{}, err
 	}
 	request.SetBasicAuth(ars.Username, ars.Password)
-	//TODO: check Sha1/2
-	//request.Header.Set("X-Checksum-Sha1", spec.??? )
+	// TODO: check Sha1/2
+	// request.Header.Set("X-Checksum-Sha1", spec.??? )
 
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {

--- a/internal/component/bosh_io_release_source.go
+++ b/internal/component/bosh_io_release_source.go
@@ -151,7 +151,7 @@ func (src BOSHIOReleaseSource) DownloadRelease(releaseDir string, remoteRelease 
 	if err != nil {
 		return Local{}, err
 	}
-	defer func() { _ = out.Close() }()
+	defer closeAndIgnoreError(out)
 
 	_, err = io.Copy(out, resp.Body)
 	_ = resp.Body.Close()

--- a/internal/component/bosh_io_release_source.go
+++ b/internal/component/bosh_io_release_source.go
@@ -229,7 +229,6 @@ type releaseResponse struct {
 }
 
 func (src BOSHIOReleaseSource) releaseExistOnBoshio(name, version string) (bool, error) {
-
 	releaseResponses, err := src.getReleases(name)
 	if err != nil {
 		return false, err

--- a/internal/component/bosh_io_release_source_test.go
+++ b/internal/component/bosh_io_release_source_test.go
@@ -87,9 +87,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 					RemotePath:   cfRabbitURL,
 					RemoteSource: component.ReleaseSourceTypeBOSHIO,
 				}))
-
 			})
-
 		})
 
 		When("a bosh release doesn't exist on bosh.io in any version", func() {
@@ -135,7 +133,6 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 				testServer.RouteToHandler("GET", pathRegex, ghttp.RespondWith(http.StatusOK, `[{"version": "4.0.4"}]`))
 
 				releaseSource = component.NewBOSHIOReleaseSource(cargo.ReleaseSourceConfig{ID: ID, Publishable: false}, testServer.URL(), log.New(GinkgoWriter, "", 0))
-
 			})
 
 			AfterEach(func() {
@@ -325,7 +322,6 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 						RemotePath:   cfRabbitURL,
 						RemoteSource: component.ReleaseSourceTypeBOSHIO,
 					}))
-
 				})
 			})
 			When("there is a version requirement", func() {

--- a/internal/component/bosh_io_release_source_test.go
+++ b/internal/component/bosh_io_release_source_test.go
@@ -57,7 +57,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 			})
 
 			AfterEach(func() {
-				defer func() { testServer.Close() }()
+				testServer.Close()
 			})
 
 			It("finds built releases which exist on bosh.io", func() {
@@ -107,7 +107,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 			})
 
 			AfterEach(func() {
-				defer func() { testServer.Close() }()
+				testServer.Close()
 			})
 
 			It("doesn't find releases which don't exist on bosh.io", func() {
@@ -136,7 +136,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 			})
 
 			AfterEach(func() {
-				defer func() { testServer.Close() }()
+				testServer.Close()
 			})
 
 			It("does not match that release", func() {
@@ -167,7 +167,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 			})
 
 			AfterEach(func() {
-				defer func() { testServer.Close() }()
+				testServer.Close()
 			})
 
 			DescribeTable("searching multiple paths for each release",
@@ -259,7 +259,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 		})
 
 		AfterEach(func() {
-			defer func() { testServer.Close() }()
+			testServer.Close()
 			_ = os.RemoveAll(releaseDir)
 		})
 
@@ -306,7 +306,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 			})
 
 			AfterEach(func() {
-				defer func() { testServer.Close() }()
+				testServer.Close()
 			})
 			When("there is no version requirement", func() {
 				It("gets the latest version from bosh.io", func() {
@@ -353,7 +353,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 			})
 
 			AfterEach(func() {
-				defer func() { testServer.Close() }()
+				testServer.Close()
 			})
 
 			It("returns not found", func() {

--- a/internal/component/component.go
+++ b/internal/component/component.go
@@ -1,6 +1,10 @@
 package component
 
-import "github.com/pivotal-cf/kiln/pkg/cargo"
+import (
+	"io"
+
+	"github.com/pivotal-cf/kiln/pkg/cargo"
+)
 
 type Spec = cargo.ComponentSpec
 
@@ -16,3 +20,5 @@ type Local struct {
 }
 
 type Lock = cargo.ComponentLock
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/component/component_suite_test.go
+++ b/internal/component/component_suite_test.go
@@ -13,3 +13,5 @@ func TestFetcher(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Suite")
 }
+
+// func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/component/github_release_source.go
+++ b/internal/component/github_release_source.go
@@ -5,14 +5,15 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"github.com/Masterminds/semver"
-	"github.com/google/go-github/v40/github"
-	"golang.org/x/oauth2"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/Masterminds/semver"
+	"github.com/google/go-github/v40/github"
+	"golang.org/x/oauth2"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
@@ -27,7 +28,6 @@ type GithubReleaseSource struct {
 // NewGithubReleaseSource will provision a new GithubReleaseSource Project
 // from the Kilnfile (ReleaseSourceConfig). If type is incorrect it will PANIC
 func NewGithubReleaseSource(c cargo.ReleaseSourceConfig) *GithubReleaseSource {
-
 	if c.Type != "" && c.Type != ReleaseSourceTypeGithub {
 		panic(panicMessageWrongReleaseSourceType)
 	}
@@ -167,7 +167,7 @@ type githubNewRequestDoer interface {
 	Do(ctx context.Context, req *http.Request, v interface{}) (*github.Response, error)
 }
 
-func downloadRelease(ctx context.Context, releaseDir string, remoteRelease Lock, client githubNewRequestDoer, logger *log.Logger) (Local, error) {
+func downloadRelease(ctx context.Context, releaseDir string, remoteRelease Lock, client githubNewRequestDoer, _ *log.Logger) (Local, error) {
 	filePath := filepath.Join(releaseDir, fmt.Sprintf("%s-%s.tgz", remoteRelease.Name, remoteRelease.Version))
 
 	file, err := os.Create(filePath)

--- a/internal/component/github_release_source.go
+++ b/internal/component/github_release_source.go
@@ -174,7 +174,7 @@ func downloadRelease(ctx context.Context, releaseDir string, remoteRelease Lock,
 	if err != nil {
 		return Local{}, err
 	}
-	defer func() { _ = file.Close() }()
+	defer closeAndIgnoreError(file)
 
 	request, err := client.NewRequest(http.MethodGet, remoteRelease.RemotePath, nil)
 	if err != nil {
@@ -244,9 +244,7 @@ func LockFromGithubRelease(ctx context.Context, downloader ReleaseAssetDownloade
 }
 
 func calculateSHA1(rc io.ReadCloser) (string, error) {
-	defer func() {
-		_ = rc.Close()
-	}()
+	defer closeAndIgnoreError(rc)
 	w := sha1.New()
 	_, err := io.Copy(w, rc)
 	if err != nil {

--- a/internal/component/github_release_source_internal_test.go
+++ b/internal/component/github_release_source_internal_test.go
@@ -2,14 +2,16 @@ package component
 
 import (
 	"context"
-	"github.com/google/go-github/v40/github"
-	Ω "github.com/onsi/gomega"
-	fakes "github.com/pivotal-cf/kiln/internal/component/fakes_internal"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/google/go-github/v40/github"
+	Ω "github.com/onsi/gomega"
+
+	fakes "github.com/pivotal-cf/kiln/internal/component/fakes_internal"
 )
 
 func TestGithubReleaseSource_downloadRelease(t *testing.T) {

--- a/internal/component/github_release_source_test.go
+++ b/internal/component/github_release_source_test.go
@@ -11,10 +11,9 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
-
+	"github.com/google/go-github/v40/github"
 	Ω "github.com/onsi/gomega"
 
-	"github.com/google/go-github/v40/github"
 	"github.com/pivotal-cf/kiln/internal/component"
 	"github.com/pivotal-cf/kiln/internal/component/fakes"
 	"github.com/pivotal-cf/kiln/pkg/cargo"
@@ -28,9 +27,9 @@ func TestListAllOfTheCrap(t *testing.T) {
 		GithubToken: os.Getenv("GITHUB_TOKEN"),
 		Org:         "cloudfoundry",
 	})
-	//grs.ListAllOfTheCrap(context.TODO(), "cloudfoundry")
+	// grs.ListAllOfTheCrap(context.TODO(), "cloudfoundry")
 
-	//grs.Client.Repositories.GetReleaseByTag()
+	// grs.Client.Repositories.GetReleaseByTag()
 	release, response, err := grs.Client.Repositories.GetReleaseByTag(context.TODO(), "cloudfoundry", "routing-release", "0.226.0")
 	if err != nil {
 		t.Error(err)

--- a/internal/component/local_release_directory.go
+++ b/internal/component/local_release_directory.go
@@ -103,7 +103,7 @@ func CalculateSum(releasePath string, fs billy.Filesystem) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = f.Close() }()
+	defer closeAndIgnoreError(f)
 
 	h := sha1.New()
 	_, err = io.Copy(h, f)

--- a/internal/component/local_release_directory.go
+++ b/internal/component/local_release_directory.go
@@ -38,7 +38,7 @@ func (l LocalReleaseDirectory) GetLocalReleases(releasesDir string) ([]Local, er
 
 	for _, rel := range rawReleases {
 		rm := rel.Metadata.(builder.ReleaseManifest)
-		lock := Lock{Name: rm.Name, Version: rm.Version, StemcellOS: rm.StemcellOS, StemcellVersion: rm.StemcellVersion }
+		lock := Lock{Name: rm.Name, Version: rm.Version, StemcellOS: rm.StemcellOS, StemcellVersion: rm.StemcellVersion}
 
 		lock.SHA1, err = CalculateSum(rel.File, osfs.New(""))
 		if err != nil {
@@ -87,7 +87,6 @@ func (l LocalReleaseDirectory) DeleteExtraReleases(extraReleaseSet []Local, noCo
 func (l LocalReleaseDirectory) deleteReleases(releasesToDelete []Local) error {
 	for _, release := range releasesToDelete {
 		err := os.Remove(release.LocalPath)
-
 		if err != nil {
 			l.logger.Printf("error removing release %s: %v\n", release.Name, err)
 			return fmt.Errorf("failed to delete release %s", release.Name)

--- a/internal/component/local_release_directory_test.go
+++ b/internal/component/local_release_directory_test.go
@@ -54,7 +54,7 @@ var _ = Describe("LocalReleaseDirectory", func() {
 			BeforeEach(func() {
 				fixtureContent, err := ioutil.ReadFile(filepath.Join("fixtures", "some-release.tgz"))
 				Expect(err).NotTo(HaveOccurred())
-				err = ioutil.WriteFile(releaseFile, fixtureContent, 0755)
+				err = ioutil.WriteFile(releaseFile, fixtureContent, 0o755)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -98,11 +98,11 @@ var _ = Describe("LocalReleaseDirectory", func() {
 		var extraFilePath, zFilePath string
 		BeforeEach(func() {
 			extraFilePath = filepath.Join(releasesDir, "extra-release-0.0-os-0-0.0.0.tgz")
-			err := ioutil.WriteFile(extraFilePath, []byte("abc"), 0644)
+			err := ioutil.WriteFile(extraFilePath, []byte("abc"), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			zFilePath = filepath.Join(releasesDir, "z-release-0.0-os-0-0.0.0.tgz")
-			err = ioutil.WriteFile(zFilePath, []byte("xyz"), 0644)
+			err = ioutil.WriteFile(zFilePath, []byte("xyz"), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -129,7 +129,6 @@ var _ = Describe("LocalReleaseDirectory", func() {
 			err := localReleaseDirectory.DeleteExtraReleases([]component.Local{zRelease, extraRelease}, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(logBuf.Contents())).To(ContainSubstring(result))
-
 		})
 
 		Context("when a file cannot be removed", func() {

--- a/internal/component/pivnet.go
+++ b/internal/component/pivnet.go
@@ -19,13 +19,12 @@ const (
 
 // Pivnet handles kiln specific request to network.pivotal.io
 type Pivnet struct {
-
 	// UAAAPIToken should be set with the token for the "UAA API Token Workflow"
 	// See: https://network.pivotal.io/docs/api#authentication
 	UAAAPIToken string
 
 	// Client allows you to inject an alternate client
-	// (for testing per say). When not set, http.DefaultClient is used.
+	// (for testing per se). When not set, http.DefaultClient is used.
 	Client *http.Client
 }
 
@@ -54,7 +53,6 @@ func (pivnet *Pivnet) StemcellVersion(slug string, majorStemcellVersion string) 
 	}
 
 	getURL, err := url.PathUnescape(locator.String())
-
 	if err != nil {
 		return "", ErrDecodingURLRequest
 	}
@@ -65,7 +63,6 @@ func (pivnet *Pivnet) StemcellVersion(slug string, majorStemcellVersion string) 
 	}
 
 	response, err := pivnet.Do(req)
-
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +91,7 @@ func (pivnet *Pivnet) StemcellVersion(slug string, majorStemcellVersion string) 
 	return version, nil
 }
 
-// Do sets required headers for requests to network.pivotal.io.
+// Do sets the required headers for requests to network.pivotal.io.
 // If pivnet.Client is nil, it uses http.DefaultClient.
 func (pivnet Pivnet) Do(req *http.Request) (*http.Response, error) {
 	if pivnet.Client == nil {

--- a/internal/component/release_source.go
+++ b/internal/component/release_source.go
@@ -2,9 +2,10 @@ package component
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/kiln/pkg/cargo"
 	"io"
 	"log"
+
+	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
 
 // MultiReleaseSource wraps a set of release sources. It is mostly used to generate fakes
@@ -78,7 +79,7 @@ const (
 	ReleaseSourceTypeS3 = "s3"
 
 	// ReleaseSourceTypeGithub is the value for the Type field on cargo.ReleaseSourceConfig
-	// for releases stored on Github.
+	// for releases stored on GitHub.
 	ReleaseSourceTypeGithub = "github"
 
 	// ReleaseSourceTypeArtifactory is the value for the Type field on cargo.ReleaseSourceConfig

--- a/internal/component/release_source_list.go
+++ b/internal/component/release_source_list.go
@@ -3,8 +3,9 @@ package component
 import (
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver"
 	"log"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 )

--- a/internal/component/release_source_list_test.go
+++ b/internal/component/release_source_list_test.go
@@ -43,9 +43,7 @@ var _ = Describe("multiReleaseSource", func() {
 
 	Describe("GetMatchedRelease", func() {
 		When("one of the release sources has a match", func() {
-			var (
-				matchedRelease component.Lock
-			)
+			var matchedRelease component.Lock
 
 			BeforeEach(func() {
 				matchedRelease = component.Lock{
@@ -190,9 +188,7 @@ var _ = Describe("multiReleaseSource", func() {
 
 	Describe("FindReleaseVersion", func() {
 		When("one of the release sources has a match", func() {
-			var (
-				matchedRelease component.Lock
-			)
+			var matchedRelease component.Lock
 
 			BeforeEach(func() {
 				matchedRelease = component.Lock{
@@ -213,9 +209,7 @@ var _ = Describe("multiReleaseSource", func() {
 			})
 		})
 		When("two of the release sources have a match", func() {
-			var (
-				matchedRelease component.Lock
-			)
+			var matchedRelease component.Lock
 
 			BeforeEach(func() {
 				unmatchedRelease := component.Lock{
@@ -242,9 +236,7 @@ var _ = Describe("multiReleaseSource", func() {
 			})
 		})
 		When("two of the release sources match the same version", func() {
-			var (
-				matchedRelease component.Lock
-			)
+			var matchedRelease component.Lock
 
 			BeforeEach(func() {
 				matchedRelease = component.Lock{

--- a/internal/component/release_source_test.go
+++ b/internal/component/release_source_test.go
@@ -77,9 +77,7 @@ var _ = Describe("ReleaseSourceList", func() {
 				releaseSources := component.NewReleaseSourceRepo(kilnfile, logger)
 
 				Expect(releaseSources).To(HaveLen(1))
-				var (
-					boshIOReleaseSource *component.BOSHIOReleaseSource
-				)
+				var boshIOReleaseSource *component.BOSHIOReleaseSource
 
 				Expect(releaseSources[0]).To(BeAssignableToTypeOf(boshIOReleaseSource))
 				Expect(releaseSources[0].(*component.BOSHIOReleaseSource).Publishable()).To(BeTrue())
@@ -145,13 +143,19 @@ var _ = Describe("ReleaseSourceList", func() {
 			BeforeEach(func() {
 				kilnfile = cargo.Kilnfile{
 					ReleaseSources: []cargo.ReleaseSourceConfig{
-						{Type: "s3", Bucket: "bucket-1", Region: "us-west-1", AccessKeyId: "ak1", SecretAccessKey: "shhhh!",
-							PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz`},
-						{Type: "s3", Bucket: "bucket-2", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
-							PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}.tgz`},
+						{
+							Type: "s3", Bucket: "bucket-1", Region: "us-west-1", AccessKeyId: "ak1", SecretAccessKey: "shhhh!",
+							PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz`,
+						},
+						{
+							Type: "s3", Bucket: "bucket-2", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
+							PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}.tgz`,
+						},
 						{Type: "bosh.io"},
-						{Type: "s3", Bucket: "bucket-3", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
-							PathTemplate: `{{.Name}}-{{.Version}}.tgz`},
+						{
+							Type: "s3", Bucket: "bucket-3", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
+							PathTemplate: `{{.Name}}-{{.Version}}.tgz`,
+						},
 					},
 				}
 			})
@@ -182,13 +186,19 @@ var _ = Describe("ReleaseSourceList", func() {
 			BeforeEach(func() {
 				kilnfile = cargo.Kilnfile{
 					ReleaseSources: []cargo.ReleaseSourceConfig{
-						{Publishable: true, Type: "s3", Bucket: "bucket-1", Region: "us-west-1", AccessKeyId: "ak1", SecretAccessKey: "shhhh!",
-							PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz`},
-						{Type: "s3", Bucket: "bucket-2", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
-							PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}.tgz`},
+						{
+							Publishable: true, Type: "s3", Bucket: "bucket-1", Region: "us-west-1", AccessKeyId: "ak1", SecretAccessKey: "shhhh!",
+							PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz`,
+						},
+						{
+							Type: "s3", Bucket: "bucket-2", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
+							PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}.tgz`,
+						},
 						{Type: "bosh.io"},
-						{Type: "s3", Bucket: "bucket-3", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
-							PathTemplate: `{{.Name}}-{{.Version}}.tgz`},
+						{
+							Type: "s3", Bucket: "bucket-3", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
+							PathTemplate: `{{.Name}}-{{.Version}}.tgz`,
+						},
 					},
 				}
 			})
@@ -218,13 +228,19 @@ var _ = Describe("ReleaseSourceList", func() {
 		BeforeEach(func() {
 			kilnfile = cargo.Kilnfile{
 				ReleaseSources: []cargo.ReleaseSourceConfig{
-					{Type: "s3", Bucket: "bucket-1", Region: "us-west-1", AccessKeyId: "ak1", SecretAccessKey: "shhhh!",
-						PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz`},
-					{Type: "s3", Bucket: "bucket-2", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
-						PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}.tgz`},
+					{
+						Type: "s3", Bucket: "bucket-1", Region: "us-west-1", AccessKeyId: "ak1", SecretAccessKey: "shhhh!",
+						PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz`,
+					},
+					{
+						Type: "s3", Bucket: "bucket-2", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
+						PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}.tgz`,
+					},
 					{Type: "bosh.io"},
-					{Type: "s3", Bucket: "bucket-3", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
-						PathTemplate: `{{.Name}}-{{.Version}}.tgz`},
+					{
+						Type: "s3", Bucket: "bucket-3", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
+						PathTemplate: `{{.Name}}-{{.Version}}.tgz`,
+					},
 				},
 			}
 		})
@@ -286,13 +302,19 @@ var _ = Describe("ReleaseSourceList", func() {
 		BeforeEach(func() {
 			kilnfile = cargo.Kilnfile{
 				ReleaseSources: []cargo.ReleaseSourceConfig{
-					{Type: "s3", Bucket: "bucket-1", Region: "us-west-1", AccessKeyId: "ak1", SecretAccessKey: "shhhh!",
-						PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz`},
-					{Type: "s3", Bucket: "bucket-2", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
-						PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}.tgz`},
+					{
+						Type: "s3", Bucket: "bucket-1", Region: "us-west-1", AccessKeyId: "ak1", SecretAccessKey: "shhhh!",
+						PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz`,
+					},
+					{
+						Type: "s3", Bucket: "bucket-2", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
+						PathTemplate: `2.8/{{trimSuffix .Name "-release"}}/{{.Name}}-{{.Version}}.tgz`,
+					},
 					{Type: "bosh.io"},
-					{Type: "s3", Bucket: "bucket-3", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
-						PathTemplate: `{{.Name}}-{{.Version}}.tgz`},
+					{
+						Type: "s3", Bucket: "bucket-3", Region: "us-west-2", AccessKeyId: "aki", SecretAccessKey: "shhhh!",
+						PathTemplate: `{{.Name}}-{{.Version}}.tgz`,
+					},
 				},
 			}
 		})

--- a/internal/component/s3_release_source.go
+++ b/internal/component/s3_release_source.go
@@ -224,7 +224,7 @@ func (src S3ReleaseSource) DownloadRelease(releaseDir string, lock Lock) (Local,
 	if err != nil {
 		return Local{}, fmt.Errorf("failed to create file %q: %w", outputFile, err)
 	}
-	defer func() { _ = file.Close() }()
+	defer closeAndIgnoreError(file)
 
 	_, err = src.s3Downloader.Download(file, &s3.GetObjectInput{
 		Bucket: aws.String(src.ReleaseSourceConfig.Bucket),

--- a/internal/component/s3_release_source_test.go
+++ b/internal/component/s3_release_source_test.go
@@ -295,7 +295,6 @@ var _ = Describe("S3ReleaseSource", func() {
 		)
 		When("version is semantic and release has version constraint", func() {
 			BeforeEach(func() {
-
 				releaseID = component.Spec{Name: "uaa", Version: "1.1.1"}
 				desiredRelease = component.Spec{
 					Name:            "uaa",

--- a/internal/helper/filesystem.go
+++ b/internal/helper/filesystem.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 )
 
-var OpenFile = os.OpenFile
-
 type Filesystem struct{}
 
 func NewFilesystem() Filesystem {

--- a/internal/helper/filesystem_test.go
+++ b/internal/helper/filesystem_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Filesystem", func() {
 			err = tempfile.Close()
 			Expect(err).NotTo(HaveOccurred())
 
-			files := []string{}
+			var files []string
 			_ = filesystem.Walk(tempDir, func(filePath string, info os.FileInfo, err error) error {
 				files = append(files, filePath)
 				return nil

--- a/internal/helper/filesystem_test.go
+++ b/internal/helper/filesystem_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Filesystem", func() {
 
 			file, err := filesystem.Create(fileToCreate)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() { _ = file.Close() }()
+			defer closeAndIgnoreError(file)
 
 			fi, err := os.Stat(fileToCreate)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/helper/init_test.go
+++ b/internal/helper/init_test.go
@@ -1,6 +1,7 @@
 package helper_test
 
 import (
+	"io"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -11,3 +12,5 @@ func TestHelper(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "helper")
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/helper/init_test.go
+++ b/internal/helper/init_test.go
@@ -1,42 +1,13 @@
 package helper_test
 
 import (
-	"bytes"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestHelper(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "helper")
-}
-
-func NewBuffer(b *bytes.Buffer) *Buffer {
-	return &Buffer{
-		buffer: b,
-	}
-}
-
-type Buffer struct {
-	buffer *bytes.Buffer
-	Error  error
-}
-
-func (b *Buffer) Read(p []byte) (int, error) {
-	if b.Error != nil {
-		return 0, b.Error
-	}
-
-	return b.buffer.Read(p)
-}
-
-func (b *Buffer) Write(p []byte) (int, error) {
-	return b.buffer.Write(p)
-}
-
-func (b Buffer) Close() error {
-	return nil
 }

--- a/internal/om/client.go
+++ b/internal/om/client.go
@@ -181,7 +181,7 @@ func BoshDirector(omConfig ClientConfiguration, omAPI GetBoshEnvironmentAndSecur
 }
 
 // insecureGetHostKey just returns the key returned by the host and does not
-// attempt to ensure the key is from who it says it is from. This is what the
+// attempt to ensure the key is from whom it says it is from. This is what the
 // bosh CLI does, so it seems to be secure enough.
 func insecureGetHostKey(signer ssh.Signer, serverURL string) (ssh.PublicKey, error) {
 	publicKeyChannel := make(chan ssh.PublicKey, 1)

--- a/internal/om/client.go
+++ b/internal/om/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -207,9 +208,7 @@ func insecureGetHostKey(signer ssh.Signer, serverURL string) (ssh.PublicKey, err
 			dialErrorChannel <- err
 			return
 		}
-		defer func() {
-			_ = conn.Close()
-		}()
+		defer closeAndIgnoreError(conn)
 		dialErrorChannel <- nil
 	}()
 
@@ -227,3 +226,5 @@ func getAuthURLFromInfo(info boshdir.InfoResp) (string, error) {
 	}
 	return s, nil
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/pivnet/service.go
+++ b/internal/pivnet/service.go
@@ -19,7 +19,7 @@ type Service struct {
 	UAAAPIToken string
 
 	// Client allows you to inject an alternate client
-	// (for testing per say). When not set, http.DefaultClient is used.
+	// (for testing per se). When not set, http.DefaultClient is used.
 	Client *http.Client
 }
 
@@ -75,7 +75,9 @@ func (service Service) Releases(productSlug string) ([]Release, error) {
 		return nil, err
 	}
 
-	defer res.Body.Close()
+	defer func() {
+		_ = res.Body.Close()
+	}()
 
 	responseBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/internal/release/notes_data.go
+++ b/internal/release/notes_data.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -196,9 +197,7 @@ func (r fetchNotesData) kilnfileFromWorktree(kilnfilePath string) (cargo.Kilnfil
 	if err != nil {
 		return cargo.Kilnfile{}, nil
 	}
-	defer func() {
-		_ = worktreeKilnfile.Close()
-	}()
+	defer closeAndIgnoreError(worktreeKilnfile)
 
 	buf, err := ioutil.ReadAll(worktreeKilnfile)
 	if err != nil {
@@ -479,3 +478,5 @@ func setEmptyComponentGitHubRepositoryFromOtherKilnfile(k1, k2 cargo.Kilnfile) c
 	}
 	return k1
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/internal/release/notes_data_test.go
+++ b/internal/release/notes_data_test.go
@@ -28,9 +28,7 @@ func Test_fetch(t *testing.T) {
 	repo, _ := git.Init(memory.NewStorage(), memfs.New())
 
 	revisionResolver := new(fakes.RevisionResolver)
-	var (
-		initialHash, finalHash plumbing.Hash
-	)
+	var initialHash, finalHash plumbing.Hash
 	fill(initialHash[:], '1')
 	fill(finalHash[:], '9')
 	revisionResolver.ResolveRevisionReturnsOnCall(0, &initialHash, nil)

--- a/internal/release/notes_page.go
+++ b/internal/release/notes_page.go
@@ -12,7 +12,7 @@ import (
 
 const DefaultReleasesSentinel = "\n## <a id='releases'></a> Releases\n\n"
 
-var releaseNoteExp = regexp.MustCompile(`(?m)(?P<notes>### <a id='(?P<version>\d+\.\d+\.\d+(-.+)?)'></a> (\d+\.\d+\.\d+(-.+)?)\w*(?P<header_suffix>.*)\n*((\*.*\n)|\n|(\</?.*)|(  .*)|(####+.*)|(\t.*)|(\w.*))*)`)
+var releaseNoteExp = regexp.MustCompile(`(?m)(?P<notes>### <a id='(?P<version>\d+\.\d+\.\d+(-.+)?)'></a> (\d+\.\d+\.\d+(-.+)?)\w*(?P<header_suffix>.*)\n*((\*.*\n)|\n|(</?.*)|( +.*)|(####+.*)|(\t.*)|(\w.*))*)`)
 
 type NotesPage struct {
 	Exp *regexp.Regexp

--- a/internal/release/notes_page_test.go
+++ b/internal/release/notes_page_test.go
@@ -161,7 +161,7 @@ func TestParseNotesPage(t *testing.T) {
 
 func TestParseNotesPageWithExpressionAndReleasesSentinel(t *testing.T) {
 	const testReleasesSentinel = "releases:"
-	var exp = regexp.MustCompile(`(?m)(?P<notes>r(?P<version>\d+)\.*)`).String()
+	exp := regexp.MustCompile(`(?m)(?P<notes>r(?P<version>\d+)\.*)`).String()
 
 	t.Run("multiple releases", func(t *testing.T) {
 		please := Ω.NewWithT(t)

--- a/internal/test-helpers/tgz_helpers.go
+++ b/internal/test-helpers/tgz_helpers.go
@@ -67,7 +67,7 @@ func WriteTarballWithFile(tarballPath, internalFilePath, fileContents string, fs
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = tarball.Close() }()
+	defer closeAndIgnoreError(tarball)
 
 	hash := sha1.New()
 	_, err = io.Copy(hash, tarball)
@@ -77,3 +77,5 @@ func WriteTarballWithFile(tarballPath, internalFilePath, fileContents string, fs
 
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/pkg/cargo/generator_test.go
+++ b/pkg/cargo/generator_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Generator", func() {
 	Describe("Execute", func() {
 		It("generates a well-formed manifest", func() {
 			f, err := os.Open("fixtures/metadata.yml")
-			defer func() { _ = f.Close() }()
+			defer closeAndIgnoreError(f)
 			Expect(err).NotTo(HaveOccurred())
 
 			template, err := proofing.Parse(f)

--- a/pkg/cargo/init_test.go
+++ b/pkg/cargo/init_test.go
@@ -1,6 +1,7 @@
 package cargo_test
 
 import (
+	"io"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -11,3 +12,5 @@ func TestCargo(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "internal/cargo")
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/pkg/cargo/kilnfile_test.go
+++ b/pkg/cargo/kilnfile_test.go
@@ -1,9 +1,9 @@
 package cargo
 
 import (
-	Ω "github.com/onsi/gomega"
 	"testing"
 
+	Ω "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 )
 

--- a/pkg/cargo/load_kilnfiles.go
+++ b/pkg/cargo/load_kilnfiles.go
@@ -24,8 +24,7 @@ func (err ConfigFileError) Error() string {
 	return fmt.Sprintf("encountered a configuration file error with %s: %s", err.HumanReadableConfigFileName, err.err.Error())
 }
 
-type KilnfileLoader struct {
-}
+type KilnfileLoader struct{}
 
 func (k KilnfileLoader) LoadKilnfiles(fs billy.Filesystem, kilnfilePath string, variablesFiles, variables []string) (Kilnfile, KilnfileLock, error) {
 	templateVariablesService := baking.NewTemplateVariablesService(fs)

--- a/pkg/cargo/load_kilnfiles.go
+++ b/pkg/cargo/load_kilnfiles.go
@@ -2,6 +2,7 @@ package cargo
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 
 	"github.com/go-git/go-billy/v5"
@@ -37,7 +38,7 @@ func (k KilnfileLoader) LoadKilnfiles(fs billy.Filesystem, kilnfilePath string, 
 	if err != nil {
 		return Kilnfile{}, KilnfileLock{}, fmt.Errorf("unable to open file %q: %w", kilnfilePath, err)
 	}
-	defer func() { _ = kf.Close() }()
+	defer closeAndIgnoreError(kf)
 	kilnfileYAML, err := ioutil.ReadAll(kf)
 	if err != nil {
 		return Kilnfile{}, KilnfileLock{}, fmt.Errorf("unable to read file %q: %w", kilnfilePath, err)
@@ -62,7 +63,7 @@ func (k KilnfileLoader) LoadKilnfiles(fs billy.Filesystem, kilnfilePath string, 
 	if err != nil {
 		return Kilnfile{}, KilnfileLock{}, err
 	}
-	defer func() { _ = lockFile.Close() }()
+	defer closeAndIgnoreError(lockFile)
 
 	var kilnfileLock KilnfileLock
 	err = yaml.NewDecoder(lockFile).Decode(&kilnfileLock)
@@ -95,3 +96,5 @@ func (KilnfileLoader) SaveKilnfileLock(fs billy.Filesystem, kilnfilePath string,
 func kilnfileLockPath(kilnfilePath string) string {
 	return fmt.Sprintf("%s.lock", kilnfilePath)
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/pkg/cargo/load_kilnfiles_test.go
+++ b/pkg/cargo/load_kilnfiles_test.go
@@ -18,7 +18,7 @@ func writeFile(fs billy.Filesystem, path string, contents string) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = file.Close() }()
+	defer closeAndIgnoreError(file)
 
 	_, err = file.Write([]byte(contents))
 	return err

--- a/pkg/historic/decode.go
+++ b/pkg/historic/decode.go
@@ -2,6 +2,7 @@ package historic
 
 import (
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"path/filepath"
 
@@ -71,9 +72,7 @@ func readBytesFromTree(storage storer.EncodedObjectStorer, tree *object.Tree, fi
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = f.Close()
-	}()
+	defer closeAndIgnoreError(f)
 	buf, err := ioutil.ReadAll(f)
 	if err != nil {
 		return nil, err
@@ -131,3 +130,5 @@ func readBytesFromTree(storage storer.EncodedObjectStorer, tree *object.Tree, fi
 //
 //	return "", matches[len(matches)-1], true
 //}
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/pkg/historic/decode.go
+++ b/pkg/historic/decode.go
@@ -113,7 +113,7 @@ func readBytesFromTree(storage storer.EncodedObjectStorer, tree *object.Tree, fi
 //	return result
 //}
 
-//var releasedVersionTag = regexp.MustCompile(`^((\w+/)*)(\d+\.\d+\.\d+)$`)
+// var releasedVersionTag = regexp.MustCompile(`^((\w+/)*)(\d+\.\d+\.\d+)$`)
 
 //func isReleaseTag(reference *plumbing.Reference) (string, string, bool) {
 //	if !reference.Name().IsTag() {

--- a/pkg/historic/historic.go
+++ b/pkg/historic/historic.go
@@ -11,10 +11,7 @@ import (
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
 
-var (
-	billOfMaterialFileNames = []string{"Kilnfile.lock", "assets.lock"}
-	// tileRootSentinelFiles   = []string{"Kilnfile", "base.yml"}
-)
+var billOfMaterialFileNames = []string{"Kilnfile.lock", "assets.lock"} // tileRootSentinelFiles   = []string{"Kilnfile", "base.yml"}
 
 func Kilnfile(storage storer.EncodedObjectStorer, commitHash plumbing.Hash, kilnfilePath string) (cargo.Kilnfile, cargo.KilnfileLock, error) {
 	tilePath := kilnfilePath

--- a/pkg/proofing/collection_property_blueprint_test.go
+++ b/pkg/proofing/collection_property_blueprint_test.go
@@ -14,7 +14,7 @@ var _ = Describe("CollectionPropertyBlueprint", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/property_blueprints.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/collection_property_blueprint_test.go
+++ b/pkg/proofing/collection_property_blueprint_test.go
@@ -61,5 +61,4 @@ var _ = Describe("CollectionPropertyBlueprint", func() {
 			})
 		})
 	})
-
 })

--- a/pkg/proofing/collection_property_input_test.go
+++ b/pkg/proofing/collection_property_input_test.go
@@ -14,7 +14,7 @@ var _ = Describe("CollectionPropertyInput", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/form_types.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/errand_template_test.go
+++ b/pkg/proofing/errand_template_test.go
@@ -14,7 +14,7 @@ var _ = Describe("ErrandTemplate", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/errands.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/form_type_test.go
+++ b/pkg/proofing/form_type_test.go
@@ -14,7 +14,7 @@ var _ = Describe("FormType", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/form_types.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/init_test.go
+++ b/pkg/proofing/init_test.go
@@ -1,6 +1,7 @@
 package proofing_test
 
 import (
+	"io"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -11,3 +12,5 @@ func TestProofing(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "proofing")
 }
+
+func closeAndIgnoreError(c io.Closer) { _ = c.Close() }

--- a/pkg/proofing/install_time_verifier_test.go
+++ b/pkg/proofing/install_time_verifier_test.go
@@ -14,7 +14,7 @@ var _ = Describe("InstallTimeVerifier", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/instance_definition_test.go
+++ b/pkg/proofing/instance_definition_test.go
@@ -14,7 +14,7 @@ var _ = Describe("InstanceDefinition", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/job_type_test.go
+++ b/pkg/proofing/job_type_test.go
@@ -14,7 +14,7 @@ var _ = Describe("JobType", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/job_types.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/parse_test.go
+++ b/pkg/proofing/parse_test.go
@@ -42,9 +42,8 @@ var _ = Describe("Parse", func() {
 	})
 })
 
-type erroringReader struct {
-}
+type erroringReader struct{}
 
-func (r erroringReader) Read(p []byte) (n int, err error) {
+func (r erroringReader) Read(_ []byte) (n int, err error) {
 	return 0, errors.New("failed to read")
 }

--- a/pkg/proofing/parse_test.go
+++ b/pkg/proofing/parse_test.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("Parse", func() {
 	It("can parse a metadata file", func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)
@@ -32,7 +32,7 @@ var _ = Describe("Parse", func() {
 		Context("when the metadata contents cannot be unmarshalled", func() {
 			It("returns an error", func() {
 				f, err := os.Open("fixtures/malformed.yml")
-				defer func() { _ = f.Close() }()
+				defer closeAndIgnoreError(f)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = proofing.Parse(f)

--- a/pkg/proofing/product_template_test.go
+++ b/pkg/proofing/product_template_test.go
@@ -14,7 +14,7 @@ var _ = Describe("ProductTemplate", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err = proofing.Parse(f)
@@ -53,7 +53,7 @@ var _ = Describe("ProductTemplate", func() {
 	Describe("AllPropertyBlueprints", func() {
 		BeforeEach(func() {
 			f, err := os.Open("fixtures/property_blueprints.yml")
-			defer func() { _ = f.Close() }()
+			defer closeAndIgnoreError(f)
 			Expect(err).NotTo(HaveOccurred())
 
 			productTemplate, err = proofing.Parse(f)

--- a/pkg/proofing/property_blueprints_test.go
+++ b/pkg/proofing/property_blueprints_test.go
@@ -15,7 +15,7 @@ var _ = Describe("PropertyBlueprints", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/property_blueprints.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err = proofing.Parse(f)

--- a/pkg/proofing/property_inputs.go
+++ b/pkg/proofing/property_inputs.go
@@ -15,7 +15,7 @@ func (pi *PropertyInputs) UnmarshalYAML(unmarshal func(v interface{}) error) err
 		return err
 	}
 
-	var contains = func(m map[string]interface{}, key string) bool {
+	contains := func(m map[string]interface{}, key string) bool {
 		_, ok := m[key]
 		return ok
 	}

--- a/pkg/proofing/property_inputs_test.go
+++ b/pkg/proofing/property_inputs_test.go
@@ -15,7 +15,7 @@ var _ = Describe("PropertyInputs", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/form_types.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/release_test.go
+++ b/pkg/proofing/release_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Release", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/resource_definitions.go
+++ b/pkg/proofing/resource_definitions.go
@@ -1,4 +1,5 @@
 package proofing
 
+// ResourceDefinitions
 // TODO: https://github.com/pivotal-cf/installation/blob/b7be08d7b50d305c08d520ee0afe81ae3a98bd9d/web/app/models/persistence/metadata/resource_definition_collection.rb
 type ResourceDefinitions []ResourceDefinition

--- a/pkg/proofing/resource_definitions.go
+++ b/pkg/proofing/resource_definitions.go
@@ -1,5 +1,5 @@
 package proofing
 
-// ResourceDefinitions
+// ResourceDefinitions are defined in the following (private) Ops Manager code
 // TODO: https://github.com/pivotal-cf/installation/blob/b7be08d7b50d305c08d520ee0afe81ae3a98bd9d/web/app/models/persistence/metadata/resource_definition_collection.rb
 type ResourceDefinitions []ResourceDefinition

--- a/pkg/proofing/resource_definitions_test.go
+++ b/pkg/proofing/resource_definitions_test.go
@@ -14,7 +14,7 @@ var _ = Describe("ResourceDefinitions", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/runtime_config_template_test.go
+++ b/pkg/proofing/runtime_config_template_test.go
@@ -14,7 +14,7 @@ var _ = Describe("RuntimeConfigTemplate", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/selector_property_blueprint_test.go
+++ b/pkg/proofing/selector_property_blueprint_test.go
@@ -14,7 +14,7 @@ var _ = Describe("SelectorPropertyBlueprint", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/property_blueprints.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/selector_property_input_test.go
+++ b/pkg/proofing/selector_property_input_test.go
@@ -14,7 +14,7 @@ var _ = Describe("SelectorPropertyInput", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/form_types.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/simple_property_blueprint_test.go
+++ b/pkg/proofing/simple_property_blueprint_test.go
@@ -14,7 +14,7 @@ var _ = Describe("SimplePropertyBlueprint", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/property_blueprints.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/simple_property_input_test.go
+++ b/pkg/proofing/simple_property_input_test.go
@@ -14,7 +14,7 @@ var _ = Describe("SimplePropertyInput", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/form_types.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/stemcell_criteria_test.go
+++ b/pkg/proofing/stemcell_criteria_test.go
@@ -14,7 +14,7 @@ var _ = Describe("StemcellCriteria", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/template_test.go
+++ b/pkg/proofing/template_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Template", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/variable_test.go
+++ b/pkg/proofing/variable_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Variable", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/verifier_blueprint_test.go
+++ b/pkg/proofing/verifier_blueprint_test.go
@@ -14,7 +14,7 @@ var _ = Describe("VerifierBlueprint", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)

--- a/pkg/proofing/zero_if_binding_test.go
+++ b/pkg/proofing/zero_if_binding_test.go
@@ -14,7 +14,7 @@ var _ = Describe("ZeroIf", func() {
 
 	BeforeEach(func() {
 		f, err := os.Open("fixtures/metadata.yml")
-		defer func() { _ = f.Close() }()
+		defer closeAndIgnoreError(f)
 		Expect(err).NotTo(HaveOccurred())
 
 		productTemplate, err := proofing.Parse(f)


### PR DESCRIPTION
I ran the Goland code analysis tool and fixed all the "Go" warnings.