### PR TITLE
only release v0 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: release
 
 on:
   push:
-    tags: ['v*']
+    tags: ['v0*']
+    # We need to do an API code review before we allow v1.
+    # Our command and package are not yet stable.
 
 permissions:
   contents: write


### PR DESCRIPTION
We need to stabilize the flags, commands, **and package api** before we ship 1.0.