### PR TITLE
Add feature to specify which BOSH Release Tarball versions are locked and how BOSH Release Tarball versions are unlocked

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/containerd/containerd v1.6.18 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4 // indirect
+	github.com/crhntr/bijection v0.0.0-20230628013949-46b5c800bc70 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,10 @@ github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4 h1:J+g
 github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4/go.mod h1:socxpf5+mELPbosI149vWpNlHK6mbfWFxSWOoSndXR8=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/crhntr/bijection v0.0.0-20230628012441-3687d8d75cd3 h1:iaa1zCNvNavpecimFRIuEcavQZKNM5JpOM+14s+q/u4=
+github.com/crhntr/bijection v0.0.0-20230628012441-3687d8d75cd3/go.mod h1:VUfsFhvnzFyGMAgtPdFUNrVPKCzi8rksDKLFTh2d9Hs=
+github.com/crhntr/bijection v0.0.0-20230628013949-46b5c800bc70 h1:KvmShEReASriUgZBk30EVVaur6/C4LUTXDmTE2vb30w=
+github.com/crhntr/bijection v0.0.0-20230628013949-46b5c800bc70/go.mod h1:VUfsFhvnzFyGMAgtPdFUNrVPKCzi8rksDKLFTh2d9Hs=
 github.com/crhntr/yamlutil v0.0.0-20230523004714-d7a84a7a5d64 h1:v9TB0YLlfTV7nZtDt8Amb9ml/udpjSE63P+0qmfK6aA=
 github.com/crhntr/yamlutil v0.0.0-20230523004714-d7a84a7a5d64/go.mod h1:ksg8an2nXLcrZReC9jceNV/Wj9OPSrN4YIH3qYRCswo=
 github.com/cucumber/gherkin-go/v19 v19.0.3 h1:mMSKu1077ffLbTJULUfM5HPokgeBcIGboyeNUof1MdE=

--- a/internal/acceptance/workflows/using_kiln.feature
+++ b/internal/acceptance/workflows/using_kiln.feature
@@ -34,7 +34,6 @@ Feature: As a developer, I want the Kiln CLI to be usable
       | find-release-version    |
       | find-stemcell-version   |
       | glaze                   |
-      | de-glaze                |
       | publish                 |
       | release-notes           |
       | sync-with-local         |

--- a/internal/acceptance/workflows/using_kiln.feature
+++ b/internal/acceptance/workflows/using_kiln.feature
@@ -34,6 +34,7 @@ Feature: As a developer, I want the Kiln CLI to be usable
       | find-release-version    |
       | find-stemcell-version   |
       | glaze                   |
+      | de-glaze                |
       | publish                 |
       | release-notes           |
       | sync-with-local         |

--- a/internal/commands/flags/parse.go
+++ b/internal/commands/flags/parse.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/pivotal-cf/jhanda"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/pivotal-cf/kiln/internal/baking"
 	"github.com/pivotal-cf/kiln/pkg/cargo"

--- a/internal/commands/init_test.go
+++ b/internal/commands/init_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/pivotal-cf/jhanda"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestCommands(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -96,8 +96,7 @@ func main() {
 	}
 
 	// commandSet["fetch"] = commands.NewFetch(outLogger, mrsProvider, localReleaseDirectory)
