### PR TITLE
refactor: use . import instead of Ω (non-ascii) character

### DIFF
--- a/internal/acceptance/workflows/scenario/step_funcs_exec_test.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_exec_test.go
@@ -5,40 +5,40 @@ import (
 	"os/exec"
 	"testing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func Test_outputContainsSubstring(t *testing.T) {
 	t.Run("stdout contains the string", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		ctx := context.Background()
 		ctx = configureStandardFileDescriptors(ctx)
 		_, err := runAndLogOnError(ctx, exec.Command("echo", "Hello, world!"), true)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 
 		err = outputContainsSubstring(ctx, "stdout", "world")
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 	})
 
 	t.Run("stderr contains the string", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		ctx := context.Background()
 		ctx = configureStandardFileDescriptors(ctx)
 		_, err := runAndLogOnError(ctx, exec.Command("bash", "-c", `echo "Hello, world!" > /dev/stderr`), true)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 
 		err = outputContainsSubstring(ctx, "stderr", "world")
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 	})
 
 	t.Run("stdout does not contain the substring", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		ctx := context.Background()
 		ctx = configureStandardFileDescriptors(ctx)
 		_, err := runAndLogOnError(ctx, exec.Command("echo", "Hello, world!"), true)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 
 		err = outputContainsSubstring(ctx, "stdout", "banana")
-		please.Expect(err).To(Ω.MatchError(Ω.Equal("expected substring \"banana\" not found in: \"Hello, world!\"")))
+		please.Expect(err).To(MatchError(Equal("expected substring \"banana\" not found in: \"Hello, world!\"")))
 	})
 }

--- a/internal/acceptance/workflows/scenario/step_funcs_github_test.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_github_test.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"testing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func Test_githubRepoHasReleaseWithTag(t *testing.T) {
 	if isRunningInCI() {
 		t.Skip("skip this step in CI. GitHub action credentials do not have access to crhntr/hello-release")
 	}
