### PR TITLE
Feat/test verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,10 @@ provides_product_versions:
   version: $( version )
 ```
 
+#### `--skip-fetch-directories`
+
+The `--skip-fetch-directories` flag bypasses the default behavior to fetch releases when running `kiln bake`.
+
 </details>
 
 
@@ -386,11 +390,27 @@ provides_product_versions:
 
 The `test` command exercises to ginkgo tests under the `/<tile>/test/manifest` path of the `pivotal/tas` repos (where `<tile>` is tas, ist, or tasw). 
 
-Running these tests require a docker daemon to be running.
-
-Here is an example command line:
+Running these tests require a docker daemon and ssh-agent to be running. If no ssh identity is added (check with `ssh-add -l`) , then `kiln test`
+will add a ssh key in the following order, prompting for a passphrase if required:
 ```
+	~/.ssh/id_rs
+	~/.ssh/id_dsa
+	~/.ssh/d_ecdsa
+	~/.ssh/d_ed25519
+	~/.ssh/dentity
+```
+
+The identity must have access to github.com/pivotal/ops-manager.
+
+Here are command line examples:
+```
+$ cd ~/workspace/tas/ist
 $ kiln test
+```
+
+```
+cd ~
+$ kiln test --verbose -tp ~/workspace/tas/ist --ginkgo-manifest-flags "-p -nodes 8 -v" 
 ```
 
 <details>
@@ -398,11 +418,19 @@ $ kiln test
 
 ##### `--ginkgo-manifest-flags`
 
-The `--ginkgo-manifest-flags` flag can be used to pass through Ginkgo test flags. The defaults being passed through are `-r -slowSpecThreshold 15`. Pass `help` as a flag to retrieve the available options for the embeded version of ginkgo.
+The `--ginkgo-manifest-flags` flag can be used to pass through Ginkgo test flags. The defaults being passed through are `-r -p -slowSpecThreshold 15`. Pass `help` as a flag to retrieve the available options for the embeded version of ginkgo.
 
 ##### `--tile-path`
 
-The `--tile-path` flag can be set the path the the directory you wish to test. It defaults to the current working directory.
+The `--tile-path` (`-tp`) flag can be set the path the directory you wish to test. It defaults to the current working directory. For example
+```
+$ kiln test -tp ~/workspace/tas/ist
+```
+
+##### `--verbose`
+
+The `--verbose` (`-v`) flag will log additional debugging info.
+
 </details>
 
 ### `fetch`

--- a/internal/commands/test_tile.go
+++ b/internal/commands/test_tile.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -42,6 +43,35 @@ type mobyClient interface {
 	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
 }
 
+type infoLog struct {
+	logger  *log.Logger
+	logging *sync.Mutex
+	enabled bool
+}
+
+func (l infoLog) Info(v ...any) {
+	if l.enabled {
+		// the below should be a single atomic op
+		l.logging.Lock()
+		defer l.logging.Unlock()
+		originalFlags := l.logger.Flags()
+		originalPrefix := l.logger.Prefix()
+		l.logger.SetFlags(log.Lmicroseconds)
+		l.logger.SetPrefix("Info: ")
+		l.logger.Println(v...)
+		l.logger.SetFlags(originalFlags)
+		l.logger.SetPrefix(originalPrefix)
+	}
+}
+
+func (l infoLog) Println(v ...any) {
+	l.logger.Println(v...)
+}
+
+func (l infoLog) Writer() io.Writer {
+	return l.logger.Writer()
+}
+
 type ManifestTest struct {
 	Options struct {
 		TilePath            string `short:"tp"   long:"tile-path"                default:"."                             description:"path to the tile directory (e.g., ~/workspace/tas/ist)"`
@@ -65,19 +95,25 @@ func NewManifestTest(logger *log.Logger, ctx context.Context, mobi mobyClient, s
 		mobi:        mobi,
 		sshProvider: sshThing,
 	}
+
 }
 
 //go:embed manifest_test_docker/*
 var dockerfileContents string
 
 func (u ManifestTest) Execute(args []string) error {
-	// TODO: check if ssh provider isn't borked
 	if u.sshProvider == nil {
 		return errors.New("ssh provider failed to initialize. check your ssh-agent is running")
 	}
 	_, err := jhanda.Parse(&u.Options, args)
 	if err != nil {
 		return fmt.Errorf("could not parse manifest-test flags: %s", err)
+	}
+
+	loggerWithInfo := infoLog{
+		logger:  u.logger,
+		logging: &sync.Mutex{},
+		enabled: u.Options.Verbose,
 	}
 
 	_, err = u.mobi.Ping(u.ctx)
@@ -106,19 +142,16 @@ func (u ManifestTest) Execute(args []string) error {
 			fmt.Printf("%+v\n", err)
 		}
 	}()
-	originalOutput := u.logger.Writer()
-	if !u.Options.Verbose {
-		u.logger.SetOutput(io.Discard)
-	}
 
-	u.logger.Println("Info: Checking for the latest ops-manager image...")
+	loggerWithInfo.Info("Checking for the latest ops-manager image...")
 
 	tr, err := getTarReader(dockerfileContents)
 	if err != nil {
 		return err
 	}
 
-	u.logger.Println("Info: Building / restoring cached docker image.\nInfo: This may take several minutes during updates to Ops Manager or the first run...")
+	loggerWithInfo.Info("Building / restoring cached docker image")
+	loggerWithInfo.Info("This may take several minutes during updates to Ops Manager or the first run...")
 	res, err := u.mobi.ImageBuild(u.ctx, tr, types.ImageBuildOptions{
 		Tags:      []string{"kiln_test_dependencies:vmware"},
 		Version:   types.BuilderBuildKit,
@@ -156,12 +189,11 @@ func (u ManifestTest) Execute(args []string) error {
 	parentDir := path.Dir(absRepoDir)
 	tileDir := path.Base(absRepoDir)
 
-	u.logger.Println("Info: Mounting", parentDir, "and testing", tileDir)
+	loggerWithInfo.Info("Mounting", parentDir, "and testing", tileDir)
 
 	envVars := getManifestTestEnvVars(absRepoDir, tileDir)
 	dockerCmd := fmt.Sprintf("cd /tas/%s/test/manifest && PRODUCT=%s RENDERER=ops-manifest ginkgo %s", tileDir, toProduct(tileDir), u.Options.GingkoManifestFlags)
-	u.logger.Println("Info: Running:", dockerCmd)
-	u.logger.SetOutput(originalOutput)
+	loggerWithInfo.Info("Running:", dockerCmd)
 	createResp, err := u.mobi.ContainerCreate(u.ctx, &container.Config{
 		Image: "kiln_test_dependencies:vmware",
 		Cmd:   []string{"/bin/bash", "-c", dockerCmd},
@@ -197,12 +229,12 @@ func (u ManifestTest) Execute(args []string) error {
 	}
 	go func() {
 		<-sigInt
-		fmt.Println("Canceling tests")
+		loggerWithInfo.Println("Canceling tests")
 		err := u.mobi.ContainerStop(u.ctx, createResp.ID, container.StopOptions{
 			Signal: "SIGKILL",
 		})
 		if err != nil {
-			fmt.Println("Error stopping container", err)
+			loggerWithInfo.Println("Error stopping container", err)
 		}
 	}()
 
@@ -211,7 +243,7 @@ func (u ManifestTest) Execute(args []string) error {
 		return err
 	}
 
-	_, err = io.Copy(u.logger.Writer(), out)
+	_, err = io.Copy(loggerWithInfo.Writer(), out)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/test_tile_acceptance_test.go
+++ b/internal/commands/test_tile_acceptance_test.go
@@ -29,7 +29,7 @@ var _ = Describe("test", func() {
 			tilePath := filepath.Join("testdata", "tas_fake", "tas")
 			Expect(goVendor(tilePath)).NotTo(HaveOccurred())
 			testTile := commands.NewManifestTest(logger, ctx, cli, sshProvider)
-			err = testTile.Execute([]string{"--tile-path", tilePath})
+			err = testTile.Execute([]string{"--verbose", "--tile-path", tilePath})
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(testOutput.String()).To(ContainSubstring("SUCCESS"))
@@ -50,7 +50,7 @@ var _ = Describe("test", func() {
 			testTile := commands.NewManifestTest(logger, ctx, cli, sshProvider)
 			tilePath := filepath.Join("testdata", "tas_fake", "tas_failing")
 			Expect(goVendor(tilePath)).NotTo(HaveOccurred())
-			err = testTile.Execute([]string{"--tile-path", tilePath})
+			err = testTile.Execute([]string{"--verbose", "--tile-path", tilePath})
 
 			Expect(err).To(HaveOccurred())
 			Expect(testOutput.String()).NotTo(ContainSubstring("SUCCESS"))

--- a/main.go
+++ b/main.go
@@ -21,11 +21,6 @@ import (
 var version = "unknown"
 
 func main() {
-	//err := commands.VaultGetCred("tas-ppe/dockerhub_username")
-	//if err != nil {
-	//	log.Fatal(err)
-	//}
-	//os.Exit(0)
 	errLogger := log.New(os.Stderr, "", 0)
 	outLogger := log.New(os.Stdout, "", 0)
 


### PR DESCRIPTION
* Make `parallel` ginkgo testing default
* By default, suppress "Info:" messages in `kiln test`
* Elaboration in docs on `test` and `bake`