### PR TITLE
feat: parse non-standard metadata filenames

### DIFF
--- a/pkg/tile/metadata.go
+++ b/pkg/tile/metadata.go
@@ -30,7 +30,15 @@ func ReadMetadataFromZip(ra io.ReaderAt, zipFileSize int64) ([]byte, error) {
 }
 
 func ReadMetadataFromFS(dir fs.FS) ([]byte, error) {
-	metadataFile, err := dir.Open("metadata/metadata.yml")
+	const pattern = "metadata/*.yml"
+	matches, err := fs.Glob(dir, pattern)
+	if err != nil {
+		return nil, err
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("metadata file not found in the tile: expected a file matching glob %q", pattern)
+	}
+	metadataFile, err := dir.Open(matches[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to do open metadata zip file: %w", err)
 	}

--- a/pkg/tile/metadata_test.go
+++ b/pkg/tile/metadata_test.go
@@ -2,6 +2,7 @@ package tile_test
 
 import (
 	"testing"
+	"testing/fstest"
 
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
@@ -22,4 +23,14 @@ func TestReadMetadataFromFile(t *testing.T) {
 	please.Expect(err).NotTo(HaveOccurred(), string(metadataBytes))
 
 	please.Expect(metadata.Name).To(Equal("hello"), string(metadataBytes))
+}
+
+func TestNonStandardMetadataFilename(t *testing.T) {
+	fileFS := fstest.MapFS{
+		"metadata/banana.yml": &fstest.MapFile{Data: []byte(`{name: "banana"}`)},
+	}
+	buf, err := tile.ReadMetadataFromFS(fileFS)
+	please := NewWithT(t)
+	please.Expect(err).NotTo(HaveOccurred())
+	please.Expect(string(buf)).To(Equal(`{name: "banana"}`))
 }


### PR DESCRIPTION
tile-generator creates metadata filenames that are not "metadata/metadata.yml" with this change you can parse those tiles with the tile.ReadMetadata* functions

fixes: #403