### PR TITLE
dev ops: retract major versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -150,4 +150,5 @@ require (
 
 retract (
 	v1.0.0 // Published accidentally
+	v1.0.1 // Using this as a workaround to retract the previous version. See https://github.com/golang/go/issues/60336 where a go maintainer described this workaround.
 )


### PR DESCRIPTION
 - versions can only retract lower or equal versions. so we're going to push a v1.0.1 tag that retracts itself and v1.0.0

   see https://github.com/golang/go/issues/60336