### PR TITLE
Minor changes to kiln output and docker image name

### DIFF
--- a/internal/commands/test_tile.go
+++ b/internal/commands/test_tile.go
@@ -113,9 +113,9 @@ func (u ManifestTest) Execute(args []string) error {
 		return err
 	}
 
-	u.logger.Println("Info: Building / restoring cached docker image. This may take several minutes during updates to Ops Manager or the first run...")
+	u.logger.Println("Info: Building / restoring cached docker image.\nInfo: This may take several minutes during updates to Ops Manager or the first run...")
 	res, err := u.mobi.ImageBuild(u.ctx, tr, types.ImageBuildOptions{
-		Tags:      []string{"dont_push_me_vmware_confidential:123"},
+		Tags:      []string{"kiln_test_dependencies:vmware"},
 		Version:   types.BuilderBuildKit,
 		SessionID: session.ID(),
 	})
@@ -124,7 +124,6 @@ func (u ManifestTest) Execute(args []string) error {
 	}
 
 	scanner := bufio.NewScanner(res.Body)
-	lastLine := ""
 	for scanner.Scan() {
 		text := scanner.Text()
 		errLine := &ErrorLine{}
@@ -142,9 +141,7 @@ func (u ManifestTest) Execute(args []string) error {
 			}
 			return errors.New(buildError)
 		}
-		lastLine = text
 	}
-	u.logger.Println("Info:", lastLine)
 
 	localTileDir := u.Options.TilePath
 	absRepoDir, err := filepath.Abs(localTileDir)
@@ -160,7 +157,7 @@ func (u ManifestTest) Execute(args []string) error {
 	dockerCmd := fmt.Sprintf("cd /tas/%s/test/manifest && PRODUCT=%s RENDERER=ops-manifest ginkgo %s", tileDir, toProduct(tileDir), u.Options.GingkoManifestFlags)
 	fmt.Println(dockerCmd)
 	createResp, err := u.mobi.ContainerCreate(u.ctx, &container.Config{
-		Image: "dont_push_me_vmware_confidential:123",
+		Image: "kiln_test_dependencies:vmware",
 		Cmd:   []string{"/bin/bash", "-c", dockerCmd},
 		Env:   envVars,
 		Tty:   true,

--- a/internal/commands/test_tile_test.go
+++ b/internal/commands/test_tile_test.go
@@ -79,7 +79,6 @@ var _ = Describe("kiln test docker", func() {
 					By("logging helpful messages", func() {
 						logs := writer.String()
 						By("logging container information", func() {
-							Expect(logs).To(ContainSubstring("tagged dont_push_me_vmware_confidential:123"))
 							Expect(logs).To(ContainSubstring("Building / restoring cached docker image"))
 						})
 						By("logging test lines", func() {
@@ -150,7 +149,7 @@ func setupFakeMobyClient(containerLogMessage string, testExitCode int64) *fakes.
 	fakeConn := &fakes.Conn{R: r, W: stdcopy.NewStdWriter(io.Discard, stdcopy.Stdout)}
 	fakeMobyClient.DialHijackReturns(fakeConn, nil)
 
-	rc := io.NopCloser(strings.NewReader(`{"error": "", "message": "tagged dont_push_me_vmware_confidential:123"}`))
+	rc := io.NopCloser(strings.NewReader(`{"error": "", "message": "tagged kiln_test_dependencies:vmware"}`))
 	imageBuildResponse := types.ImageBuildResponse{
 		Body: rc,
 	}


### PR DESCRIPTION
**Minor changes to the log output when running `kiln test`**

Before:
<img width="863" alt="Screenshot 2023-04-13 at 8 40 19 PM" src="https://user-images.githubusercontent.com/16111/231919888-e238b804-8478-4297-b593-2e53d0dfdfca.png">

After:
<img width="863" alt="Screenshot 2023-04-13 at 8 40 05 PM" src="https://user-images.githubusercontent.com/16111/231919921-67dfc42a-9f53-4d60-be94-126df3a4155b.png">

**Change docker image name to `kiln_test_dependencies:vmware` instead of `dont_push_me_vmware_confidential:123`**

Before:
<img width="1013" alt="Screenshot 2023-04-13 at 8 04 12 PM" src="https://user-images.githubusercontent.com/16111/231919873-8a603c67-baec-44ef-aa3d-0caa1726cd44.png">

After:
<img width="1001" alt="Screenshot 2023-04-13 at 8 04 17 PM" src="https://user-images.githubusercontent.com/16111/231919936-f22aeea3-d278-4aa9-88da-67877372e3c0.png">