-	setup := func(t *testing.T) (context.Context, Ω.Gomega) {
-		please := Ω.NewWithT(t)
+	setup := func(t *testing.T) (context.Context, Gomega) {
+		please := NewWithT(t)
 		ctx := context.Background()
 		err := checkoutMain(testTilePath)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 		ctx = setTileRepoPath(ctx, testTilePath)
 		ctx, err = loadGithubToken(ctx)
 		if err != nil {
@@ -27,12 +27,12 @@ func Test_githubRepoHasReleaseWithTag(t *testing.T) {
 	t.Run("release exists", func(t *testing.T) {
 		ctx, please := setup(t)
 		err := githubRepoHasReleaseWithTag(ctx, "crhntr", "hello-release", "v0.1.5")
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 	})
 
 	t.Run("release does not exist", func(t *testing.T) {
 		ctx, please := setup(t)
 		err := githubRepoHasReleaseWithTag(ctx, "crhntr", "hello-release", "v99.99.99-banana")
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 }

--- a/internal/acceptance/workflows/scenario/step_funcs_tile_test.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_tile_test.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"testing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func Test_theLockSpecifiesVersionForRelease(t *testing.T) {
-	setup := func(t *testing.T) (context.Context, Ω.Gomega) {
-		please := Ω.NewWithT(t)
+	setup := func(t *testing.T) (context.Context, Gomega) {
+		please := NewWithT(t)
 		ctx := context.Background()
 		err := checkoutMain(testTilePath)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 		ctx = setTileRepoPath(ctx, testTilePath)
 		return ctx, please
 	}
@@ -20,12 +20,12 @@ func Test_theLockSpecifiesVersionForRelease(t *testing.T) {
 	t.Run("it matches the release version", func(t *testing.T) {
 		ctx, please := setup(t)
 		err := theLockSpecifiesVersionForRelease(ctx, "0.1.5", "hello-release")
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 	})
 
 	t.Run("it does not match the release version", func(t *testing.T) {
 		ctx, please := setup(t)
 		err := theLockSpecifiesVersionForRelease(ctx, "9000.0.0", "hello-release")
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 }

--- a/internal/commands/bake_internal_test.go
+++ b/internal/commands/bake_internal_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/pivotal-cf/kiln/internal/builder"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 var _ metadataTemplatesParser = (*builder.MetadataPartsDirectoryReader)(nil)
 
 func TestBake_loadFlags_sets_reasonable_defaults(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	var (
 		bake Bake
@@ -33,27 +33,27 @@ func TestBake_loadFlags_sets_reasonable_defaults(t *testing.T) {
 
 	err := bake.loadFlags([]string{}, statNoError, readFile)
 
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(bake.Options.Kilnfile).To(Ω.Equal("Kilnfile"))
-	please.Expect(bake.Options.Metadata).To(Ω.Equal("base.yml"))
-	please.Expect(bake.Options.IconPath).To(Ω.Equal("icon.png"))
-	please.Expect(bake.Options.OutputFile).To(Ω.Equal("tile-4.2.0.pivotal"))
+	please.Expect(bake.Options.Kilnfile).To(Equal("Kilnfile"))
+	please.Expect(bake.Options.Metadata).To(Equal("base.yml"))
+	please.Expect(bake.Options.IconPath).To(Equal("icon.png"))
+	please.Expect(bake.Options.OutputFile).To(Equal("tile-4.2.0.pivotal"))
 
-	please.Expect(bake.Options.ReleaseDirectories).To(Ω.Equal([]string{"releases"}))
-	please.Expect(bake.Options.FormDirectories).To(Ω.Equal([]string{"forms"}))
-	please.Expect(bake.Options.InstanceGroupDirectories).To(Ω.Equal([]string{"instance_groups"}))
-	please.Expect(bake.Options.JobDirectories).To(Ω.Equal([]string{"jobs"}))
-	please.Expect(bake.Options.MigrationDirectories).To(Ω.Equal([]string{"migrations"}))
-	please.Expect(bake.Options.PropertyDirectories).To(Ω.Equal([]string{"properties"}))
-	please.Expect(bake.Options.RuntimeConfigDirectories).To(Ω.Equal([]string{"runtime_configs"}))
-	please.Expect(bake.Options.BOSHVariableDirectories).To(Ω.Equal([]string{"bosh_variables"}))
+	please.Expect(bake.Options.ReleaseDirectories).To(Equal([]string{"releases"}))
+	please.Expect(bake.Options.FormDirectories).To(Equal([]string{"forms"}))
+	please.Expect(bake.Options.InstanceGroupDirectories).To(Equal([]string{"instance_groups"}))
+	please.Expect(bake.Options.JobDirectories).To(Equal([]string{"jobs"}))
+	please.Expect(bake.Options.MigrationDirectories).To(Equal([]string{"migrations"}))
+	please.Expect(bake.Options.PropertyDirectories).To(Equal([]string{"properties"}))
+	please.Expect(bake.Options.RuntimeConfigDirectories).To(Equal([]string{"runtime_configs"}))
+	please.Expect(bake.Options.BOSHVariableDirectories).To(Equal([]string{"bosh_variables"}))
 
-	please.Expect(readFileCallCount).To(Ω.Equal(1))
+	please.Expect(readFileCallCount).To(Equal(1))
 }
 
 func TestBake_loadFlags_kilnfile_path_provided(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	var (
 		bake Bake
@@ -77,30 +77,30 @@ func TestBake_loadFlags_kilnfile_path_provided(t *testing.T) {
 		"--forms-directory", "do-not-change",
 	}, statNoError, readFile)
 
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(bake.Options.Kilnfile).To(Ω.Equal("some-dir/Kilnfile"))
+	please.Expect(bake.Options.Kilnfile).To(Equal("some-dir/Kilnfile"))
 
 	description := "it should prefix defaults with kiln path"
-	please.Expect(bake.Options.Metadata).To(Ω.Equal("some-dir/base.yml"), description)
-	please.Expect(bake.Options.IconPath).To(Ω.Equal("some-dir/icon.png"), description)
-	please.Expect(bake.Options.OutputFile).To(Ω.Equal("tile-4.2.0.pivotal"))
+	please.Expect(bake.Options.Metadata).To(Equal("some-dir/base.yml"), description)
+	please.Expect(bake.Options.IconPath).To(Equal("some-dir/icon.png"), description)
+	please.Expect(bake.Options.OutputFile).To(Equal("tile-4.2.0.pivotal"))
 
-	please.Expect(bake.Options.FormDirectories).To(Ω.Equal([]string{"do-not-change"}), "it should not prefix explicitly passed flags")
+	please.Expect(bake.Options.FormDirectories).To(Equal([]string{"do-not-change"}), "it should not prefix explicitly passed flags")
 
-	please.Expect(bake.Options.ReleaseDirectories).To(Ω.Equal([]string{"some-dir/releases"}), description)
-	please.Expect(bake.Options.InstanceGroupDirectories).To(Ω.Equal([]string{"some-dir/instance_groups"}), description)
-	please.Expect(bake.Options.JobDirectories).To(Ω.Equal([]string{"some-dir/jobs"}), description)
-	please.Expect(bake.Options.MigrationDirectories).To(Ω.Equal([]string{"some-dir/migrations"}), description)
-	please.Expect(bake.Options.PropertyDirectories).To(Ω.Equal([]string{"some-dir/properties"}), description)
-	please.Expect(bake.Options.RuntimeConfigDirectories).To(Ω.Equal([]string{"some-dir/runtime_configs"}), description)
-	please.Expect(bake.Options.BOSHVariableDirectories).To(Ω.Equal([]string{"some-dir/bosh_variables"}), description)
+	please.Expect(bake.Options.ReleaseDirectories).To(Equal([]string{"some-dir/releases"}), description)
+	please.Expect(bake.Options.InstanceGroupDirectories).To(Equal([]string{"some-dir/instance_groups"}), description)
+	please.Expect(bake.Options.JobDirectories).To(Equal([]string{"some-dir/jobs"}), description)
+	please.Expect(bake.Options.MigrationDirectories).To(Equal([]string{"some-dir/migrations"}), description)
+	please.Expect(bake.Options.PropertyDirectories).To(Equal([]string{"some-dir/properties"}), description)
+	please.Expect(bake.Options.RuntimeConfigDirectories).To(Equal([]string{"some-dir/runtime_configs"}), description)
+	please.Expect(bake.Options.BOSHVariableDirectories).To(Equal([]string{"some-dir/bosh_variables"}), description)
 
-	please.Expect(readFileCallCount).To(Ω.Equal(1))
+	please.Expect(readFileCallCount).To(Equal(1))
 }
 
 func TestBake_loadFlags_sets_empty_options_when_default_is_not_applicable(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	var (
 		bake Bake
@@ -111,24 +111,24 @@ func TestBake_loadFlags_sets_empty_options_when_default_is_not_applicable(t *tes
 
 	err := bake.loadFlags([]string{}, statError, readError)
 
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(bake.Options.Kilnfile).To(Ω.Equal(""))
-	please.Expect(bake.Options.Metadata).To(Ω.Equal(""))
-	please.Expect(bake.Options.Version).To(Ω.Equal(""))
+	please.Expect(bake.Options.Kilnfile).To(Equal(""))
+	please.Expect(bake.Options.Metadata).To(Equal(""))
+	please.Expect(bake.Options.Version).To(Equal(""))
 
-	please.Expect(bake.Options.ReleaseDirectories).To(Ω.HaveLen(0))
-	please.Expect(bake.Options.FormDirectories).To(Ω.HaveLen(0))
-	please.Expect(bake.Options.InstanceGroupDirectories).To(Ω.HaveLen(0))
-	please.Expect(bake.Options.JobDirectories).To(Ω.HaveLen(0))
-	please.Expect(bake.Options.MigrationDirectories).To(Ω.HaveLen(0))
-	please.Expect(bake.Options.PropertyDirectories).To(Ω.HaveLen(0))
-	please.Expect(bake.Options.RuntimeConfigDirectories).To(Ω.HaveLen(0))
-	please.Expect(bake.Options.BOSHVariableDirectories).To(Ω.HaveLen(0))
+	please.Expect(bake.Options.ReleaseDirectories).To(HaveLen(0))
+	please.Expect(bake.Options.FormDirectories).To(HaveLen(0))
+	please.Expect(bake.Options.InstanceGroupDirectories).To(HaveLen(0))
+	please.Expect(bake.Options.JobDirectories).To(HaveLen(0))
+	please.Expect(bake.Options.MigrationDirectories).To(HaveLen(0))
+	please.Expect(bake.Options.PropertyDirectories).To(HaveLen(0))
+	please.Expect(bake.Options.RuntimeConfigDirectories).To(HaveLen(0))
+	please.Expect(bake.Options.BOSHVariableDirectories).To(HaveLen(0))
 }
 
 func TestBake_loadFlags_does_not_override_provided_flags(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	var (
 		bake Bake
@@ -175,28 +175,28 @@ func TestBake_loadFlags_does_not_override_provided_flags(t *testing.T) {
 		"--bosh-variables-directory", "bosh-variables-directory-2",
 	}, statError, readNotFound)
 
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(bake.Options.Kilnfile).To(Ω.Equal("kilnfile"))
-	please.Expect(bake.Options.Metadata).To(Ω.Equal("metadata"))
-	please.Expect(bake.Options.IconPath).To(Ω.Equal("icon"))
-	please.Expect(bake.Options.Version).To(Ω.Equal("4.2.0"))
-	please.Expect(bake.Options.OutputFile).To(Ω.Equal("some-tile.pivotal"))
+	please.Expect(bake.Options.Kilnfile).To(Equal("kilnfile"))
+	please.Expect(bake.Options.Metadata).To(Equal("metadata"))
+	please.Expect(bake.Options.IconPath).To(Equal("icon"))
+	please.Expect(bake.Options.Version).To(Equal("4.2.0"))
+	please.Expect(bake.Options.OutputFile).To(Equal("some-tile.pivotal"))
 
-	please.Expect(bake.Options.ReleaseDirectories).To(Ω.Equal([]string{"releases-directory-1", "releases-directory-2"}))
-	please.Expect(bake.Options.FormDirectories).To(Ω.Equal([]string{"forms-directory-1", "forms-directory-2"}))
-	please.Expect(bake.Options.InstanceGroupDirectories).To(Ω.Equal([]string{"instance-groups-directory-1", "instance-groups-directory-2"}))
-	please.Expect(bake.Options.JobDirectories).To(Ω.Equal([]string{"jobs-directory-1", "jobs-directory-2"}))
-	please.Expect(bake.Options.MigrationDirectories).To(Ω.Equal([]string{"migrations-directory-1", "migrations-directory-2"}))
-	please.Expect(bake.Options.PropertyDirectories).To(Ω.Equal([]string{"properties-directory-1", "properties-directory-2"}))
-	please.Expect(bake.Options.RuntimeConfigDirectories).To(Ω.Equal([]string{"runtime-configs-directory-1", "runtime-configs-directory-2"}))
-	please.Expect(bake.Options.BOSHVariableDirectories).To(Ω.Equal([]string{"bosh-variables-directory-1", "bosh-variables-directory-2"}))
+	please.Expect(bake.Options.ReleaseDirectories).To(Equal([]string{"releases-directory-1", "releases-directory-2"}))
+	please.Expect(bake.Options.FormDirectories).To(Equal([]string{"forms-directory-1", "forms-directory-2"}))
+	please.Expect(bake.Options.InstanceGroupDirectories).To(Equal([]string{"instance-groups-directory-1", "instance-groups-directory-2"}))
+	please.Expect(bake.Options.JobDirectories).To(Equal([]string{"jobs-directory-1", "jobs-directory-2"}))
+	please.Expect(bake.Options.MigrationDirectories).To(Equal([]string{"migrations-directory-1", "migrations-directory-2"}))
+	please.Expect(bake.Options.PropertyDirectories).To(Equal([]string{"properties-directory-1", "properties-directory-2"}))
+	please.Expect(bake.Options.RuntimeConfigDirectories).To(Equal([]string{"runtime-configs-directory-1", "runtime-configs-directory-2"}))
+	please.Expect(bake.Options.BOSHVariableDirectories).To(Equal([]string{"bosh-variables-directory-1", "bosh-variables-directory-2"}))
 
-	please.Expect(readFileCallCount).To(Ω.Equal(0))
+	please.Expect(readFileCallCount).To(Equal(0))
 }
 
 func TestBake_loadFlags_sets_default_output_file_if_not_set(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	var (
 		bake Bake
@@ -217,13 +217,13 @@ func TestBake_loadFlags_sets_default_output_file_if_not_set(t *testing.T) {
 
 	err := bake.loadFlags([]string{}, statNoError, readFile)
 
-	please.Expect(err).NotTo(Ω.HaveOccurred())
-	please.Expect(bake.Options.OutputFile).To(Ω.Equal("tile-1.2.3.pivotal"))
-	please.Expect(readFileCallCount).To(Ω.Equal(1))
+	please.Expect(err).NotTo(HaveOccurred())
+	please.Expect(bake.Options.OutputFile).To(Equal("tile-1.2.3.pivotal"))
+	please.Expect(readFileCallCount).To(Equal(1))
 }
 
 func TestBake_loadFlags_does_not_set_outputs_file_when_meta_data_only_is_true(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	var (
 		bake Bake
@@ -236,12 +236,12 @@ func TestBake_loadFlags_does_not_set_outputs_file_when_meta_data_only_is_true(t 
 		"--metadata-only",
 	}, statNoError, readFileError)
 
-	please.Expect(err).NotTo(Ω.HaveOccurred())
-	please.Expect(bake.Options.OutputFile).To(Ω.Equal(""))
+	please.Expect(err).NotTo(HaveOccurred())
+	please.Expect(bake.Options.OutputFile).To(Equal(""))
 }
 
 func TestBake_loadFlags_version_file_does_not_exist(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	var (
 		bake Bake
@@ -256,5 +256,5 @@ func TestBake_loadFlags_version_file_does_not_exist(t *testing.T) {
 
 	err := bake.loadFlags([]string{}, statError, readFileError)
 
-	please.Expect(err).NotTo(Ω.HaveOccurred(), "it should not return an error")
+	please.Expect(err).NotTo(HaveOccurred(), "it should not return an error")
 }

--- a/internal/commands/cache_compiled_releases_test.go
+++ b/internal/commands/cache_compiled_releases_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cloudfoundry/bosh-cli/director"
 	boshdirFakes "github.com/cloudfoundry/bosh-cli/director/directorfakes"
 	"github.com/go-git/go-billy/v5/memfs"
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/pivotal-cf/jhanda"
 
 	"github.com/pivotal-cf/kiln/internal/commands"
@@ -24,14 +24,14 @@ import (
 var _ jhanda.Command = (*commands.CacheCompiledReleases)(nil)
 
 func TestNewCacheCompiledReleases(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	cmd := commands.NewCacheCompiledReleases()
-	please.Expect(cmd).NotTo(Ω.BeNil())
-	please.Expect(cmd.Logger).NotTo(Ω.BeNil())
-	please.Expect(cmd.FS).NotTo(Ω.BeNil())
-	please.Expect(cmd.ReleaseSourceAndCache).NotTo(Ω.BeNil())
-	please.Expect(cmd.OpsManager).NotTo(Ω.BeNil())
-	please.Expect(cmd.Director).NotTo(Ω.BeNil())
+	please.Expect(cmd).NotTo(BeNil())
+	please.Expect(cmd.Logger).NotTo(BeNil())
+	please.Expect(cmd.FS).NotTo(BeNil())
+	please.Expect(cmd.ReleaseSourceAndCache).NotTo(BeNil())
+	please.Expect(cmd.OpsManager).NotTo(BeNil())
+	please.Expect(cmd.Director).NotTo(BeNil())
 }
 
 type cacheCompiledReleasesTestData struct {
@@ -120,7 +120,7 @@ func newCacheCompiledReleasesTestData(t *testing.T, kf cargo.Kilnfile, kl cargo.
 }
 
 func TestCacheCompiledReleases_Execute_all_releases_are_already_compiled(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	// setup
 
@@ -154,12 +154,12 @@ func TestCacheCompiledReleases_Execute_all_releases_are_already_compiled(t *test
 
 	// check
 
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("cache already contains releases"))
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(test.output.String()).To(ContainSubstring("cache already contains releases"))
+	please.Expect(err).NotTo(HaveOccurred())
 }
 
 func TestCacheCompiledReleases_Execute_all_releases_are_already_cached(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	// setup
 
@@ -195,12 +195,12 @@ func TestCacheCompiledReleases_Execute_all_releases_are_already_cached(t *testin
 
 	// check
 
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("cache already contains releases"))
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(test.output.String()).To(ContainSubstring("cache already contains releases"))
+	please.Expect(err).NotTo(HaveOccurred())
 
 	var updatedKilnfile cargo.KilnfileLock
-	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedKilnfile)).NotTo(Ω.HaveOccurred())
-	please.Expect(updatedKilnfile.Releases).To(Ω.ContainElement(component.Lock{
+	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedKilnfile)).NotTo(HaveOccurred())
+	please.Expect(updatedKilnfile.Releases).To(ContainElement(component.Lock{
 		Name: "orange", Version: "1.0.0",
 		SHA1:         "fake-checksum",
 		RemoteSource: "cached-compiled-releases",
@@ -307,27 +307,27 @@ func TestCacheCompiledReleases_Execute_when_one_release_is_cached_another_is_alr
 	})
 
 	// check
-	please := Ω.NewWithT(t)
-	please.Expect(err).NotTo(Ω.HaveOccurred())
-	please.Expect(test.releaseStorage.GetMatchedReleaseCallCount()).To(Ω.Equal(3))
-	please.Expect(test.bosh.DownloadResourceUncheckedCallCount()).To(Ω.Equal(1))
+	please := NewWithT(t)
+	please.Expect(err).NotTo(HaveOccurred())
+	please.Expect(test.releaseStorage.GetMatchedReleaseCallCount()).To(Equal(3))
+	please.Expect(test.bosh.DownloadResourceUncheckedCallCount()).To(Equal(1))
 
 	requestedID, _ := test.bosh.DownloadResourceUncheckedArgsForCall(0)
-	please.Expect(requestedID).To(Ω.Equal("some-blob-id"))
+	please.Expect(requestedID).To(Equal("some-blob-id"))
 
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("1 release needs to be exported and cached"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("lemon/3.0.0 compiled with alpine/9.0.0 not found in cache"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("exporting from bosh deployment cf-some-id"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("exporting lemon"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("downloading lemon"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("uploading lemon"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("DON'T FORGET TO MAKE A COMMIT AND PR"))
+	please.Expect(test.output.String()).To(ContainSubstring("1 release needs to be exported and cached"))
+	please.Expect(test.output.String()).To(ContainSubstring("lemon/3.0.0 compiled with alpine/9.0.0 not found in cache"))
+	please.Expect(test.output.String()).To(ContainSubstring("exporting from bosh deployment cf-some-id"))
+	please.Expect(test.output.String()).To(ContainSubstring("exporting lemon"))
+	please.Expect(test.output.String()).To(ContainSubstring("downloading lemon"))
+	please.Expect(test.output.String()).To(ContainSubstring("uploading lemon"))
+	please.Expect(test.output.String()).To(ContainSubstring("DON'T FORGET TO MAKE A COMMIT AND PR"))
 
-	please.Expect(uploadedRelease.String()).To(Ω.Equal(releaseInBlobstore))
+	please.Expect(uploadedRelease.String()).To(Equal(releaseInBlobstore))
 
 	var updatedKilnfile cargo.KilnfileLock
-	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedKilnfile)).NotTo(Ω.HaveOccurred())
-	please.Expect(updatedKilnfile.Releases).To(Ω.ContainElement(component.Lock{
+	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedKilnfile)).NotTo(HaveOccurred())
+	please.Expect(updatedKilnfile.Releases).To(ContainElement(component.Lock{
 		Name:         "lemon",
 		Version:      "3.0.0",
 		SHA1:         "012ed191f1d07c14bbcbbc0423d0de1c56757348",
@@ -342,7 +342,7 @@ func TestCacheCompiledReleases_Execute_when_one_release_is_cached_another_is_alr
 // - export release returns a broken bosh release because we requested the wrong compilation target and the director didn't have the source code necessarily to re-compile against the requested stemcell
 // - (ideally bosh export-release should return an error but in this case it doesn't so we are just checking for a release with the correct stemcell before downloading a bad one)
 func TestCacheCompiledReleases_Execute_when_a_release_is_not_compiled_with_the_correct_stemcell(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	// setup
 
@@ -398,27 +398,27 @@ func TestCacheCompiledReleases_Execute_when_a_release_is_not_compiled_with_the_c
 
 	// check
 
-	please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("not found on bosh director")))
+	please.Expect(err).To(MatchError(ContainSubstring("not found on bosh director")))
 
-	please.Expect(test.bosh.DownloadResourceUncheckedCallCount()).To(Ω.Equal(0))
-	please.Expect(test.bosh.HasReleaseCallCount()).To(Ω.Equal(0))
-	please.Expect(test.bosh.FindReleaseCallCount()).To(Ω.Equal(1))
+	please.Expect(test.bosh.DownloadResourceUncheckedCallCount()).To(Equal(0))
+	please.Expect(test.bosh.HasReleaseCallCount()).To(Equal(0))
+	please.Expect(test.bosh.FindReleaseCallCount()).To(Equal(1))
 
 	{
 		requestedReleaseSlug := test.bosh.FindReleaseArgsForCall(0)
-		please.Expect(requestedReleaseSlug.Name()).To(Ω.Equal("banana"))
-		please.Expect(requestedReleaseSlug.Version()).To(Ω.Equal("2.0.0"))
+		please.Expect(requestedReleaseSlug.Name()).To(Equal("banana"))
+		please.Expect(requestedReleaseSlug.Version()).To(Equal("2.0.0"))
 	}
 
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("1 release needs to be exported and cached"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("banana/2.0.0 compiled with alpine/8.0.0 not found in cache"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("exporting from bosh deployment cf-some-id"))
-	please.Expect(test.output.String()).NotTo(Ω.ContainSubstring("exporting lemon"))
-	please.Expect(test.output.String()).NotTo(Ω.ContainSubstring("DON'T FORGET TO MAKE A COMMIT AND PR"))
+	please.Expect(test.output.String()).To(ContainSubstring("1 release needs to be exported and cached"))
+	please.Expect(test.output.String()).To(ContainSubstring("banana/2.0.0 compiled with alpine/8.0.0 not found in cache"))
+	please.Expect(test.output.String()).To(ContainSubstring("exporting from bosh deployment cf-some-id"))
+	please.Expect(test.output.String()).NotTo(ContainSubstring("exporting lemon"))
+	please.Expect(test.output.String()).NotTo(ContainSubstring("DON'T FORGET TO MAKE A COMMIT AND PR"))
 
 	var updatedKilnfile cargo.KilnfileLock
-	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedKilnfile)).NotTo(Ω.HaveOccurred())
-	please.Expect(updatedKilnfile.Releases).To(Ω.ContainElement(component.Lock{
+	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedKilnfile)).NotTo(HaveOccurred())
+	please.Expect(updatedKilnfile.Releases).To(ContainElement(component.Lock{
 		Name:    "banana",
 		Version: "2.0.0",
 
@@ -432,7 +432,7 @@ func TestCacheCompiledReleases_Execute_when_a_release_is_not_compiled_with_the_c
 // this test covers
 // - when a release does not contain packages
 func TestCacheCompiledReleases_Execute_when_a_release_has_no_packages(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	// setup
 	test := newCacheCompiledReleasesTestData(t, cargo.Kilnfile{
@@ -503,25 +503,25 @@ func TestCacheCompiledReleases_Execute_when_a_release_has_no_packages(t *testing
 
 	// check
 
-	please.Expect(test.bosh.DownloadResourceUncheckedCallCount()).To(Ω.Equal(1))
-	please.Expect(test.bosh.HasReleaseCallCount()).To(Ω.Equal(0))
-	please.Expect(test.bosh.FindReleaseCallCount()).To(Ω.Equal(1))
+	please.Expect(test.bosh.DownloadResourceUncheckedCallCount()).To(Equal(1))
+	please.Expect(test.bosh.HasReleaseCallCount()).To(Equal(0))
+	please.Expect(test.bosh.FindReleaseCallCount()).To(Equal(1))
 
 	{
 		requestedReleaseSlug := test.bosh.FindReleaseArgsForCall(0)
-		please.Expect(requestedReleaseSlug.Name()).To(Ω.Equal("banana"))
-		please.Expect(requestedReleaseSlug.Version()).To(Ω.Equal("2.0.0"))
+		please.Expect(requestedReleaseSlug.Name()).To(Equal("banana"))
+		please.Expect(requestedReleaseSlug.Version()).To(Equal("2.0.0"))
 	}
 
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("1 release needs to be exported and cached"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("banana/2.0.0 compiled with alpine/8.0.0 not found in cache"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("exporting from bosh deployment cf-some-id"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("oes not have any packages"))
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("exporting banana"))
+	please.Expect(test.output.String()).To(ContainSubstring("1 release needs to be exported and cached"))
+	please.Expect(test.output.String()).To(ContainSubstring("banana/2.0.0 compiled with alpine/8.0.0 not found in cache"))
+	please.Expect(test.output.String()).To(ContainSubstring("exporting from bosh deployment cf-some-id"))
+	please.Expect(test.output.String()).To(ContainSubstring("oes not have any packages"))
+	please.Expect(test.output.String()).To(ContainSubstring("exporting banana"))
 
 	var updatedKilnfile cargo.KilnfileLock
-	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedKilnfile)).NotTo(Ω.HaveOccurred())
-	please.Expect(updatedKilnfile.Releases).To(Ω.ContainElement(component.Lock{
+	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedKilnfile)).NotTo(HaveOccurred())
+	please.Expect(updatedKilnfile.Releases).To(ContainElement(component.Lock{
 		Name:    "banana",
 		Version: "2.0.0",
 
@@ -531,13 +531,13 @@ func TestCacheCompiledReleases_Execute_when_a_release_has_no_packages(t *testing
 		SHA1: "fake-checksum",
 	}), "it should not override the in-correct element in the Kilnfile.lock")
 
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(test.output.String()).To(Ω.ContainSubstring("DON'T FORGET TO MAKE A COMMIT AND PR"))
+	please.Expect(test.output.String()).To(ContainSubstring("DON'T FORGET TO MAKE A COMMIT AND PR"))
 }
 
 func TestCacheCompiledReleases_Execute_staged_and_lock_stemcells_are_not_the_same(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	// setup
 
@@ -598,11 +598,11 @@ func TestCacheCompiledReleases_Execute_staged_and_lock_stemcells_are_not_the_sam
 
 	// check
 
-	please.Expect(test.releaseStorage.GetMatchedReleaseCallCount()).To(Ω.Equal(0))
-	please.Expect(test.bosh.DownloadResourceUncheckedCallCount()).To(Ω.Equal(0))
-	please.Expect(err).To(Ω.MatchError(Ω.Equal("staged stemcell (alpine 9.0.1) and lock stemcell (alpine 9.0.0) do not match")))
+	please.Expect(test.releaseStorage.GetMatchedReleaseCallCount()).To(Equal(0))
+	please.Expect(test.bosh.DownloadResourceUncheckedCallCount()).To(Equal(0))
+	please.Expect(err).To(MatchError(Equal("staged stemcell (alpine 9.0.1) and lock stemcell (alpine 9.0.0) do not match")))
 
 	var updatedLock cargo.KilnfileLock
-	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedLock)).NotTo(Ω.HaveOccurred())
-	please.Expect(updatedLock).To(Ω.Equal(initialLock))
+	please.Expect(fsReadYAML(test.cmd.FS, "Kilnfile.lock", &updatedLock)).NotTo(HaveOccurred())
+	please.Expect(updatedLock).To(Equal(initialLock))
 }

--- a/internal/commands/release_notes_test.go
+++ b/internal/commands/release_notes_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pivotal-cf/kiln/internal/component"
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/Masterminds/semver"
 	"github.com/go-git/go-billy/v5/memfs"
@@ -26,13 +26,13 @@ import (
 var _ jhanda.Command = ReleaseNotes{}
 
 func TestReleaseNotes_Usage(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	rn := ReleaseNotes{}
 
-	please.Expect(rn.Usage().Description).NotTo(Ω.BeEmpty())
-	please.Expect(rn.Usage().ShortDescription).NotTo(Ω.BeEmpty())
-	please.Expect(rn.Usage().Flags).NotTo(Ω.BeNil())
+	please.Expect(rn.Usage().Description).NotTo(BeEmpty())
+	please.Expect(rn.Usage().ShortDescription).NotTo(BeEmpty())
+	please.Expect(rn.Usage().Flags).NotTo(BeNil())
 }
 
 //go:embed testdata/release_notes_output.md
@@ -47,10 +47,10 @@ func TestReleaseNotes_Execute(t *testing.T) {
 			return tm
 		}
 
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		nonNilRepo, _ := git.Init(memory.NewStorage(), memfs.New())
-		please.Expect(nonNilRepo).NotTo(Ω.BeNil())
+		please.Expect(nonNilRepo).NotTo(BeNil())
 
 		readFileCount := 0
 		readFileFunc := func(string) ([]byte, error) {
@@ -116,24 +116,24 @@ func TestReleaseNotes_Execute(t *testing.T) {
 			"tile/1.1.0",
 			"tile/1.2.0",
 		})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 
-		please.Expect(ctx).NotTo(Ω.BeNil())
-		please.Expect(repository).NotTo(Ω.BeNil())
-		please.Expect(client).NotTo(Ω.BeNil())
+		please.Expect(ctx).NotTo(BeNil())
+		please.Expect(repository).NotTo(BeNil())
+		please.Expect(client).NotTo(BeNil())
 
-		please.Expect(tileRepoOwner).To(Ω.Equal("bunch"))
-		please.Expect(tileRepoName).To(Ω.Equal("banana"))
-		please.Expect(kilnfilePath).To(Ω.Equal("tile/Kilnfile"))
-		please.Expect(initialRevision).To(Ω.Equal("tile/1.1.0"))
-		please.Expect(finalRevision).To(Ω.Equal("tile/1.2.0"))
+		please.Expect(tileRepoOwner).To(Equal("bunch"))
+		please.Expect(tileRepoName).To(Equal("banana"))
+		please.Expect(kilnfilePath).To(Equal("tile/Kilnfile"))
+		please.Expect(initialRevision).To(Equal("tile/1.1.0"))
+		please.Expect(finalRevision).To(Equal("tile/1.2.0"))
 
-		please.Expect(issuesQuery.IssueMilestone).To(Ω.Equal("smoothie"))
-		please.Expect(issuesQuery.IssueIDs).To(Ω.Equal([]string{"54000", "54321"}))
-		please.Expect(issuesQuery.IssueLabels).To(Ω.Equal([]string{"tropical", "20000"}))
+		please.Expect(issuesQuery.IssueMilestone).To(Equal("smoothie"))
+		please.Expect(issuesQuery.IssueIDs).To(Equal([]string{"54000", "54321"}))
+		please.Expect(issuesQuery.IssueLabels).To(Equal([]string{"tropical", "20000"}))
 
 		t.Log(out.String())
-		please.Expect(out.String()).To(Ω.Equal(releaseNotesExpectedOutput))
+		please.Expect(out.String()).To(Equal(releaseNotesExpectedOutput))
 	})
 
 	t.Run("when updating a docs file", func(t *testing.T) {
@@ -144,90 +144,90 @@ func TestReleaseNotes_checkInputs(t *testing.T) {
 	t.Parallel()
 
 	t.Run("missing args", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		rn := ReleaseNotes{}
 		err := rn.checkInputs(nil)
-		please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("expected two arguments")))
+		please.Expect(err).To(MatchError(ContainSubstring("expected two arguments")))
 	})
 
 	t.Run("missing arg", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		rn := ReleaseNotes{}
 		err := rn.checkInputs([]string{"some-hash"})
-		please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("expected two arguments")))
+		please.Expect(err).To(MatchError(ContainSubstring("expected two arguments")))
 	})
 
 	t.Run("too many args", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		rn := ReleaseNotes{}
 		err := rn.checkInputs([]string{"a", "b", "c"})
-		please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("expected two arguments")))
+		please.Expect(err).To(MatchError(ContainSubstring("expected two arguments")))
 	})
 
 	t.Run("too many args", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		rn := ReleaseNotes{}
 		err := rn.checkInputs([]string{"a", "b", "c"})
-		please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("expected two arguments")))
+		please.Expect(err).To(MatchError(ContainSubstring("expected two arguments")))
 	})
 
 	t.Run("bad issue title expression", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		rn := ReleaseNotes{}
 		rn.Options.IssueTitleExp = `\`
 		err := rn.checkInputs([]string{"a", "b"})
-		please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("expression")))
+		please.Expect(err).To(MatchError(ContainSubstring("expression")))
 	})
 
 	t.Run("malformed release date", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		rn := ReleaseNotes{}
 		rn.Options.ReleaseDate = `some-date`
 		err := rn.checkInputs([]string{"a", "b"})
-		please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("cannot parse")))
+		please.Expect(err).To(MatchError(ContainSubstring("cannot parse")))
 	})
 
 	t.Run("issue flag without auth", func(t *testing.T) {
 		t.Run("milestone", func(t *testing.T) {
-			please := Ω.NewWithT(t)
+			please := NewWithT(t)
 
 			rn := ReleaseNotes{}
 			rn.Options.IssueMilestone = "s"
 			err := rn.checkInputs([]string{"a", "b"})
-			please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("github-token")))
+			please.Expect(err).To(MatchError(ContainSubstring("github-token")))
 		})
 
 		t.Run("ids", func(t *testing.T) {
-			please := Ω.NewWithT(t)
+			please := NewWithT(t)
 
 			rn := ReleaseNotes{}
 			rn.Options.IssueIDs = []string{"s"}
 			err := rn.checkInputs([]string{"a", "b"})
-			please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("github-token")))
+			please.Expect(err).To(MatchError(ContainSubstring("github-token")))
 		})
 
 		t.Run("labels", func(t *testing.T) {
-			please := Ω.NewWithT(t)
+			please := NewWithT(t)
 
 			rn := ReleaseNotes{}
 			rn.Options.IssueLabels = []string{"s"}
 			err := rn.checkInputs([]string{"a", "b"})
-			please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("github-token")))
+			please.Expect(err).To(MatchError(ContainSubstring("github-token")))
 		})
 
 		t.Run("exp", func(t *testing.T) {
-			please := Ω.NewWithT(t)
+			please := NewWithT(t)
 
 			rn := ReleaseNotes{}
 			rn.Options.IssueTitleExp = "s"
 			err := rn.checkInputs([]string{"a", "b"})
-			please.Expect(err).NotTo(Ω.HaveOccurred())
+			please.Expect(err).NotTo(HaveOccurred())
 		})
 	})
 }
@@ -235,7 +235,7 @@ func TestReleaseNotes_checkInputs(t *testing.T) {
 func Test_getGithubRemoteRepoOwnerAndName(t *testing.T) {
 	t.Parallel()
 	t.Run("when there is a github http remote", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		repo, _ := git.Init(memory.NewStorage(), memfs.New())
 		_, _ = repo.CreateRemote(&config.RemoteConfig{
@@ -245,13 +245,13 @@ func Test_getGithubRemoteRepoOwnerAndName(t *testing.T) {
 			},
 		})
 		o, r, err := getGithubRemoteRepoOwnerAndName(repo)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(o).To(Ω.Equal("pivotal-cf"))
-		please.Expect(r).To(Ω.Equal("kiln"))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(o).To(Equal("pivotal-cf"))
+		please.Expect(r).To(Equal("kiln"))
 	})
 
 	t.Run("when there is a github ssh remote", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		repo, _ := git.Init(memory.NewStorage(), memfs.New())
 		_, _ = repo.CreateRemote(&config.RemoteConfig{
@@ -261,21 +261,21 @@ func Test_getGithubRemoteRepoOwnerAndName(t *testing.T) {
 			},
 		})
 		o, r, err := getGithubRemoteRepoOwnerAndName(repo)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(o).To(Ω.Equal("pivotal-cf"))
-		please.Expect(r).To(Ω.Equal("kiln"))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(o).To(Equal("pivotal-cf"))
+		please.Expect(r).To(Equal("kiln"))
 	})
 
 	t.Run("when there are no remotes", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		repo, _ := git.Init(memory.NewStorage(), memfs.New())
 		_, _, err := getGithubRemoteRepoOwnerAndName(repo)
-		please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("not found")))
+		please.Expect(err).To(MatchError(ContainSubstring("not found")))
 	})
 
 	t.Run("when there are many remotes", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		repo, _ := git.Init(memory.NewStorage(), memfs.New())
 		_, _ = repo.CreateRemote(&config.RemoteConfig{
@@ -291,8 +291,8 @@ func Test_getGithubRemoteRepoOwnerAndName(t *testing.T) {
 			},
 		})
 		o, _, err := getGithubRemoteRepoOwnerAndName(repo)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(o).To(Ω.Equal("pivotal-cf"), "it uses the remote with name 'origin'")
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(o).To(Equal("pivotal-cf"), "it uses the remote with name 'origin'")
 	})
 }
 

--- a/internal/component/bump_internal_test.go
+++ b/internal/component/bump_internal_test.go
@@ -2,12 +2,12 @@ package component
 
 import (
 	"github.com/google/go-github/v40/github"
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"testing"
 )
 
 func TestInternal_deduplicateReleasesWithTheSameTagName(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	b := Bump{
 		Releases: []*github.RepositoryRelease{
 			{TagName: ptr("Y")},
@@ -27,7 +27,7 @@ func TestInternal_deduplicateReleasesWithTheSameTagName(t *testing.T) {
 	for _, r := range b.Releases {
 		tags = append(tags, r.GetTagName())
 	}
-	please.Expect(tags).To(Ω.Equal([]string{
+	please.Expect(tags).To(Equal([]string{
 		"Y",
 		"1",
 		"2",

--- a/internal/component/bump_test.go
+++ b/internal/component/bump_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-github/v40/github"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	fakes "github.com/pivotal-cf/kiln/internal/component/fakes_internal"
 
@@ -17,14 +17,14 @@ import (
 
 func TestCalculateBumps(t *testing.T) {
 	t.Parallel()
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	t.Run("when the components stay the same", func(t *testing.T) {
 		please.Expect(CalculateBumps([]Lock{
 			{Name: "a", Version: "1"},
 		}, []Lock{
 			{Name: "a", Version: "1"},
-		})).To(Ω.HaveLen(0))
+		})).To(HaveLen(0))
 	})
 
 	t.Run("when a component is bumped", func(t *testing.T) {
@@ -34,7 +34,7 @@ func TestCalculateBumps(t *testing.T) {
 		}, []Lock{
 			{Name: "a", Version: "1"},
 			{Name: "b", Version: "1"},
-		})).To(Ω.Equal([]Bump{
+		})).To(Equal([]Bump{
 			{Name: "b", FromVersion: "1", ToVersion: "2"},
 		}),
 			"it returns the changed lock",
@@ -50,7 +50,7 @@ func TestCalculateBumps(t *testing.T) {
 			{Name: "a", Version: "1"},
 			{Name: "b", Version: "1"},
 			{Name: "c", Version: "1"},
-		})).To(Ω.Equal([]Bump{
+		})).To(Equal([]Bump{
 			{Name: "a", FromVersion: "1", ToVersion: "2"},
 			{Name: "c", FromVersion: "1", ToVersion: "2"},
 		}),
@@ -64,7 +64,7 @@ func TestCalculateBumps(t *testing.T) {
 		}, []Lock{
 			{Name: "a", Version: "1"},
 			{Name: "b", Version: "1"},
-		})).To(Ω.HaveLen(0),
+		})).To(HaveLen(0),
 			"it does not return a bump",
 		)
 	})
@@ -78,7 +78,7 @@ func TestCalculateBumps(t *testing.T) {
 			{Name: "b", Version: "1"},
 		}, []Lock{
 			{Name: "a", Version: "1"},
-		})).To(Ω.Equal([]Bump{
+		})).To(Equal([]Bump{
 			{Name: "b", FromVersion: "", ToVersion: "1"},
 		}),
 			"it returns the component as a bump",
@@ -87,7 +87,7 @@ func TestCalculateBumps(t *testing.T) {
 }
 
 func TestInternal_addReleaseNotes(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	var ltsCallCount int
 
@@ -150,12 +150,12 @@ func TestInternal_addReleaseNotes(t *testing.T) {
 				FromVersion: "9",
 			},
 		})
-	please.Expect(err).NotTo(Ω.HaveOccurred())
-	please.Expect(result).To(Ω.HaveLen(2))
+	please.Expect(err).NotTo(HaveOccurred())
+	please.Expect(result).To(HaveLen(2))
 
-	please.Expect(ltsCallCount).To(Ω.Equal(3))
+	please.Expect(ltsCallCount).To(Equal(3))
 
-	please.Expect(result[0].ReleaseNotes()).To(Ω.Equal("served\nplated\nstored\nlabeled\npreserved\nchopped\ncleaned"))
+	please.Expect(result[0].ReleaseNotes()).To(Equal("served\nplated\nstored\nlabeled\npreserved\nchopped\ncleaned"))
 }
 
 func githubResponse(t *testing.T, status int) *github.Response {

--- a/internal/component/github_release_source_internal_test.go
+++ b/internal/component/github_release_source_internal_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/go-github/v40/github"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/pivotal-cf/kiln/internal/component/fakes_internal"
 )
@@ -23,7 +23,7 @@ func TestGithubReleaseSource_downloadRelease(t *testing.T) {
 		RemotePath: "https://github.com/cloudfoundry/routing-release/releases/download/v0.239.0/routing-0.239.0.tgz",
 	}
 
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	tempDir := t.TempDir()
 	t.Cleanup(func() {
 		_ = os.RemoveAll(tempDir)
@@ -44,21 +44,21 @@ func TestGithubReleaseSource_downloadRelease(t *testing.T) {
 
 	logger := log.New(io.Discard, "", 0)
 	local, err := downloadRelease(context.Background(), tempDir, lock, downloader, logger)
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
 	{
 		_, org, repo, tag := downloader.GetReleaseByTagArgsForCall(0)
-		please.Expect(org).To(Ω.Equal("cloudfoundry"))
-		please.Expect(repo).To(Ω.Equal("routing-release"))
-		please.Expect(tag).To(Ω.Equal("0.239.0"))
+		please.Expect(org).To(Equal("cloudfoundry"))
+		please.Expect(repo).To(Equal("routing-release"))
+		please.Expect(tag).To(Equal("0.239.0"))
 	}
 	{
 		_, org, repo, tag := downloader.GetReleaseByTagArgsForCall(1)
-		please.Expect(org).To(Ω.Equal("cloudfoundry"))
-		please.Expect(repo).To(Ω.Equal("routing-release"))
-		please.Expect(tag).To(Ω.Equal("v0.239.0"))
+		please.Expect(org).To(Equal("cloudfoundry"))
+		please.Expect(repo).To(Equal("routing-release"))
+		please.Expect(tag).To(Equal("v0.239.0"))
 	}
 
-	please.Expect(local.LocalPath).To(Ω.BeAnExistingFile(), "it finds the created asset file")
-	please.Expect(local.SHA1).To(Ω.Equal("3a2be7b07a1a19072bf54c95a8c4a3fe0cdb35d4"))
+	please.Expect(local.LocalPath).To(BeAnExistingFile(), "it finds the created asset file")
+	please.Expect(local.SHA1).To(Equal("3a2be7b07a1a19072bf54c95a8c4a3fe0cdb35d4"))
 }

--- a/internal/component/github_release_source_test.go
+++ b/internal/component/github_release_source_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v40/github"
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/pivotal-cf/kiln/internal/component"
 	"github.com/pivotal-cf/kiln/internal/component/fakes"
@@ -105,45 +105,45 @@ func TestGithubReleaseSource_ComponentLockFromGithubRelease(t *testing.T) {
 		})
 
 		t.Run("it returns success stuff", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
+			damnIt := NewWithT(t)
 
-			damnIt.Expect(err).NotTo(Ω.HaveOccurred())
+			damnIt.Expect(err).NotTo(HaveOccurred())
 		})
 
 		t.Run("it sets the lock fields properly", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
+			damnIt := NewWithT(t)
 
-			damnIt.Expect(lock.Name).To(Ω.Equal("routing"))
-			damnIt.Expect(lock.Version).To(Ω.Equal("0.226.0"))
-			damnIt.Expect(lock.RemoteSource).To(Ω.Equal(owner))
-			damnIt.Expect(lock.RemotePath).To(Ω.Equal("https://github.com/cloudfoundry/routing-release/releases/download/0.226.0/routing-0.226.0.tgz"))
+			damnIt.Expect(lock.Name).To(Equal("routing"))
+			damnIt.Expect(lock.Version).To(Equal("0.226.0"))
+			damnIt.Expect(lock.RemoteSource).To(Equal(owner))
+			damnIt.Expect(lock.RemotePath).To(Equal("https://github.com/cloudfoundry/routing-release/releases/download/0.226.0/routing-0.226.0.tgz"))
 		})
 
 		t.Run("it downloads the file", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
+			damnIt := NewWithT(t)
 
-			damnIt.Expect(downloader.DownloadReleaseAssetCallCount()).To(Ω.Equal(1))
+			damnIt.Expect(downloader.DownloadReleaseAssetCallCount()).To(Equal(1))
 			_, org, repo, build, client := downloader.DownloadReleaseAssetArgsForCall(0)
-			damnIt.Expect(org).To(Ω.Equal("cloudfoundry"))
-			damnIt.Expect(repo).To(Ω.Equal("routing-release"))
-			damnIt.Expect(build).To(Ω.Equal(int64(420)))
-			damnIt.Expect(client).NotTo(Ω.BeNil())
+			damnIt.Expect(org).To(Equal("cloudfoundry"))
+			damnIt.Expect(repo).To(Equal("routing-release"))
+			damnIt.Expect(build).To(Equal(int64(420)))
+			damnIt.Expect(client).NotTo(BeNil())
 
 			t.Run("it sets the tarball hash", func(t *testing.T) {
-				doubleDamnIt := Ω.NewWithT(t)
-				doubleDamnIt.Expect(lock.SHA1).To(Ω.Equal("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"))
-				doubleDamnIt.Expect(file.CloseCalled).To(Ω.BeTrue())
+				doubleDamnIt := NewWithT(t)
+				doubleDamnIt.Expect(lock.SHA1).To(Equal("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"))
+				doubleDamnIt.Expect(file.CloseCalled).To(BeTrue())
 			})
 		})
 
 		t.Run("it makes the right request", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
+			damnIt := NewWithT(t)
 
-			damnIt.Expect(releaseGetter.GetReleaseByTagCallCount()).To(Ω.Equal(1))
+			damnIt.Expect(releaseGetter.GetReleaseByTagCallCount()).To(Equal(1))
 			_, org, repo, tag := releaseGetter.GetReleaseByTagArgsForCall(0)
-			damnIt.Expect(org).To(Ω.Equal("cloudfoundry"))
-			damnIt.Expect(repo).To(Ω.Equal("routing-release"))
-			damnIt.Expect(tag).To(Ω.Equal("v0.226.0"))
+			damnIt.Expect(org).To(Equal("cloudfoundry"))
+			damnIt.Expect(repo).To(Equal("routing-release"))
+			damnIt.Expect(tag).To(Equal("v0.226.0"))
 		})
 	})
 
@@ -196,30 +196,30 @@ func TestGithubReleaseSource_ComponentLockFromGithubRelease(t *testing.T) {
 
 		// Then...
 		t.Run("it returns success stuff", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
+			damnIt := NewWithT(t)
 
-			damnIt.Expect(err).NotTo(Ω.HaveOccurred())
+			damnIt.Expect(err).NotTo(HaveOccurred())
 		})
 
 		t.Run("it sets the lock fields properly", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
+			damnIt := NewWithT(t)
 
-			damnIt.Expect(lock.Name).To(Ω.Equal("routing"))
-			damnIt.Expect(lock.Version).To(Ω.Equal("0.226.0"))
-			damnIt.Expect(lock.RemoteSource).To(Ω.Equal(owner))
-			damnIt.Expect(lock.RemotePath).To(Ω.Equal("https://github.com/cloudfoundry/routing-release/releases/download/v0.226.0/routing-0.226.0.tgz"))
+			damnIt.Expect(lock.Name).To(Equal("routing"))
+			damnIt.Expect(lock.Version).To(Equal("0.226.0"))
+			damnIt.Expect(lock.RemoteSource).To(Equal(owner))
+			damnIt.Expect(lock.RemotePath).To(Equal("https://github.com/cloudfoundry/routing-release/releases/download/v0.226.0/routing-0.226.0.tgz"))
 		})
 
 		t.Run("it makes the right request", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
+			damnIt := NewWithT(t)
 
-			damnIt.Expect(releaseGetter.GetReleaseByTagCallCount()).To(Ω.Equal(2))
+			damnIt.Expect(releaseGetter.GetReleaseByTagCallCount()).To(Equal(2))
 
 			_, _, _, tag := releaseGetter.GetReleaseByTagArgsForCall(0)
-			damnIt.Expect(tag).To(Ω.Equal("v0.226.0"))
+			damnIt.Expect(tag).To(Equal("v0.226.0"))
 
 			_, _, _, tag = releaseGetter.GetReleaseByTagArgsForCall(1)
-			damnIt.Expect(tag).To(Ω.Equal("0.226.0"))
+			damnIt.Expect(tag).To(Equal("0.226.0"))
 		})
 	})
 }
@@ -233,14 +233,14 @@ func TestGithubReleaseSource_FindReleaseVersion(t *testing.T) {
 		_, err := grs.FindReleaseVersion(s, false)
 
 		t.Run("it returns an error about version not being specific", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
-			damnIt.Expect(err).To(Ω.HaveOccurred())
-			damnIt.Expect(err.Error()).To(Ω.ContainSubstring("expected version to be a constraint"))
+			damnIt := NewWithT(t)
+			damnIt.Expect(err).To(HaveOccurred())
+			damnIt.Expect(err.Error()).To(ContainSubstring("expected version to be a constraint"))
 		})
 	})
 
 	t.Run("noDownload is true", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		downloader := new(fakes.ReleaseAssetDownloader)
 		downloader.DownloadReleaseAssetReturns(nil, "", fmt.Errorf("this is a mistake! I'm not supposed to be here!"))
@@ -287,10 +287,10 @@ func TestGithubReleaseSource_FindReleaseVersion(t *testing.T) {
 		}
 
 		lock, err := grsMock.FindReleaseVersion(s, true)
-		please.Expect(err).ToNot(Ω.HaveOccurred())
+		please.Expect(err).ToNot(HaveOccurred())
 
-		please.Expect(lock.SHA1).To(Ω.Equal("not-calculated"))
-		please.Expect(downloader.Invocations()).To(Ω.BeEmpty())
+		please.Expect(lock.SHA1).To(Equal("not-calculated"))
+		please.Expect(downloader.Invocations()).To(BeEmpty())
 	})
 }
 
@@ -303,16 +303,16 @@ func TestGithubReleaseSource_GetMatchedRelease(t *testing.T) {
 		_, err := grs.GetMatchedRelease(s)
 
 		t.Run("it returns an error about version not being specific", func(t *testing.T) {
-			damnIt := Ω.NewWithT(t)
-			damnIt.Expect(err).To(Ω.HaveOccurred())
-			damnIt.Expect(err.Error()).To(Ω.ContainSubstring("expected version to be an exact version"))
+			damnIt := NewWithT(t)
+			damnIt.Expect(err).To(HaveOccurred())
+			damnIt.Expect(err.Error()).To(ContainSubstring("expected version to be an exact version"))
 		})
 	})
 }
 
 func TestGetGithubReleaseWithTag(t *testing.T) {
 	t.Run("when get release with tag api request fails", func(t *testing.T) {
-		damnIt := Ω.NewWithT(t)
+		damnIt := NewWithT(t)
 
 		releaseGetter := new(fakes.ReleaseByTagGetter)
 
@@ -341,12 +341,12 @@ func TestGetGithubReleaseWithTag(t *testing.T) {
 		}
 
 		_, err := grsMock.GetGithubReleaseWithTag(ctx, s)
-		damnIt.Expect(err).To(Ω.HaveOccurred())
+		damnIt.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("when the status code is unauthorized and the error is nil", func(t *testing.T) {
 		// yes this happened... how is this not an error?
-		damnIt := Ω.NewWithT(t)
+		damnIt := NewWithT(t)
 
 		defer func() {
 			r := recover()
@@ -382,7 +382,7 @@ func TestGetGithubReleaseWithTag(t *testing.T) {
 		}
 
 		_, err := grsMock.GetGithubReleaseWithTag(ctx, s)
-		damnIt.Expect(err).To(Ω.HaveOccurred())
+		damnIt.Expect(err).To(HaveOccurred())
 	})
 }
 
@@ -390,7 +390,7 @@ func TestGetLatestMatchingRelease(t *testing.T) {
 	strPtr := func(s string) *string { return &s }
 
 	t.Run("when get release with tag api request fails", func(t *testing.T) {
-		damnIt := Ω.NewWithT(t)
+		damnIt := NewWithT(t)
 
 		releaseGetter := new(fakes.ReleasesLister)
 
@@ -446,13 +446,13 @@ func TestGetLatestMatchingRelease(t *testing.T) {
 		}
 
 		rel, err := grsMock.GetLatestMatchingRelease(context.TODO(), s)
-		damnIt.Expect(err).NotTo(Ω.HaveOccurred())
-		damnIt.Expect(rel.GetTagName()).To(Ω.Equal("2.0.4"))
-		damnIt.Expect(releaseGetter.ListReleasesCallCount()).To(Ω.Equal(3))
+		damnIt.Expect(err).NotTo(HaveOccurred())
+		damnIt.Expect(rel.GetTagName()).To(Equal("2.0.4"))
+		damnIt.Expect(releaseGetter.ListReleasesCallCount()).To(Equal(3))
 	})
 
 	t.Run("when some of the github releases tags have a v prefix", func(t *testing.T) {
-		damnIt := Ω.NewWithT(t)
+		damnIt := NewWithT(t)
 
 		releaseGetter := new(fakes.ReleasesLister)
 
@@ -496,9 +496,9 @@ func TestGetLatestMatchingRelease(t *testing.T) {
 		}
 
 		rel, err := grsMock.GetLatestMatchingRelease(context.TODO(), s)
-		damnIt.Expect(err).NotTo(Ω.HaveOccurred())
-		damnIt.Expect(rel.GetTagName()).To(Ω.Equal("v2.0.4"))
-		damnIt.Expect(releaseGetter.ListReleasesCallCount()).To(Ω.Equal(3))
+		damnIt.Expect(err).NotTo(HaveOccurred())
+		damnIt.Expect(rel.GetTagName()).To(Equal("v2.0.4"))
+		damnIt.Expect(releaseGetter.ListReleasesCallCount()).To(Equal(3))
 	})
 
 	t.Run("component repo does not match release source org", func(t *testing.T) {
@@ -525,8 +525,8 @@ func TestGetLatestMatchingRelease(t *testing.T) {
 		_, err := grsMock.GetLatestMatchingRelease(ctx, spec)
 
 		// then
-		please := Ω.NewWithT(t)
-		please.Expect(component.IsErrNotFound(err)).To(Ω.BeTrue())
+		please := NewWithT(t)
+		please.Expect(component.IsErrNotFound(err)).To(BeTrue())
 	})
 }
 
@@ -544,15 +544,15 @@ func TestDownloadReleaseAsset(t *testing.T) {
 	}
 
 	t.Run("when the release is downloaded", func(t *testing.T) {
-		damnIt := Ω.NewWithT(t)
+		damnIt := NewWithT(t)
 		tempDir := t.TempDir()
 		t.Cleanup(func() {
 			_ = os.RemoveAll(tempDir)
 		})
 
 		local, err := grs.DownloadRelease(tempDir, testLock)
-		damnIt.Expect(err).NotTo(Ω.HaveOccurred())
+		damnIt.Expect(err).NotTo(HaveOccurred())
 
-		damnIt.Expect(local.LocalPath).NotTo(Ω.BeAnExistingFile(), "it creates the expected asset")
+		damnIt.Expect(local.LocalPath).NotTo(BeAnExistingFile(), "it creates the expected asset")
 	})
 }

--- a/internal/release/notes_data_test.go
+++ b/internal/release/notes_data_test.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"testing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
@@ -21,7 +21,7 @@ import (
 )
 
 func Test_fetch(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	t.Setenv("GITHUB_TOKEN", "")
 
@@ -110,85 +110,85 @@ func Test_fetch(t *testing.T) {
 	}
 
 	_, err := rn.fetch(context.Background())
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(revisionResolver.ResolveRevisionCallCount()).To(Ω.Equal(2))
-	please.Expect(revisionResolver.ResolveRevisionArgsForCall(0)).To(Ω.Equal(plumbing.Revision("tile/1.1.0")))
-	please.Expect(revisionResolver.ResolveRevisionArgsForCall(1)).To(Ω.Equal(plumbing.Revision("tile/1.2.0")))
+	please.Expect(revisionResolver.ResolveRevisionCallCount()).To(Equal(2))
+	please.Expect(revisionResolver.ResolveRevisionArgsForCall(0)).To(Equal(plumbing.Revision("tile/1.1.0")))
+	please.Expect(revisionResolver.ResolveRevisionArgsForCall(1)).To(Equal(plumbing.Revision("tile/1.2.0")))
 
-	please.Expect(historicVersion.CallCount()).To(Ω.Equal(1))
+	please.Expect(historicVersion.CallCount()).To(Equal(1))
 	_, historicVersionHashArg, _ := historicVersion.ArgsForCall(0)
-	please.Expect(historicVersionHashArg).To(Ω.Equal(finalHash))
-	please.Expect(fakeReleaseService.ListReleasesCallCount()).To(Ω.Equal(2))
-	please.Expect(fakeIssuesService.GetCallCount()).To(Ω.Equal(2))
+	please.Expect(historicVersionHashArg).To(Equal(finalHash))
+	please.Expect(fakeReleaseService.ListReleasesCallCount()).To(Equal(2))
+	please.Expect(fakeIssuesService.GetCallCount()).To(Equal(2))
 
 	_, orgName, repoName, n := fakeIssuesService.GetArgsForCall(0)
-	please.Expect(orgName).To(Ω.Equal("pivotal-cf"))
-	please.Expect(repoName).To(Ω.Equal("fake-tile-repo"))
-	please.Expect(n).To(Ω.Equal(54000))
+	please.Expect(orgName).To(Equal("pivotal-cf"))
+	please.Expect(repoName).To(Equal("fake-tile-repo"))
+	please.Expect(n).To(Equal(54000))
 
 	_, orgName, repoName, n = fakeIssuesService.GetArgsForCall(1)
-	please.Expect(orgName).To(Ω.Equal("pivotal-cf"))
-	please.Expect(repoName).To(Ω.Equal("fake-tile-repo"))
-	please.Expect(n).To(Ω.Equal(54321))
+	please.Expect(orgName).To(Equal("pivotal-cf"))
+	please.Expect(repoName).To(Equal("fake-tile-repo"))
+	please.Expect(n).To(Equal(54321))
 }
 
 func Test_issuesFromIssueIDs(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no ids", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.IssueGetter)
 
 		result, err := issuesFromIssueIDs(context.Background(), issuesService, "o", "n", nil)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(result).To(Ω.HaveLen(0))
-		please.Expect(issuesService.GetCallCount()).To(Ω.Equal(0))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(result).To(HaveLen(0))
+		please.Expect(issuesService.GetCallCount()).To(Equal(0))
 	})
 
 	t.Run("some ids", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.IssueGetter)
 
 		issuesService.GetReturnsOnCall(0, &github.Issue{Number: intPtr(1)}, githubResponse(t, 200), nil)
 		issuesService.GetReturnsOnCall(1, &github.Issue{Number: intPtr(2)}, githubResponse(t, 200), nil)
 
 		result, err := issuesFromIssueIDs(context.Background(), issuesService, "o", "n", []string{"1", "2"})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 
-		please.Expect(result).To(Ω.HaveLen(2))
-		please.Expect(result[0].GetNumber()).To(Ω.Equal(1))
-		please.Expect(result[1].GetNumber()).To(Ω.Equal(2))
+		please.Expect(result).To(HaveLen(2))
+		please.Expect(result[0].GetNumber()).To(Equal(1))
+		please.Expect(result[1].GetNumber()).To(Equal(2))
 
-		please.Expect(issuesService.GetCallCount()).To(Ω.Equal(2))
+		please.Expect(issuesService.GetCallCount()).To(Equal(2))
 		ctx, ro, rn, number := issuesService.GetArgsForCall(0)
-		please.Expect(ctx).NotTo(Ω.BeNil())
-		please.Expect(ro).To(Ω.Equal("o"))
-		please.Expect(rn).To(Ω.Equal("n"))
-		please.Expect(number).To(Ω.Equal(1))
+		please.Expect(ctx).NotTo(BeNil())
+		please.Expect(ro).To(Equal("o"))
+		please.Expect(rn).To(Equal("n"))
+		please.Expect(number).To(Equal(1))
 
 		_, _, _, number = issuesService.GetArgsForCall(1)
-		please.Expect(number).To(Ω.Equal(2))
+		please.Expect(number).To(Equal(2))
 	})
 
 	t.Run("the issues service returns an error", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.IssueGetter)
 
 		issuesService.GetReturnsOnCall(0, &github.Issue{Number: intPtr(1)}, nil, errors.New("banana"))
 
 		_, err := issuesFromIssueIDs(context.Background(), issuesService, "o", "n", []string{"1"})
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("the issues service returns a not okay status", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.IssueGetter)
 
 		issuesService.GetReturnsOnCall(0, &github.Issue{Number: intPtr(1)}, githubResponse(t, http.StatusUnauthorized), nil)
 
 		_, err := issuesFromIssueIDs(context.Background(), issuesService, "o", "n", []string{"1"})
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 }
 
@@ -196,26 +196,26 @@ func Test_resolveMilestoneNumber(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty milestone option", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.MilestoneLister)
 
 		result, err := resolveMilestoneNumber(context.Background(), issuesService, "o", "n", "")
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(result).To(Ω.Equal(""))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(result).To(Equal(""))
 	})
 
 	t.Run("when passed a number", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.MilestoneLister)
 
 		result, err := resolveMilestoneNumber(context.Background(), issuesService, "o", "n", "42")
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(result).To(Ω.Equal("42"), "it returns that number")
-		please.Expect(issuesService.ListMilestonesCallCount()).To(Ω.Equal(0), "it does not reach out o")
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(result).To(Equal("42"), "it returns that number")
+		please.Expect(issuesService.ListMilestonesCallCount()).To(Equal(0), "it does not reach out o")
 	})
 
 	t.Run("when the milestone is found on the second page", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.MilestoneLister)
 
 		issuesService.ListMilestonesReturnsOnCall(0,
@@ -237,31 +237,31 @@ func Test_resolveMilestoneNumber(t *testing.T) {
 
 		result, err := resolveMilestoneNumber(context.Background(), issuesService, "o", "n", "banana")
 
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(issuesService.ListMilestonesCallCount()).To(Ω.Equal(2))
-		please.Expect(result).To(Ω.Equal("42"))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(issuesService.ListMilestonesCallCount()).To(Equal(2))
+		please.Expect(result).To(Equal("42"))
 	})
 
 	// TODO: test pagination
 
 	t.Run("the issues service returns an error", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.MilestoneLister)
 
 		issuesService.ListMilestonesReturns(nil, nil, errors.New("banana"))
 
 		_, err := resolveMilestoneNumber(context.Background(), issuesService, "o", "n", "m")
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("the issues service returns a not okay status", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.MilestoneLister)
 
 		issuesService.ListMilestonesReturns(nil, githubResponse(t, http.StatusUnauthorized), nil)
 
 		_, err := resolveMilestoneNumber(context.Background(), issuesService, "o", "n", "m")
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 }
 
@@ -269,39 +269,39 @@ func Test_fetchIssuesWithLabelAndMilestone(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty milestone and labels", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.IssuesByRepoLister)
 
 		result, err := fetchIssuesWithLabelAndMilestone(context.Background(), issuesService, "o", "n", "", nil)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(result).To(Ω.HaveLen(0))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(result).To(HaveLen(0))
 	})
 
 	// TODO: issue service call params
 
 	t.Run("the issues service returns an error", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.IssuesByRepoLister)
 
 		issuesService.ListByRepoReturns(nil, nil, errors.New("banana"))
 
 		_, err := fetchIssuesWithLabelAndMilestone(context.Background(), issuesService, "o", "n", "1", nil)
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("the issues service returns a not okay status", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		issuesService := new(fakes.IssuesByRepoLister)
 
 		issuesService.ListByRepoReturns(nil, githubResponse(t, http.StatusUnauthorized), nil)
 
 		_, err := fetchIssuesWithLabelAndMilestone(context.Background(), issuesService, "o", "n", "1", nil)
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 }
 
 func Test_issuesBySemanticTitlePrefix(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	issues := []*github.Issue{
 		{Title: strPtr("**[NONE]** lorem ipsum")},
@@ -318,7 +318,7 @@ func Test_issuesBySemanticTitlePrefix(t *testing.T) {
 		titles = append(titles, issue.GetTitle())
 	}
 
-	please.Expect(titles).To(Ω.Equal([]string{
+	please.Expect(titles).To(Equal([]string{
 		"**[security Fix]** 111 lorem ipsum",
 		"**[security fix]** 222 lorem ipsum",
 		"**[Feature]** lorem ipsum",
@@ -329,7 +329,7 @@ func Test_issuesBySemanticTitlePrefix(t *testing.T) {
 }
 
 func Test_appendFilterAndSortIssues(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	getID := func() func() int64 {
 		var n int64
 		return func() int64 {
@@ -358,7 +358,7 @@ func Test_appendFilterAndSortIssues(t *testing.T) {
 		titles = append(titles, issue.GetTitle())
 	}
 
-	please.Expect(titles).To(Ω.Equal([]string{
+	please.Expect(titles).To(Equal([]string{
 		"**[security Fix]** 111 lorem ipsum",
 		"**[security fix]** 222 lorem ipsum",
 		"**[Feature]** lorem ipsum",
@@ -369,24 +369,24 @@ func Test_appendFilterAndSortIssues(t *testing.T) {
 }
 
 func TestReleaseNotes_Options_IssueTitleExp(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	exp, err := IssuesQuery{}.Exp()
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(exp.MatchString("**[Bug Fix]** Lorem Ipsum")).To(Ω.BeTrue())
-	please.Expect(exp.MatchString("**[bug fix]** Lorem Ipsum")).To(Ω.BeTrue())
-	please.Expect(exp.MatchString("**[Feature]** Lorem Ipsum")).To(Ω.BeTrue())
-	please.Expect(exp.MatchString("**[feature improvement]** Lorem Ipsum")).To(Ω.BeTrue())
-	please.Expect(exp.MatchString("**[security fix]** Lorem Ipsum")).To(Ω.BeTrue())
+	please.Expect(exp.MatchString("**[Bug Fix]** Lorem Ipsum")).To(BeTrue())
+	please.Expect(exp.MatchString("**[bug fix]** Lorem Ipsum")).To(BeTrue())
+	please.Expect(exp.MatchString("**[Feature]** Lorem Ipsum")).To(BeTrue())
+	please.Expect(exp.MatchString("**[feature improvement]** Lorem Ipsum")).To(BeTrue())
+	please.Expect(exp.MatchString("**[security fix]** Lorem Ipsum")).To(BeTrue())
 
-	please.Expect(exp.MatchString("**[none]** Lorem Ipsum")).To(Ω.BeFalse())
-	please.Expect(exp.MatchString("**[none]** feature bug fix security")).To(Ω.BeFalse())
-	please.Expect(exp.MatchString("Lorem Ipsum")).To(Ω.BeFalse())
-	please.Expect(exp.MatchString("")).To(Ω.BeFalse())
-	please.Expect(exp.MatchString("**[]**")).To(Ω.BeFalse())
-	please.Expect(exp.MatchString("**[bugFix]**")).To(Ω.BeFalse())
-	please.Expect(exp.MatchString("**[security]**")).To(Ω.BeFalse())
+	please.Expect(exp.MatchString("**[none]** Lorem Ipsum")).To(BeFalse())
+	please.Expect(exp.MatchString("**[none]** feature bug fix security")).To(BeFalse())
+	please.Expect(exp.MatchString("Lorem Ipsum")).To(BeFalse())
+	please.Expect(exp.MatchString("")).To(BeFalse())
+	please.Expect(exp.MatchString("**[]**")).To(BeFalse())
+	please.Expect(exp.MatchString("**[bugFix]**")).To(BeFalse())
+	please.Expect(exp.MatchString("**[security]**")).To(BeFalse())
 }
 
 func getIssueTitleExp(t *testing.T) string {

--- a/internal/release/notes_page_test.go
+++ b/internal/release/notes_page_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/Masterminds/semver"
 	"github.com/go-git/go-billy/v5/memfs"
@@ -27,18 +27,18 @@ import (
 var releaseNotesPageTAS27 string
 
 func TestParseNotesPage(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	t0, err := time.Parse("2006-01-02", "2021-11-23")
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
 	someDeveloper := &object.Signature{Name: "author", Email: "email", When: t0}
 
 	// setup docs repo with initial state
 	repo, err := git.Init(memory.NewStorage(), memfs.New())
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 	wt, err := repo.Worktree()
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 	{
 		notesMD, _ := wt.Filesystem.Create("notes.md")
 		_, _ = notesMD.Write([]byte(releaseNotesPageTAS27))
@@ -49,12 +49,12 @@ func TestParseNotesPage(t *testing.T) {
 			Author:    someDeveloper,
 			Committer: someDeveloper,
 		})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 	}
 	// parse release notes
 	page, err := ParseNotesPage(releaseNotesPageTAS27)
-	please.Expect(err).NotTo(Ω.HaveOccurred())
-	please.Expect(page.Releases).To(Ω.HaveLen(42))
+	please.Expect(err).NotTo(HaveOccurred())
+	please.Expect(page.Releases).To(HaveLen(42))
 
 	// assign new release notes data
 	alreadyPublishedReleaseNotesData := NotesData{
@@ -138,25 +138,25 @@ func TestParseNotesPage(t *testing.T) {
 	}
 
 	alreadyPublishedVersionNote, err := alreadyPublishedReleaseNotesData.WriteVersionNotes()
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
 	err = page.Add(alreadyPublishedVersionNote)
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
 	notesMD, _ := wt.Filesystem.Create("notes.md")
 	pageContent := new(bytes.Buffer)
 	_, err = page.WriteTo(io.MultiWriter(notesMD, pageContent))
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 	_ = notesMD.Close()
 	_, _ = wt.Add(notesMD.Name())
 	status, err := wt.Status()
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 	if !status.IsClean() {
 		_ = os.WriteFile("exp.txt", []byte(releaseNotesPageTAS27), fs.ModePerm)
 		_ = os.WriteFile("got.txt", pageContent.Bytes(), fs.ModePerm)
 		t.Logf("run: %q", "diff --unified internal/release/{exp,got}.txt | colordiff")
 	}
-	please.Expect(status.IsClean()).To(Ω.BeTrue())
+	please.Expect(status.IsClean()).To(BeTrue())
 }
 
 func TestParseNotesPageWithExpressionAndReleasesSentinel(t *testing.T) {
@@ -164,15 +164,15 @@ func TestParseNotesPageWithExpressionAndReleasesSentinel(t *testing.T) {
 	exp := regexp.MustCompile(`(?m)(?P<notes>r(?P<version>\d+)\.*)`).String()
 
 	t.Run("multiple releases", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		input := "prefix.releases:r1.r2..r3r4...r5...suffix"
 
 		page, err := ParseNotesPageWithExpressionAndReleasesSentinel(input, exp, testReleasesSentinel)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 
-		please.Expect(page.Releases).To(Ω.HaveLen(5))
-		please.Expect(page.Releases).To(Ω.Equal([]VersionNote{
+		please.Expect(page.Releases).To(HaveLen(5))
+		please.Expect(page.Releases).To(Equal([]VersionNote{
 			{Version: "1", Notes: "r1."},
 			{Version: "2", Notes: "r2.."},
 			{Version: "3", Notes: "r3"},
@@ -180,73 +180,73 @@ func TestParseNotesPageWithExpressionAndReleasesSentinel(t *testing.T) {
 			{Version: "5", Notes: "r5..."},
 		}))
 
-		please.Expect(page.Prefix).To(Ω.Equal("prefix.releases:"))
-		please.Expect(page.Suffix).To(Ω.Equal("suffix"))
+		please.Expect(page.Prefix).To(Equal("prefix.releases:"))
+		please.Expect(page.Suffix).To(Equal("suffix"))
 	})
 
 	t.Run("no releases", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		input := "prefix.releases:suffix"
 
 		page, err := ParseNotesPageWithExpressionAndReleasesSentinel(input, exp, testReleasesSentinel)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 
-		please.Expect(page.Releases).To(Ω.HaveLen(0))
-		please.Expect(page.Prefix).To(Ω.Equal("prefix.releases:"))
-		please.Expect(page.Suffix).To(Ω.Equal("suffix"))
+		please.Expect(page.Releases).To(HaveLen(0))
+		please.Expect(page.Prefix).To(Equal("prefix.releases:"))
+		please.Expect(page.Suffix).To(Equal("suffix"))
 	})
 }
 
 func Test_newFetchNotesData(t *testing.T) {
 	t.Run("when called", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		f, err := newFetchNotesData(&git.Repository{}, "o", "r", "k", "ri", "rf", nil, IssuesQuery{
 			IssueMilestone: "BLA",
 		})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(f.repoOwner).To(Ω.Equal("o"))
-		please.Expect(f.repoName).To(Ω.Equal("r"))
-		please.Expect(f.kilnfilePath).To(Ω.Equal("k"))
-		please.Expect(f.initialRevision).To(Ω.Equal("ri"))
-		please.Expect(f.finalRevision).To(Ω.Equal("rf"))
-		please.Expect(f.historicKilnfile).NotTo(Ω.BeNil())
-		please.Expect(f.historicVersion).NotTo(Ω.BeNil())
-		please.Expect(f.issuesQuery).To(Ω.Equal(IssuesQuery{
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(f.repoOwner).To(Equal("o"))
+		please.Expect(f.repoName).To(Equal("r"))
+		please.Expect(f.kilnfilePath).To(Equal("k"))
+		please.Expect(f.initialRevision).To(Equal("ri"))
+		please.Expect(f.finalRevision).To(Equal("rf"))
+		please.Expect(f.historicKilnfile).NotTo(BeNil())
+		please.Expect(f.historicVersion).NotTo(BeNil())
+		please.Expect(f.issuesQuery).To(Equal(IssuesQuery{
 			IssueMilestone: "BLA",
 		}))
 	})
 	t.Run("when repo is nil", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		_, err := newFetchNotesData(nil, "o", "r", "k", "ri", "rf", &github.Client{}, IssuesQuery{})
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 	t.Run("when repo is not nil", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		f, err := newFetchNotesData(&git.Repository{
 			Storer: &memory.Storage{},
 		}, "o", "r", "k", "ri", "rf", &github.Client{}, IssuesQuery{})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(f.repository).NotTo(Ω.BeNil())
-		please.Expect(f.revisionResolver).NotTo(Ω.BeNil())
-		please.Expect(f.Storer).NotTo(Ω.BeNil())
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(f.repository).NotTo(BeNil())
+		please.Expect(f.revisionResolver).NotTo(BeNil())
+		please.Expect(f.Storer).NotTo(BeNil())
 	})
 	t.Run("when github client is not nil", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		f, err := newFetchNotesData(&git.Repository{}, "o", "r", "k", "ri", "rf", &github.Client{
 			Issues:       &github.IssuesService{},
 			Repositories: &github.RepositoriesService{},
 		}, IssuesQuery{})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(f.issuesService).NotTo(Ω.BeNil())
-		please.Expect(f.releasesService).NotTo(Ω.BeNil())
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(f.issuesService).NotTo(BeNil())
+		please.Expect(f.releasesService).NotTo(BeNil())
 	})
 	t.Run("when github client is nil", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		f, err := newFetchNotesData(&git.Repository{}, "o", "r", "k", "ri", "rf", nil, IssuesQuery{})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(f.issuesService).To(Ω.BeNil())
-		please.Expect(f.releasesService).To(Ω.BeNil())
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(f.issuesService).To(BeNil())
+		please.Expect(f.releasesService).To(BeNil())
 	})
 }
 
@@ -259,17 +259,17 @@ func TestReleaseNotesPage_Add(t *testing.T) {
 	//   The release notes for tile 2.7.43 were inserted at the top of the document (index 0)
 
 	t.Run("initial release", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		page := NotesPage{
 			Exp: regexp.MustCompile(`r\d+`), // a simpler release expression
 		}
 		note := VersionNote{Version: "1", Notes: "r1"}
 		err := page.Add(note)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(page.Releases).To(Ω.ConsistOf(note))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(page.Releases).To(ConsistOf(note))
 	})
 	t.Run("new latest release", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		page := NotesPage{
 			Exp: regexp.MustCompile(`r\d+`),
 			Releases: []VersionNote{
@@ -278,14 +278,14 @@ func TestReleaseNotesPage_Add(t *testing.T) {
 		}
 		newNote := VersionNote{Version: "3", Notes: "r3"}
 		err := page.Add(newNote)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(page.Releases).To(Ω.Equal([]VersionNote{
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(page.Releases).To(Equal([]VersionNote{
 			{Version: "3", Notes: "r3"},
 			{Version: "2", Notes: "r2"},
 		}))
 	})
 	t.Run("update existing release notes", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		page := NotesPage{
 			Exp: regexp.MustCompile(`r\d+`),
 			Releases: []VersionNote{
@@ -294,13 +294,13 @@ func TestReleaseNotesPage_Add(t *testing.T) {
 		}
 		newNote := VersionNote{Version: "1", Notes: "r2"}
 		err := page.Add(newNote)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(page.Releases).To(Ω.Equal([]VersionNote{
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(page.Releases).To(Equal([]VersionNote{
 			{Version: "1", Notes: "r2"},
 		}))
 	})
 	t.Run("insert between", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		page := NotesPage{
 			Exp: regexp.MustCompile(`r\d+`),
 			Releases: []VersionNote{
@@ -310,15 +310,15 @@ func TestReleaseNotesPage_Add(t *testing.T) {
 		}
 		newNote := VersionNote{Version: "2", Notes: "r2"}
 		err := page.Add(newNote)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(page.Releases).To(Ω.Equal([]VersionNote{
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(page.Releases).To(Equal([]VersionNote{
 			{Version: "3", Notes: "r3"},
 			{Version: "2", Notes: "r2"},
 			{Version: "1", Notes: "r1"},
 		}))
 	})
 	t.Run("notes version field is invalid", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		page := NotesPage{
 			Exp: regexp.MustCompile(`r\d+`),
 			Releases: []VersionNote{
@@ -327,10 +327,10 @@ func TestReleaseNotesPage_Add(t *testing.T) {
 		}
 		newNote := VersionNote{Version: "s", Notes: "r2"}
 		err := page.Add(newNote)
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 	t.Run("add notes to end", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		page := NotesPage{
 			Exp: regexp.MustCompile(`r\d+`),
 			Releases: []VersionNote{
@@ -340,15 +340,15 @@ func TestReleaseNotesPage_Add(t *testing.T) {
 		}
 		newNote := VersionNote{Version: "1", Notes: "r1"}
 		err := page.Add(newNote)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(page.Releases).To(Ω.Equal([]VersionNote{
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(page.Releases).To(Equal([]VersionNote{
 			{Version: "3", Notes: "r3"},
 			{Version: "2", Notes: "r2"},
 			{Version: "1", Notes: "r1"},
 		}))
 	})
 	t.Run("notes content does not match page regex", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		page := NotesPage{
 			Exp: regexp.MustCompile(`r\d+`),
 			Releases: []VersionNote{
@@ -357,7 +357,7 @@ func TestReleaseNotesPage_Add(t *testing.T) {
 		}
 		newNote := VersionNote{Version: "2", Notes: "s2"}
 		err := page.Add(newNote)
-		please.Expect(err).To(Ω.HaveOccurred())
+		please.Expect(err).To(HaveOccurred())
 	})
 }
 

--- a/internal/release/notes_template_test.go
+++ b/internal/release/notes_template_test.go
@@ -7,16 +7,16 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/google/go-github/v40/github"
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/pivotal-cf/kiln/internal/component"
 )
 
 func Test_defaultReleaseNotesTemplate(t *testing.T) {
 	t.Run("empty github release body", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		tmp, err := DefaultTemplateFuncs(template.New("")).Parse(DefaultNotesTemplate())
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 		var b bytes.Buffer
 		err = tmp.Execute(&b, NotesData{
 			Version: semver.MustParse("0.0"),
@@ -30,7 +30,7 @@ func Test_defaultReleaseNotesTemplate(t *testing.T) {
 				},
 			},
 		})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(b.String()).To(Ω.ContainSubstring("<tr><td>banana</td><td>1.2</td><td></td></tr>"))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(b.String()).To(ContainSubstring("<tr><td>banana</td><td>1.2</td><td></td></tr>"))
 	})
 }

--- a/pkg/cargo/kilnfile_helpers_test.go
+++ b/pkg/cargo/kilnfile_helpers_test.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 	"testing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
 
 func TestInterpolateAndParseKilnfile(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	variables := map[string]interface{}{
 		"bucket":        "my-bucket",
@@ -25,9 +25,9 @@ func TestInterpolateAndParseKilnfile(t *testing.T) {
 		strings.NewReader(validKilnfile), variables,
 	)
 
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(kilnfile).To(Ω.Equal(cargo.Kilnfile{
+	please.Expect(kilnfile).To(Equal(cargo.Kilnfile{
 		ReleaseSources: []cargo.ReleaseSourceConfig{
 			{
 				Type:            "s3",
@@ -42,7 +42,7 @@ func TestInterpolateAndParseKilnfile(t *testing.T) {
 }
 
 func TestInterpolateAndParseKilnfile_input_is_not_valid_yaml(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	variables := map[string]interface{}{
 		"bucket":        "my-bucket",
@@ -57,11 +57,11 @@ func TestInterpolateAndParseKilnfile_input_is_not_valid_yaml(t *testing.T) {
 		strings.NewReader("invalid : bad : yaml"), variables,
 	)
 
-	please.Expect(err).To(Ω.HaveOccurred())
+	please.Expect(err).To(HaveOccurred())
 }
 
 func TestInterpolateAndParseKilnfile_interpolation_variable_not_found(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	variables := map[string]interface{}{
 		"bucket": "my-bucket",
@@ -76,7 +76,7 @@ func TestInterpolateAndParseKilnfile_interpolation_variable_not_found(t *testing
 		strings.NewReader(validKilnfile), variables,
 	)
 
-	please.Expect(err).To(Ω.HaveOccurred())
+	please.Expect(err).To(HaveOccurred())
 }
 
 const validKilnfile = `---

--- a/pkg/cargo/kilnfile_test.go
+++ b/pkg/cargo/kilnfile_test.go
@@ -3,7 +3,7 @@ package cargo
 import (
 	"testing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 )
 
@@ -14,7 +14,7 @@ version: fake-version
 remote_source: fake-source
 remote_path: fake/path/to/fake-component-name
 `
-	damnit := Ω.NewWithT(t)
+	damnit := NewWithT(t)
 
 	cl, err := yaml.Marshal(ComponentLock{
 		Name:         "fake-component-name",
@@ -24,6 +24,6 @@ remote_path: fake/path/to/fake-component-name
 		RemotePath:   "fake/path/to/fake-component-name",
 	})
 
-	damnit.Expect(err).NotTo(Ω.HaveOccurred())
-	damnit.Expect(string(cl)).To(Ω.Equal(validComponentLockYaml))
+	damnit.Expect(err).NotTo(HaveOccurred())
+	damnit.Expect(string(cl)).To(Equal(validComponentLockYaml))
 }

--- a/pkg/cargo/kilnfile_validate_test.go
+++ b/pkg/cargo/kilnfile_validate_test.go
@@ -3,12 +3,12 @@ package cargo
 import (
 	"testing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestValidate_MissingName(t *testing.T) {
 	t.Parallel()
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	results := Validate(Kilnfile{
 		Releases: []ComponentSpec{
 			{},
@@ -18,12 +18,12 @@ func TestValidate_MissingName(t *testing.T) {
 			{Name: "banana", Version: "1.2.3"},
 		},
 	})
-	please.Expect(results).To(Ω.HaveLen(1))
+	please.Expect(results).To(HaveLen(1))
 }
 
 func TestValidate_FloatingRelease(t *testing.T) {
 	t.Parallel()
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	results := Validate(Kilnfile{
 		Releases: []ComponentSpec{
 			{Name: "banana", Version: "1.1.*"},
@@ -33,23 +33,23 @@ func TestValidate_FloatingRelease(t *testing.T) {
 			{Name: "banana", Version: "1.1.12"},
 		},
 	})
-	please.Expect(results).To(Ω.HaveLen(0))
+	please.Expect(results).To(HaveLen(0))
 }
 
 func TestValidate_MissingLock(t *testing.T) {
 	t.Parallel()
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	results := Validate(Kilnfile{
 		Releases: []ComponentSpec{
 			{Name: "banana", Version: "1.1.*"},
 		},
 	}, KilnfileLock{})
-	please.Expect(results).To(Ω.HaveLen(1))
+	please.Expect(results).To(HaveLen(1))
 }
 
 func TestValidate_InvalidConstraint(t *testing.T) {
 	t.Parallel()
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	results := Validate(Kilnfile{
 		Releases: []ComponentSpec{
 			{Name: "banana", Version: "NOT A CONSTRAINT"},
@@ -59,12 +59,12 @@ func TestValidate_InvalidConstraint(t *testing.T) {
 			{Name: "banana", Version: "1.2.3"},
 		},
 	})
-	please.Expect(results).To(Ω.HaveLen(1))
+	please.Expect(results).To(HaveLen(1))
 }
 
 func TestValidate_PinnedRelease(t *testing.T) {
 	t.Parallel()
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 	results := Validate(Kilnfile{
 		Releases: []ComponentSpec{
 			{Name: "banana", Version: "1.2.3"},
@@ -74,12 +74,12 @@ func TestValidate_PinnedRelease(t *testing.T) {
 			{Name: "banana", Version: "1.2.3"},
 		},
 	})
-	please.Expect(results).To(Ω.HaveLen(0))
+	please.Expect(results).To(HaveLen(0))
 }
 
 func TestValidate_checkComponentVersionsAndConstraint(t *testing.T) {
 	t.Run("no version", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		r := ComponentSpec{
 			Name: "capi",
 		}
@@ -88,11 +88,11 @@ func TestValidate_checkComponentVersionsAndConstraint(t *testing.T) {
 			Version: "2.3.4",
 		}
 		err := checkComponentVersionsAndConstraint(r, l, 0)
-		please.Expect(err).NotTo(Ω.HaveOccurred())
+		please.Expect(err).NotTo(HaveOccurred())
 	})
 
 	t.Run("invalid version constraint", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		r := ComponentSpec{
 			Name:    "capi",
 			Version: "meh",
@@ -102,14 +102,14 @@ func TestValidate_checkComponentVersionsAndConstraint(t *testing.T) {
 			Version: "2.3.4",
 		}
 		err := checkComponentVersionsAndConstraint(r, l, 0)
-		please.Expect(err).To(Ω.And(
-			Ω.HaveOccurred(),
-			Ω.MatchError(Ω.ContainSubstring("invalid version constraint")),
+		please.Expect(err).To(And(
+			HaveOccurred(),
+			MatchError(ContainSubstring("invalid version constraint")),
 		))
 	})
 
 	t.Run("version does not match constraint", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		r := ComponentSpec{
 			Name:    "capi",
 			Version: "~2",
@@ -119,14 +119,14 @@ func TestValidate_checkComponentVersionsAndConstraint(t *testing.T) {
 			Version: "3.0.5",
 		}
 		err := checkComponentVersionsAndConstraint(r, l, 0)
-		please.Expect(err).To(Ω.And(
-			Ω.HaveOccurred(),
-			Ω.MatchError(Ω.ContainSubstring("match constraint")),
+		please.Expect(err).To(And(
+			HaveOccurred(),
+			MatchError(ContainSubstring("match constraint")),
 		))
 	})
 
 	t.Run("invalid lock version", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 		r := ComponentSpec{
 			Name:    "capi",
 			Version: "~2",
@@ -136,9 +136,9 @@ func TestValidate_checkComponentVersionsAndConstraint(t *testing.T) {
 			Version: "BAD",
 		}
 		err := checkComponentVersionsAndConstraint(r, l, 0)
-		please.Expect(err).To(Ω.And(
-			Ω.HaveOccurred(),
-			Ω.MatchError(Ω.ContainSubstring("invalid lock version")),
+		please.Expect(err).To(And(
+			HaveOccurred(),
+			MatchError(ContainSubstring("invalid lock version")),
 		))
 	})
 }

--- a/pkg/history/historic_test.go
+++ b/pkg/history/historic_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
@@ -17,7 +17,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	// START setup
 	tileDir := "tile"
@@ -51,15 +51,15 @@ func TestVersion(t *testing.T) {
 	t.Run("alpha", func(t *testing.T) {
 		version, err := Version(repo.Storer, initialHash, "tile")
 
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(version).To(Ω.Equal("1.0.0-alpha.1"))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(version).To(Equal("1.0.0-alpha.1"))
 	})
 
 	t.Run("ga release", func(t *testing.T) {
 		version, err := Version(repo.Storer, finalHash, "tile")
 
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(version).To(Ω.Equal("1.0.0"))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(version).To(Equal("1.0.0"))
 	})
 }
 
@@ -120,24 +120,24 @@ func TestKilnfile(t *testing.T) {
 	// END setup
 
 	t.Run("legacy bill of materials", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		_, kl, err := Kilnfile(repo.Storer, initialHash, "tile")
 
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(kl.Releases).To(Ω.Equal([]cargo.ComponentLock{
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(kl.Releases).To(Equal([]cargo.ComponentLock{
 			{Name: "banana", Version: "0.1.0"},
 			{Name: "lemon", Version: "1.1.0"},
 		}))
 	})
 
 	t.Run("Kilnfile.lock", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		_, finalKF, err := Kilnfile(repo.Storer, finalHash, "tile/Kilnfile")
 
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(finalKF.Releases).To(Ω.Equal([]cargo.ComponentLock{
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(finalKF.Releases).To(Equal([]cargo.ComponentLock{
 			{Name: "banana", Version: "0.9.0"},
 			{Name: "lemon", Version: "1.9.0"},
 			{Name: "apple", Version: "0.0.1"},
@@ -145,23 +145,23 @@ func TestKilnfile(t *testing.T) {
 	})
 
 	t.Run("Kilnfile", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		kf, _, err := Kilnfile(repo.Storer, finalHash, "tile")
 
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(kf.Releases).To(Ω.Equal([]cargo.ComponentSpec{
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(kf.Releases).To(Equal([]cargo.ComponentSpec{
 			{Name: "banana"},
 			{Name: "lemon"},
 		}))
 	})
 
 	t.Run("bad yaml", func(t *testing.T) {
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		_, _, err := Kilnfile(repo.Storer, badYAML, "tile")
 
-		please.Expect(err).To(Ω.MatchError(Ω.ContainSubstring("cannot unmarshal")))
+		please.Expect(err).To(MatchError(ContainSubstring("cannot unmarshal")))
 	})
 }
 
@@ -217,15 +217,15 @@ func TestWalk(t *testing.T) {
 		}, h1)
 		// END setup
 
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		callCount := 0
 		err := Walk(repo.Storer, hf, func(*object.Commit) error {
 			callCount++
 			return nil
 		})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(callCount).To(Ω.Equal(3))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(callCount).To(Equal(3))
 	})
 
 	t.Run("with branch", func(t *testing.T) {
@@ -277,15 +277,15 @@ func TestWalk(t *testing.T) {
 		}, h1, b2)
 		// END setup
 
-		please := Ω.NewWithT(t)
+		please := NewWithT(t)
 
 		callCount := 0
 		err := Walk(repo.Storer, hf, func(*object.Commit) error {
 			callCount++
 			return nil
 		})
-		please.Expect(err).NotTo(Ω.HaveOccurred())
-		please.Expect(callCount).To(Ω.Equal(5))
+		please.Expect(err).NotTo(HaveOccurred())
+		please.Expect(callCount).To(Equal(5))
 	})
 }
 

--- a/pkg/tile/metadata_test.go
+++ b/pkg/tile/metadata_test.go
@@ -3,23 +3,23 @@ package tile_test
 import (
 	"testing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 
 	"github.com/pivotal-cf/kiln/pkg/tile"
 )
 
 func TestReadMetadataFromFile(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	metadataBytes, err := tile.ReadMetadataFromFile("testdata/tile-0.1.2.pivotal")
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
 	var metadata struct {
 		Name string `yaml:"name"`
 	}
 	err = yaml.Unmarshal(metadataBytes, &metadata)
-	please.Expect(err).NotTo(Ω.HaveOccurred(), string(metadataBytes))
+	please.Expect(err).NotTo(HaveOccurred(), string(metadataBytes))
 
-	please.Expect(metadata.Name).To(Ω.Equal("hello"), string(metadataBytes))
+	please.Expect(metadata.Name).To(Equal("hello"), string(metadataBytes))
 }

--- a/pkg/tile/releases_test.go
+++ b/pkg/tile/releases_test.go
@@ -7,19 +7,19 @@ import (
 
 	"github.com/pivotal-cf/kiln/pkg/proofing"
 
-	Ω "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/pivotal-cf/kiln/pkg/tile"
 )
 
 func TestReadReleaseFromFile(t *testing.T) {
-	please := Ω.NewWithT(t)
+	please := NewWithT(t)
 
 	buf := bytes.NewBuffer(nil)
 	releaseMetadata, err := tile.ReadReleaseFromFile("testdata/tile-0.1.2.pivotal", "hello-release", "v0.1.4", buf)
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 
-	please.Expect(releaseMetadata).To(Ω.Equal(proofing.Release{
+	please.Expect(releaseMetadata).To(Equal(proofing.Release{
 		File:    "hello-release-v0.1.4-ubuntu-xenial-621.256.tgz",
 		Name:    "hello-release",
 		SHA1:    "c471ac6371eb8fc24508b14d9a49a44f9a5ef98c",
@@ -27,5 +27,5 @@ func TestReadReleaseFromFile(t *testing.T) {
 	}))
 
 	_, err = io.ReadAll(buf)
-	please.Expect(err).NotTo(Ω.HaveOccurred())
+	please.Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
this makes it easier for non-mac developers to contribute