-	commandSet["glaze"] = new(commands.Glaze)
-	commandSet["de-glaze"] = new(commands.DeGlaze)
+	commandSet["glaze"] = commands.NewGlaze()
 
 	commandSet["generate-osm-manifest"] = commands.NewOSM(outLogger, nil)
 

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ func main() {
 
 	// commandSet["fetch"] = commands.NewFetch(outLogger, mrsProvider, localReleaseDirectory)
 	commandSet["glaze"] = new(commands.Glaze)
+	commandSet["de-glaze"] = new(commands.DeGlaze)
 
 	commandSet["generate-osm-manifest"] = commands.NewOSM(outLogger, nil)
 

--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -49,7 +49,7 @@ func (kf *Kilnfile) Glaze(kl KilnfileLock) error {
 }
 
 func (kf *Kilnfile) DeGlaze(kl KilnfileLock) error {
-	// TODO: what do do about the stemcell???
+	// TODO: what do about the stemcell???
 	for index, spec := range kf.Releases {
 		lock, err := kl.FindBOSHReleaseWithName(spec.Name)
 		if err != nil {

--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -108,6 +108,9 @@ type BOSHReleaseTarballSpecification struct {
 
 	// DeGlazeBehavior changes how version filed changes when de-glaze is run.
 	DeGlazeBehavior DeGlazeBehavior `yaml:"glaze_behavior"`
+
+	// TeamSlackChannel slack channel for team that maintains this bosh release
+	TeamSlackChannel string `yaml:"slack,omitempty"`
 }
 
 func (spec BOSHReleaseTarballSpecification) VersionConstraints() (*semver.Constraints, error) {

--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -3,10 +3,16 @@ package cargo
 import (
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	boshdir "github.com/cloudfoundry/bosh-cli/director"
+	"github.com/crhntr/bijection"
+)
+
+const (
+	unconstrainedVersion = "*"
 )
 
 type Kilnfile struct {
@@ -25,6 +31,34 @@ func (kf Kilnfile) BOSHReleaseTarballSpecification(name string) (BOSHReleaseTarb
 		}
 	}
 	return BOSHReleaseTarballSpecification{}, fmt.Errorf("failed to find component specification with name %q in Kilnfile", name)
+}
+
+func (kf *Kilnfile) Glaze(kl KilnfileLock) error {
+	kf.Stemcell.Version = kl.Stemcell.Version
+	for index, spec := range kf.Releases {
+		lock, err := kl.FindBOSHReleaseWithName(spec.Name)
+		if err != nil {
+			return fmt.Errorf("release with name %q not found in Kilnfile.lock: %w", spec.Name, err)
+		}
+		kf.Releases[index].Version = lock.Version
+	}
+	return nil
+}
+
+func (kf *Kilnfile) DeGlaze(kl KilnfileLock) error {
+	// TODO: what do do about the stemcell???
+	for index, spec := range kf.Releases {
+		lock, err := kl.FindBOSHReleaseWithName(spec.Name)
+		if err != nil {
+			return fmt.Errorf("release with name %q not found in Kilnfile.lock: %w", spec.Name, err)
+		}
+		deGlazed, err := deGlazeBOSHReleaseTarballSpecification(spec, lock)
+		if err != nil {
+			return err
+		}
+		kf.Releases[index] = deGlazed
+	}
+	return nil
 }
 
 type KilnfileLock struct {
@@ -71,11 +105,14 @@ type BOSHReleaseTarballSpecification struct {
 
 	// GitHubRepository are where the BOSH release source code is
 	GitHubRepository string `yaml:"github_repository,omitempty"`
+
+	// DeGlazeBehavior changes how version filed changes when de-glaze is run.
+	DeGlazeBehavior DeGlazeBehavior `yaml:"glaze_behavior"`
 }
 
 func (spec BOSHReleaseTarballSpecification) VersionConstraints() (*semver.Constraints, error) {
 	if spec.Version == "" {
-		spec.Version = ">=0"
+		spec.Version = unconstrainedVersion
 	}
 	c, err := semver.NewConstraint(spec.Version)
 	if err != nil {
@@ -216,4 +253,94 @@ func (stemcell Stemcell) ProductSlug() (string, error) {
 	default:
 		return "", fmt.Errorf("stemcell slug not set for os %s", stemcell.OS)
 	}
+}
+
+type DeGlazeBehavior int
+
+const (
+	LockNone  DeGlazeBehavior = iota - 1
+	LockMajor                 // default value
+	LockMinor
+	LockPatch
+)
+
+var deGlazeStrings = bijection.New(map[DeGlazeBehavior]string{
+	LockNone:  "LockNone",
+	LockPatch: "LockPatch",
+	LockMinor: "LockMinor",
+	LockMajor: "LockMajor",
+})
+
+//goland:noinspection GoMixedReceiverTypes
+func (dgb DeGlazeBehavior) String() string {
+	buf, _ := dgb.MarshalText()
+	return string(buf)
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (dgb DeGlazeBehavior) MarshalText() (text []byte, err error) {
+	s, found := deGlazeStrings.GetB(dgb)
+	if !found {
+		return nil, fmt.Errorf("unknown behavior")
+	}
+	return []byte(s), nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (dgb *DeGlazeBehavior) UnmarshalText(text []byte) error {
+	behavior, found := deGlazeStrings.GetA(string(text))
+	if !found {
+		return fmt.Errorf("unknown behavior")
+	}
+	*dgb = behavior
+	return nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (dgb DeGlazeBehavior) MarshalYAML() (any, error) {
+	s, found := deGlazeStrings.GetB(dgb)
+	if !found {
+		return nil, fmt.Errorf("unknown behavior")
+	}
+	return s, nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (dgb *DeGlazeBehavior) UnmarshalYAML(node *yaml.Node) error {
+	var s string
+	if err := node.Decode(&s); err != nil {
+		return err
+	}
+	behavior, found := deGlazeStrings.GetA(s)
+	if !found {
+		return fmt.Errorf("unknown behavior")
+	}
+	*dgb = behavior
+	return nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (dgb DeGlazeBehavior) createConstraint(lockVersion string) (string, error) {
+	v, err := BOSHReleaseTarballLock{Version: lockVersion}.ParseVersion()
+	if err != nil {
+		return "", err
+	}
+	var versionConstraint string
+	switch dgb {
+	case LockNone:
+		versionConstraint = unconstrainedVersion
+	case LockPatch:
+		versionConstraint = fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch())
+	case LockMinor:
+		versionConstraint = fmt.Sprintf("~%d.%d", v.Major(), v.Minor())
+	case LockMajor:
+		versionConstraint = fmt.Sprintf("~%d", v.Major())
+	}
+	return versionConstraint, nil
+}
+
+func deGlazeBOSHReleaseTarballSpecification(spec BOSHReleaseTarballSpecification, lock BOSHReleaseTarballLock) (BOSHReleaseTarballSpecification, error) {
+	var err error
+	spec.Version, err = spec.DeGlazeBehavior.createConstraint(lock.Version)
+	return spec, err
 }

--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -36,6 +36,9 @@ func (kf Kilnfile) BOSHReleaseTarballSpecification(name string) (BOSHReleaseTarb
 func (kf *Kilnfile) Glaze(kl KilnfileLock) error {
 	kf.Stemcell.Version = kl.Stemcell.Version
 	for index, spec := range kf.Releases {
+		if spec.FloatAlways {
+			continue
+		}
 		lock, err := kl.FindBOSHReleaseWithName(spec.Name)
 		if err != nil {
 			return fmt.Errorf("release with name %q not found in Kilnfile.lock: %w", spec.Name, err)
@@ -107,7 +110,11 @@ type BOSHReleaseTarballSpecification struct {
 	GitHubRepository string `yaml:"github_repository,omitempty"`
 
 	// DeGlazeBehavior changes how version filed changes when de-glaze is run.
-	DeGlazeBehavior DeGlazeBehavior `yaml:"glaze_behavior"`
+	DeGlazeBehavior DeGlazeBehavior `yaml:"maintenance_version_bump_policy"`
+
+	// FloatAlways when does not override version constraint.
+	// It skips locking it during Kilnfile.Glaze.
+	FloatAlways bool `yaml:"float_always,omitempty"`
 
 	// TeamSlackChannel slack channel for team that maintains this bosh release
 	TeamSlackChannel string `yaml:"slack,omitempty"`

--- a/pkg/cargo/kilnfile_test.go
+++ b/pkg/cargo/kilnfile_test.go
@@ -9,8 +9,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestComponentLock_yaml_marshal_order(t *testing.T) {
-	const validComponentLockYaml = `name: fake-component-name
+func TestBOSHReleaseTarballLock_yaml_marshal_order(t *testing.T) {
+	const validBOSHReleaseTarballLockYaml = `name: fake-component-name
 sha1: fake-component-sha1
 version: fake-version
 remote_source: fake-source
@@ -27,7 +27,7 @@ remote_path: fake/path/to/fake-component-name
 	})
 
 	damnit.Expect(err).NotTo(HaveOccurred())
-	damnit.Expect(string(cl)).To(Equal(validComponentLockYaml))
+	damnit.Expect(string(cl)).To(Equal(validBOSHReleaseTarballLockYaml))
 }
 
 func TestKilnfileLock_UpdateBOSHReleaseTarballLockWithName(t *testing.T) {
@@ -117,6 +117,193 @@ func TestStemcell_ProductSlug(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.ExpSlug, productSlug)
+			}
+		})
+	}
+}
+
+func TestKilnfile_Glaze(t *testing.T) {
+	t.Run("it updates the Kilnfile", func(t *testing.T) {
+		kf := Kilnfile{
+			Releases: []BOSHReleaseTarballSpecification{
+				{Name: "banana"},
+				{Name: "orange", Version: "~ 8.0"},
+			},
+			Stemcell: Stemcell{
+				OS: "alpine",
+			},
+		}
+		kl := KilnfileLock{
+			Releases: []BOSHReleaseTarballLock{
+				{Name: "banana", Version: "1.2.3"},
+				{Name: "orange", Version: "8.0.8"},
+			},
+			Stemcell: Stemcell{
+				OS:      "alpine",
+				Version: "42.0",
+			},
+		}
+
+		require.NoError(t, kf.Glaze(kl))
+
+		assert.Equal(t, Kilnfile{
+			Releases: []BOSHReleaseTarballSpecification{
+				{Name: "banana", Version: "1.2.3"},
+				{Name: "orange", Version: "8.0.8"},
+			},
+			Stemcell: Stemcell{
+				OS:      "alpine",
+				Version: "42.0",
+			},
+		}, kf)
+	})
+}
+
+func TestKilnfile_DeGlaze(t *testing.T) {
+	t.Run("it updates the Kilnfile", func(t *testing.T) {
+		kf := Kilnfile{
+			Releases: []BOSHReleaseTarballSpecification{
+				{Name: "mango", Version: "1.2.3", DeGlazeBehavior: LockMajor},
+				{Name: "orange", Version: "8.0.8", DeGlazeBehavior: LockMinor},
+				{Name: "papaya", Version: "4.2.0", DeGlazeBehavior: LockPatch},
+				{Name: "peach", Version: "9.8.7", DeGlazeBehavior: LockNone},
+			},
+		}
+		kl := KilnfileLock{
+			Releases: []BOSHReleaseTarballLock{
+				{Name: "mango", Version: "1.2.3"},
+				{Name: "orange", Version: "8.0.8"},
+				{Name: "papaya", Version: "4.2.0"},
+				{Name: "peach", Version: "9.8.7"},
+			},
+		}
+
+		require.NoError(t, kf.DeGlaze(kl))
+
+		assert.Equal(t, Kilnfile{
+			Releases: []BOSHReleaseTarballSpecification{
+				{Name: "mango", Version: "~1", DeGlazeBehavior: LockMajor},
+				{Name: "orange", Version: "~8.0", DeGlazeBehavior: LockMinor},
+				{Name: "papaya", Version: "4.2.0", DeGlazeBehavior: LockPatch},
+				{Name: "peach", Version: "*", DeGlazeBehavior: LockNone},
+			},
+		}, kf)
+	})
+}
+
+func TestDeGlazeBehavior_TextUnmarshalMarshaller(t *testing.T) {
+	for _, tt := range []DeGlazeBehavior{
+		LockNone,
+		LockPatch,
+		LockMinor,
+		LockMajor,
+	} {
+		t.Run(tt.String(), func(t *testing.T) {
+			text, err := tt.MarshalText()
+			assert.NoError(t, err)
+			var out DeGlazeBehavior
+			assert.NoError(t, out.UnmarshalText(text))
+			assert.Equal(t, tt, out)
+
+			type Structure struct {
+				B DeGlazeBehavior `yaml:"b"`
+			}
+
+			buf, err := yaml.Marshal(Structure{
+				B: tt,
+			})
+			assert.Contains(t, string(buf), tt.String())
+			require.NoError(t, err)
+			var fromYAML Structure
+			require.NoError(t, yaml.Unmarshal(buf, &fromYAML))
+			assert.Equal(t, tt, fromYAML.B)
+		})
+	}
+
+	t.Run("marshal text unknown", func(t *testing.T) {
+		unknown := DeGlazeBehavior(101)
+		text, err := unknown.MarshalText()
+		assert.Error(t, err)
+		assert.Zero(t, text)
+	})
+	t.Run("unmarshal text unknown", func(t *testing.T) {
+		var value DeGlazeBehavior
+		err := value.UnmarshalText([]byte("banana"))
+		assert.Error(t, err)
+		assert.Zero(t, value)
+	})
+
+	t.Run("marshal yaml unknown", func(t *testing.T) {
+		unknown := DeGlazeBehavior(101)
+		_, err := yaml.Marshal(unknown)
+		assert.Error(t, err)
+	})
+	t.Run("unmarshal yaml unknown", func(t *testing.T) {
+		var out DeGlazeBehavior
+		err := yaml.Unmarshal([]byte("banana"), &out)
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong yaml type", func(t *testing.T) {
+		var out DeGlazeBehavior
+		err := yaml.Unmarshal([]byte("{}"), &out)
+		assert.Error(t, err)
+	})
+}
+
+func Test_deGlazeBOSHReleaseTarballSpecification(t *testing.T) {
+	for _, tt := range []struct {
+		Name           string
+		InSpec         BOSHReleaseTarballSpecification
+		InLock         BOSHReleaseTarballLock
+		Out            BOSHReleaseTarballSpecification
+		ErrorSubstring string
+	}{
+		{
+			Name:   "zero value behavior",
+			InSpec: BOSHReleaseTarballSpecification{},
+			InLock: BOSHReleaseTarballLock{Version: "1.2.3"},
+			Out:    BOSHReleaseTarballSpecification{DeGlazeBehavior: LockMajor, Version: "~1"},
+		},
+		{
+			Name:   "LockNone",
+			InSpec: BOSHReleaseTarballSpecification{DeGlazeBehavior: LockNone},
+			InLock: BOSHReleaseTarballLock{Version: "1.2.3"},
+			Out:    BOSHReleaseTarballSpecification{DeGlazeBehavior: LockNone, Version: "*"},
+		},
+		{
+			Name:   "LockPatch",
+			InSpec: BOSHReleaseTarballSpecification{DeGlazeBehavior: LockPatch},
+			InLock: BOSHReleaseTarballLock{Version: "1.2.3"},
+			Out:    BOSHReleaseTarballSpecification{DeGlazeBehavior: LockPatch, Version: "1.2.3"},
+		},
+		{
+			Name:   "LockMinor",
+			InSpec: BOSHReleaseTarballSpecification{DeGlazeBehavior: LockMinor},
+			InLock: BOSHReleaseTarballLock{Version: "1.2.3"},
+			Out:    BOSHReleaseTarballSpecification{DeGlazeBehavior: LockMinor, Version: "~1.2"},
+		},
+		{
+			Name:   "LockMajor",
+			InSpec: BOSHReleaseTarballSpecification{DeGlazeBehavior: LockMajor},
+			InLock: BOSHReleaseTarballLock{Version: "1.2.3"},
+			Out:    BOSHReleaseTarballSpecification{DeGlazeBehavior: LockMajor, Version: "~1"},
+		},
+
+		{
+			Name:           "not a valid version in Lock",
+			InSpec:         BOSHReleaseTarballSpecification{DeGlazeBehavior: LockMajor},
+			InLock:         BOSHReleaseTarballLock{Version: "lemon"},
+			ErrorSubstring: "Invalid Semantic Version",
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			out, err := deGlazeBOSHReleaseTarballSpecification(tt.InSpec, tt.InLock)
+			if tt.ErrorSubstring != "" {
+				require.ErrorContains(t, err, tt.ErrorSubstring)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.Out, out)
 			}
 		})
 	}


### PR DESCRIPTION
## New Behavior

- **`kiln glaze`**: pins all releases to exact version in current Kilnfile.lock

  The release in the Kilnfile is skipped if it has the field value `always_float: true`

- **`kiln glaze --undo`**: "unpins" by pinning component version according to glaze_behaivor

  The release in the Kilnfile gets it's version constraint set based on the value of `maintenance_version_bump_policy`. 

  The permitted values are:

  - "LockNone"
  - "LockMajor" (this is also the default for when the value is the empty string or is not set)
  - "LockMinor"
  - "LockPatch"

  The stemcell version constraint is not changed by this command.

## Code Review Notes

The business logic is in the cargo package the command code does not exercise the functionality.

## `github.com/pivotal-cf/kiln/internal/commands`

The Glaze command tests do not test functionality; they exercise the flag parsing and pass values to faked out functions.

[The rarely used syntax to convert a method to an function that can be passed/assigned has a simple example here to make understanding it in the PR code easier.](https://go.dev/play/p/C_tv6ccNsKj)

## `github.com/pivotal-cf/kiln/pkg/cargo`

### Error Behavior
- When the version of the component in the Kilnfile.lock is not valid, the error is just returned.
- When the input `string`/`[]byte` or `cargo.DeGlazeBehavior` value is unknown, an error with message "unknown behavior" is returned.
- When parsing fails, the error is just returned.

### Notes

- `cargo.DeGlazeBehavior.String` returns an empty string when the value of `DeGlazeBehavior` is unknown.
- I add a dependency on a ["bijection"](github.com/crhntr/bijection) data structure that I wrote a while back as an exploration of generics. It is not required and the idiomatic way would be to use ["Stringer"](https://pkg.go.dev/github.com/golang/tools/cmd/stringer). This is internal behavior and can be refactored in the future.
- Both `cargo.Kilnfile.Glaze` and `cargo.Kilnfile.DeGlaze` return an error with a message like `"release with name "banana" not found in Kilnfile.lock: not found"` when the Lock does not contain a spec found in the Kilnfile.
