### PR TITLE
remove proofing.ExtractTileMetadataFile

### DIFF
--- a/pkg/planitest/manifest.go
+++ b/pkg/planitest/manifest.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/cppforlife/go-patch/patch"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type Manifest string
 
-func (m *Manifest) FindInstanceGroupJob(instanceGroup, job string) (Manifest, error) {
+func (m Manifest) FindInstanceGroupJob(instanceGroup, job string) (Manifest, error) {
 	path := fmt.Sprintf("/instance_groups/name=%s/jobs/name=%s", instanceGroup, job)
 
 	result, err := m.interpolate(path)
@@ -21,7 +21,7 @@ func (m *Manifest) FindInstanceGroupJob(instanceGroup, job string) (Manifest, er
 	if err != nil {
 		return "", err // should never happen
 	}
-	return Manifest(string(content)), nil
+	return Manifest(content), nil
 }
 
 func (m Manifest) Property(path string) (interface{}, error) {

--- a/pkg/planitest/product_service.go
+++ b/pkg/planitest/product_service.go
@@ -101,7 +101,3 @@ func ExtractTileMetadataFile(path string) (io.ReadSeeker, error) {
 	b, err := tile.ReadMetadataFromFile(path)
 	return bytes.NewReader(b), err
 }
-
-func closeAndIgnoreError(c io.Closer) {
-	_ = c.Close()
-}

--- a/pkg/planitest/product_service.go
+++ b/pkg/planitest/product_service.go
@@ -1,9 +1,7 @@
 package planitest
 
 import (
-	"bytes"
 	"errors"
-	"github.com/pivotal-cf/kiln/pkg/tile"
 	"io"
 	"os"
 
@@ -91,13 +89,4 @@ func (p *ProductService) RenderManifest(additionalProperties map[string]interfac
 	}
 
 	return Manifest(m), nil
-}
-
-// ExtractTileMetadataFile reads a metadata file in the metadata directory.
-// It will read the first yaml file found.
-//
-// Deprecated: please use github.com/pivotal-cf/kiln/pkg/tile.ReadMetadataFromFile instead.
-func ExtractTileMetadataFile(path string) (io.ReadSeeker, error) {
-	b, err := tile.ReadMetadataFromFile(path)
-	return bytes.NewReader(b), err
 }

--- a/pkg/planitest/product_service.go
+++ b/pkg/planitest/product_service.go
@@ -1,9 +1,9 @@
 package planitest
 
 import (
-	"archive/zip"
 	"bytes"
 	"errors"
+	"github.com/pivotal-cf/kiln/pkg/tile"
 	"io"
 	"os"
 
@@ -93,28 +93,13 @@ func (p *ProductService) RenderManifest(additionalProperties map[string]interfac
 	return Manifest(m), nil
 }
 
+// ExtractTileMetadataFile reads a metadata file in the metadata directory.
+// It will read the first yaml file found.
 func ExtractTileMetadataFile(path string) (io.ReadSeeker, error) {
-	f, err := zip.OpenReader(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
+	b, err := tile.ReadMetadataFromFile(path)
+	return bytes.NewReader(b), err
+}
 
-	for _, file := range f.File {
-		if file.Name == "metadata/metadata.yml" {
-			r, err := file.Open()
-			if err != nil {
-				return nil, err
-			}
-
-			b, err := io.ReadAll(r)
-			if err != nil {
-				return nil, err
-			}
-
-			return bytes.NewReader(b), nil
-		}
-	}
-
-	return nil, errors.New("did not find metadata/metadata.yml in tile")
+func closeAndIgnoreError(c io.Closer) {
+	_ = c.Close()
 }

--- a/pkg/planitest/product_service.go
+++ b/pkg/planitest/product_service.go
@@ -95,6 +95,8 @@ func (p *ProductService) RenderManifest(additionalProperties map[string]interfac
 
 // ExtractTileMetadataFile reads a metadata file in the metadata directory.
 // It will read the first yaml file found.
+//
+// Deprecated: please use github.com/pivotal-cf/kiln/pkg/tile.ReadMetadataFromFile instead.
 func ExtractTileMetadataFile(path string) (io.ReadSeeker, error) {
 	b, err := tile.ReadMetadataFromFile(path)
 	return bytes.NewReader(b), err

--- a/pkg/planitest/product_service_test.go
+++ b/pkg/planitest/product_service_test.go
@@ -1,12 +1,8 @@
 package planitest
 
 import (
-	"archive/zip"
 	"io"
-	"log"
 	"os"
-	"path"
-	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -114,39 +110,6 @@ var _ = Describe("Product Service", func() {
 				tileConfig, err := io.ReadAll(tileConfigReader)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(tileConfig)).To(ContainSubstring("product-properties: {}"))
-			})
-		})
-	})
-
-	Describe("ExtractTileMetadataFile", func() {
-		When("it reads metadata from a tile", func() {
-			var (
-				tileFileName string
-			)
-			BeforeEach(func() {
-				t := GinkgoT()
-				tempDir := t.TempDir()
-				tileFileName = filepath.Join(tempDir, "tile.pivotal")
-				zf, err := os.Create(tileFileName)
-				if err != nil {
-					log.Fatal(err)
-				}
-				defer closeAndIgnoreError(zf)
-				zw := zip.NewWriter(zf)
-				defer closeAndIgnoreError(zw)
-				if err != nil {
-					log.Fatal(err)
-				}
-				mf, err := zw.Create(path.Join("metadata/a.yml"))
-				if err != nil {
-					log.Fatal(err)
-				}
-				_, _ = mf.Write([]byte("---\nhello: world\n"))
-			})
-
-			It("sets the key's value to an empty hash in the YAML", func() {
-				_, err := ExtractTileMetadataFile(tileFileName)
-				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
This does the same thing and has tests: https://pkg.go.dev/github.com/pivotal-cf/kiln@v0.80.0/pkg/tile#ReadMetadataFromFile

Initially, I wanted to add test coverage; however, I noticed that I could just use the well tested implementation from the tile package. It has the same semantics as the original implementation. Then I thought, maybe we should just deprecate this function and recommend using the one from tile.

I also added some linter warning "fixes" in this commit.