### PR TITLE
component: consistently handle not found errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pivotal-cf/kiln
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/internal/component/errors.go
+++ b/internal/component/errors.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -8,11 +9,7 @@ import (
 const ErrNotFound stringError = "not found"
 
 func IsErrNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	e, ok := err.(stringError)
-	return ok && e == ErrNotFound
+	return errors.Is(err, ErrNotFound)
 }
 
 type stringError string

--- a/internal/component/github_release_source.go
+++ b/internal/component/github_release_source.go
@@ -218,7 +218,7 @@ func (grs *GithubReleaseSource) getLockFromRelease(ctx context.Context, r *githu
 		}, nil
 	}
 
-	return Lock{}, fmt.Errorf("no matching GitHub release asset file name equal to %q", expectedAssetName)
+	return Lock{}, errors.Join(ErrNotFound, fmt.Errorf("no matching GitHub release asset file name equal to %q", expectedAssetName))
 }
 
 func (grs *GithubReleaseSource) getReleaseSHA1(ctx context.Context, s Spec, id int64) (string, error) {


### PR DESCRIPTION
When a github-release source is not found, kiln aborts early without trying additional release sources.

This change ensures the github release source reports "ErrNotFound" so that subsequent release sources can be tried.

Bumped go.mod -go=1.20 to pull in "errors.Join".  kiln is already built with Go 1.20 so this seems reasonable.