### PR TITLE
fix acceptance tests after semver/v3 bump

### DIFF
--- a/internal/acceptance/workflows/acceptance_test.go
+++ b/internal/acceptance/workflows/acceptance_test.go
@@ -12,6 +12,7 @@
 package workflows
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
@@ -84,9 +85,10 @@ func setupAndRunFeatureTest(t *testing.T, initializers ...func(ctx *godog.Scenar
 			}
 		},
 		Options: &godog.Options{
-			Format:   "pretty",
-			Paths:    []string{featurePath},
-			TestingT: t, // Testing instance that will run subtests.
+			Format:         "pretty",
+			Paths:          []string{featurePath},
+			DefaultContext: scenario.DefaultContext(context.Background(), t.TempDir()),
+			TestingT:       t, // Testing instance that will run subtests.
 		},
 	}
 

--- a/internal/acceptance/workflows/scenario/initialize.go
+++ b/internal/acceptance/workflows/scenario/initialize.go
@@ -131,7 +131,6 @@ func InitializeTileSourceCode(ctx *godog.ScenarioContext) { initializeTileSource
 func initializeTileSourceCode(ctx scenarioContext) {
 	ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
 		err := exec.CommandContext(ctx, "git", "submodule", "update", "--init", "--recursive").Run()
-		ctx = setKilnBuildPath(ctx)
 		return setTileRepoPath(ctx, "hello-tile"), err
 	})
 	ctx.After(resetTileRepository)

--- a/internal/acceptance/workflows/scenario/initialize.go
+++ b/internal/acceptance/workflows/scenario/initialize.go
@@ -135,7 +135,6 @@ func initializeTileSourceCode(ctx scenarioContext) {
 		return setTileRepoPath(ctx, "hello-tile"), err
 	})
 	ctx.After(resetTileRepository)
-	ctx.After(removeKilnBuild)
 
 	ctx.Step(regexp.MustCompile(`^kiln validate succeeds$`), kilnValidateSucceeds)
 

--- a/internal/acceptance/workflows/scenario/shared_state.go
+++ b/internal/acceptance/workflows/scenario/shared_state.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,14 +35,10 @@ func contextValue[T any](ctx context.Context, k key, name string) (T, error) {
 	return s, nil
 }
 
-type tempDirKeyType byte
-
-const tempDirKey tempDirKeyType = 1
-
 // DefaultContext must be configured for tests to run properly
 // it sets up a context with required data for all scenarios.
-func DefaultContext(ctx context.Context, tempDir string) context.Context {
-	return context.WithValue(ctx, tempDirKey, tempDir)
+func DefaultContext(ctx context.Context, kilnBinaryPath string) context.Context {
+	return context.WithValue(ctx, kilnBuildCacheKey, kilnBinaryPath)
 }
 
 func tileRepoPath(ctx context.Context) (string, error) {
@@ -52,15 +47,6 @@ func tileRepoPath(ctx context.Context) (string, error) {
 
 func setTileRepoPath(ctx context.Context, p string) context.Context {
 	return context.WithValue(ctx, tileRepoKey, p)
-}
-
-func setKilnBuildPath(ctx context.Context) context.Context {
-	val := ctx.Value(tempDirKey)
-	if val == nil {
-		log.Fatal("temporary directory for test not set (call SetTempDir on context passed to godog.Options)")
-	}
-	tempKiln := filepath.Join(val.(string), "kiln")
-	return context.WithValue(ctx, kilnBuildCacheKey, tempKiln)
 }
 
 func kilnBuildPath(ctx context.Context) string {

--- a/internal/acceptance/workflows/scenario/utilities.go
+++ b/internal/acceptance/workflows/scenario/utilities.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	kilnDevVersion = "1.0.0-dev"
-
 	indexNotFound = -1
 
 	kilnBuildCacheKey kilnBuildCacheKeyType = 0
@@ -25,16 +23,7 @@ const (
 type kilnBuildCacheKeyType int
 
 func kilnCommand(ctx context.Context, args ...string) *exec.Cmd {
-	kilnExecutable := kilnBuildPath(ctx)
-	_, err := os.Stat(kilnExecutable)
-	if err != nil {
-		err := exec.CommandContext(ctx, "go", "build", "-o", kilnExecutable, "-ldflags", "-X main.version="+kilnDevVersion, "github.com/pivotal-cf/kiln").Run()
-		if err != nil {
-			_, _ = os.Stderr.WriteString(err.Error())
-			os.Exit(1)
-		}
-	}
-	return exec.CommandContext(ctx, kilnExecutable, args...)
+	return exec.CommandContext(ctx, kilnBuildPath(ctx), args...)
 }
 
 func checkoutMain(repoPath string) error {

--- a/internal/acceptance/workflows/using_kiln.feature
+++ b/internal/acceptance/workflows/using_kiln.feature
@@ -3,7 +3,7 @@ Feature: As a developer, I want the Kiln CLI to be usable
     When I invoke kiln
       | version |
     Then the exit code is 0
-    And stdout contains substring: 1.0.0-dev
+    And stdout contains substring: 0.0.0+acceptance-tests
   Scenario: I ask for help
     When I invoke kiln
       | help |

--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -75,7 +75,7 @@ type ComponentSpec struct {
 
 func (spec ComponentSpec) VersionConstraints() (*semver.Constraints, error) {
 	if spec.Version == "" {
-		spec.Version = ">0"
+		spec.Version = ">=0"
 	}
 	c, err := semver.NewConstraint(spec.Version)
 	if err != nil {


### PR DESCRIPTION
The acceptance tests failure was caused by a change introduced in Masterminds/semver/v3. The comparison semantics for major 0 changed. The problem is summarized in this playground: https://go.dev/play/p/t5beNbYVR9K. I changed the zero value of the cargo.ComponentSpec version field from ">0" to ">=0" go get the same behavior as before.

The first commit in this branch fixes the issue. I found some other issues with the acceptance tests that caused failures on MacOS. I fixed those and refactored to make build failures easier to understand.