### PR TITLE
feat: fetch release notes for component bumps from trainstat

### DIFF
--- a/internal/commands/release_notes.go
+++ b/internal/commands/release_notes.go
@@ -46,7 +46,7 @@ type ReleaseNotes struct {
 	repoOwner, repoName string
 }
 
-type FetchNotesData func(ctx context.Context, repo *git.Repository, client *github.Client, tileRepoOwner, tileRepoName, kilnfilePath, initialRevision, finalRevision string, issuesQuery notes.IssuesQuery, trainstatClient notes.TrainstatFetcher) (notes.Data, error)
+type FetchNotesData func(ctx context.Context, repo *git.Repository, client *github.Client, tileRepoOwner, tileRepoName, kilnfilePath, initialRevision, finalRevision string, issuesQuery notes.IssuesQuery, trainstatClient notes.TrainstatNotesFetcher) (notes.Data, error)
 
 func NewReleaseNotesCommand() (ReleaseNotes, error) {
 	return ReleaseNotes{
@@ -87,7 +87,7 @@ func (r ReleaseNotes) Execute(args []string) error {
 		client = gh.Client(ctx, r.Options.GithubToken)
 	}
 
-	var trainstatClient = notes.NewTrainstatClient(r.Options.TrainstatQuery.TrainstatUrl)
+	var trainstatClient = notes.NewTrainstatClient(r.Options.TrainstatQuery.TrainstatURL)
 
 	_ = notes.FetchData // fetchNotesData is github.com/pivotal/kiln/internal/notes.FetchData
 	data, err := r.fetchNotesData(ctx,

--- a/internal/commands/release_notes_test.go
+++ b/internal/commands/release_notes_test.go
@@ -72,7 +72,7 @@ func TestReleaseNotes_Execute(t *testing.T) {
 			repoOwner:  "bunch",
 			repoName:   "banana",
 			readFile:   readFileFunc,
-			fetchNotesData: func(c context.Context, repo *git.Repository, ghc *github.Client, tro, trn, kfp, ir, fr string, iq notes.IssuesQuery) (notes.Data, error) {
+			fetchNotesData: func(c context.Context, repo *git.Repository, ghc *github.Client, tro, trn, kfp, ir, fr string, iq notes.IssuesQuery, tf notes.TrainstatFetcher) (notes.Data, error) {
 				ctx, repository, client = c, repo, ghc
 				tileRepoOwner, tileRepoName, kilnfilePath, initialRevision, finalRevision = tro, trn, kfp, ir, fr
 				issuesQuery = iq
@@ -95,6 +95,10 @@ func TestReleaseNotes_Execute(t *testing.T) {
 					},
 					Bumps: cargo.BumpList{
 						{Name: "banana", FromVersion: "1.1.0", ToVersion: "1.2.0"},
+					},
+					TrainstatNotes: []string{
+						"* **[Feature]** this is a feature.",
+						"* **[Bug Fix]** this is a bug fix.",
 					},
 				}, nil
 			},

--- a/internal/commands/release_notes_test.go
+++ b/internal/commands/release_notes_test.go
@@ -72,7 +72,7 @@ func TestReleaseNotes_Execute(t *testing.T) {
 			repoOwner:  "bunch",
 			repoName:   "banana",
 			readFile:   readFileFunc,
-			fetchNotesData: func(c context.Context, repo *git.Repository, ghc *github.Client, tro, trn, kfp, ir, fr string, iq notes.IssuesQuery, tf notes.TrainstatFetcher) (notes.Data, error) {
+			fetchNotesData: func(c context.Context, repo *git.Repository, ghc *github.Client, tro, trn, kfp, ir, fr string, iq notes.IssuesQuery, _ notes.TrainstatNotesFetcher) (notes.Data, error) {
 				ctx, repository, client = c, repo, ghc
 				tileRepoOwner, tileRepoName, kilnfilePath, initialRevision, finalRevision = tro, trn, kfp, ir, fr
 				issuesQuery = iq

--- a/internal/commands/testdata/release_notes_output.md
+++ b/internal/commands/testdata/release_notes_output.md
@@ -4,6 +4,8 @@
 
 * **[Feature Improvement]** Reduce default log-cache max per source
 * **[Bug Fix]** banana metadata migration does not fail on upgrade from previous LTS
+* **[Feature]** this is a feature.
+* **[Bug Fix]** this is a bug fix.
 * Bump banana to version `1.2.0`
 
 <table border="1" class="nice">

--- a/pkg/notes/fakes/trainstat_client.go
+++ b/pkg/notes/fakes/trainstat_client.go
@@ -1,0 +1,103 @@
+package fakes
+
+import (
+	"sync"
+)
+
+type TrainstatClient struct {
+	FetchStub          func(milestone string, version string, tile string) ([]string, error)
+	fetchMutex         sync.RWMutex
+	fetchReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
+	fetchArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	fetchReturns struct {
+		result1 []string
+		result2 error
+	}
+	invocations      map[string][][]interface{}
+	invocationsMutex sync.RWMutex
+}
+
+func (fake *TrainstatClient) FetchTrainstatNotes(arg1 string, arg2 string, arg3 string) (notes []string, err error) {
+	fake.fetchMutex.Lock()
+	ret, specificReturn := fake.fetchReturnsOnCall[len(fake.fetchArgsForCall)]
+	fake.fetchArgsForCall = append(fake.fetchArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.FetchStub
+	fakeReturns := fake.fetchReturns
+	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})
+	fake.fetchMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *TrainstatClient) FetchReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.fetchMutex.Lock()
+	defer fake.fetchMutex.Unlock()
+	fake.FetchStub = nil
+	if fake.fetchReturnsOnCall == nil {
+		fake.fetchReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.fetchReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *TrainstatClient) GetCallCount() int {
+	fake.fetchMutex.RLock()
+	defer fake.fetchMutex.RUnlock()
+	return len(fake.fetchArgsForCall)
+}
+
+func (fake *TrainstatClient) GetCalls(stub func(string, string, string) ([]string, error)) {
+	fake.fetchMutex.Lock()
+	defer fake.fetchMutex.Unlock()
+	fake.FetchStub = stub
+}
+
+func (fake *TrainstatClient) GetArgsForCall(i int) (string, string, string) {
+	fake.fetchMutex.RLock()
+	defer fake.fetchMutex.RUnlock()
+	argsForCall := fake.fetchArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *TrainstatClient) Invocations() map[string][][]interface{} {
+	fake.invocationsMutex.RLock()
+	defer fake.invocationsMutex.RUnlock()
+	copiedInvocations := map[string][][]interface{}{}
+	for key, value := range fake.invocations {
+		copiedInvocations[key] = value
+	}
+	return copiedInvocations
+}
+
+func (fake *TrainstatClient) recordInvocation(key string, args []interface{}) {
+	fake.invocationsMutex.Lock()
+	defer fake.invocationsMutex.Unlock()
+	if fake.invocations == nil {
+		fake.invocations = map[string][][]interface{}{}
+	}
+	if fake.invocations[key] == nil {
+		fake.invocations[key] = [][]interface{}{}
+	}
+	fake.invocations[key] = append(fake.invocations[key], args)
+}

--- a/pkg/notes/fakes/trainstat_client.go
+++ b/pkg/notes/fakes/trainstat_client.go
@@ -1,6 +1,7 @@
 package fakes
 
 import (
+	"context"
 	"sync"
 )
 
@@ -12,6 +13,7 @@ type TrainstatClient struct {
 		result2 error
 	}
 	fetchArgsForCall []struct {
+		ctx  context.Context
 		arg1 string
 		arg2 string
 		arg3 string
@@ -24,14 +26,15 @@ type TrainstatClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TrainstatClient) FetchTrainstatNotes(arg1 string, arg2 string, arg3 string) (notes []string, err error) {
+func (fake *TrainstatClient) FetchTrainstatNotes(ctx context.Context, arg1 string, arg2 string, arg3 string) (notes []string, err error) {
 	fake.fetchMutex.Lock()
 	ret, specificReturn := fake.fetchReturnsOnCall[len(fake.fetchArgsForCall)]
 	fake.fetchArgsForCall = append(fake.fetchArgsForCall, struct {
+		ctx  context.Context
 		arg1 string
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+	}{ctx, arg1, arg2, arg3})
 	stub := fake.FetchStub
 	fakeReturns := fake.fetchReturns
 	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})

--- a/pkg/notes/notes.go.md
+++ b/pkg/notes/notes.go.md
@@ -29,6 +29,9 @@
 {{range .Issues -}}
   * {{.GetTitle}}
 {{ end -}}
+{{range .TrainstatNotes -}}
+  {{.}}
+{{ end -}}
 {{range .Bumps -}}
   * Bump {{ .Name }} to version `{{ .ToVersion }}`
 {{ end }}

--- a/pkg/notes/notes_data_test.go
+++ b/pkg/notes/notes_data_test.go
@@ -474,3 +474,10 @@ func TestData_WriteVersionNotes(t *testing.T) {
 		please.Expect(releaseNotes.Notes).To(ContainSubstring("### <a id='4.0.0+LTS-T'></a> 4.0.0+LTS-T"))
 	})
 }
+
+func Test_trainstatURLFieldName_shouldNotChange(t *testing.T) {
+	please := NewWithT(t)
+	_, found := reflect.ValueOf(TrainstatQuery{}).Type().FieldByName("TrainstatURL")
+
+	please.Expect(found).To(BeTrue())
+}

--- a/pkg/notes/testdata/runtime-rn.html.md.erb
+++ b/pkg/notes/testdata/runtime-rn.html.md.erb
@@ -34,6 +34,8 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 
 * **[Bug Fix]** Breaking Change: Any customers with gorouter certificates lacking a SubjectAltName extension will experience failures upon deployment. As a workaround to complete deployment while new certificates are procured, enable the "Enable temporary workaround for certs without SANs" property in the Networking section of the TAS tile. For more information on updating certs, see https://community.pivotal.io/s/article/Routing-and-golang-1-15-X-509-CommonName-deprecation?language=en_US
 * **[Bug Fix]** Cloud Controller - Ensure app lifecycle_type is not nil when determining app lifecycle
+* **[Feature]** this is a feature.
+* **[Bug Fix]** this is a bug fix.
 * Bump backup-and-restore-sdk to version `1.18.26`
 * Bump bpm to version `1.1.15`
 * Bump capi to version `1.84.20`


### PR DESCRIPTION
- Add -tu flag to release notes command to specify a different trainstat url

Authored-by: Pablo Rodas <prodas@vmware.com>