### PR TITLE
support sts assume role with s3 release sources

### DIFF
--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -109,6 +109,7 @@ type ReleaseSourceConfig struct {
 	Region          string `yaml:"region,omitempty"`
 	AccessKeyId     string `yaml:"access_key_id,omitempty"`
 	SecretAccessKey string `yaml:"secret_access_key,omitempty"`
+	AwsRoleARN      string `yaml:"aws_role_arn,omitempty"`
 	PathTemplate    string `yaml:"path_template,omitempty"`
 	Endpoint        string `yaml:"endpoint,omitempty"`
 	Org             string `yaml:"org,omitempty"`


### PR DESCRIPTION
Adds an optional "aws_role_arn" property for a release source that can assume a role in an aws account.

[#185364456](https://www.pivotaltracker.com/story/show/185364456)