### PR TITLE
fix: log errors when loading SSH provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 
@@ -84,7 +85,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	sshProvider, _ := commands.NewSshProvider(commands.SSHClientCreator{})
+	sshProvider, err := commands.NewSshProvider(commands.SSHClientCreator{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error fetching SSH provider: %s\n", err)
+	}
 	commandSet["test"] = commands.NewTileTest(outLogger, context.Background(), mobyClient, sshProvider)
 	commandSet["help"] = commands.NewHelp(os.Stdout, globalFlagsUsage, commandSet)
 	commandSet["version"] = commands.NewVersion(outLogger, version)


### PR DESCRIPTION
If there is an error loading the local SSH provider (e.g. there is no running ssh-agent), it will be logged to standard error instead of swallowed. Panicking on this error breaks acceptance tests, so logging is the next best thing.