### PR TITLE
feat: allow TanzuNet slug to be set in the Kilnfile stemcell criteria

### DIFF
--- a/internal/commands/find_stemcell_version.go
+++ b/internal/commands/find_stemcell_version.go
@@ -52,15 +52,9 @@ func (cmd FindStemcellVersion) Execute(args []string) error {
 		return err
 	}
 
-	productSlug := ""
-
-	// Get Stemcell OS and major from Kilnfile
-	if kilnfile.Stemcell.OS == "ubuntu-xenial" {
-		productSlug = "stemcells-ubuntu-xenial"
-	} else if kilnfile.Stemcell.OS == "ubuntu-jammy" {
-		productSlug = "stemcells-ubuntu-jammy"
-	} else if kilnfile.Stemcell.OS == "windows2019" {
-		productSlug = "stemcells-windows-server"
+	productSlug, err := kilnfile.Stemcell.ProductSlug()
+	if err != nil {
+		return err
 	}
 
 	if productSlug == "" {

--- a/internal/commands/find_stemcell_version.go
+++ b/internal/commands/find_stemcell_version.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	ErrStemcellOSInfoMustBeValid       = "stemcell os information is missing or invalid"
 	ErrStemcellMajorVersionMustBeValid = "stemcell major Version is missing or invalid"
 	TanzuNetRemotePath                 = "network.pivotal.io"
 )
@@ -55,10 +54,6 @@ func (cmd FindStemcellVersion) Execute(args []string) error {
 	productSlug, err := kilnfile.Stemcell.ProductSlug()
 	if err != nil {
 		return err
-	}
-
-	if productSlug == "" {
-		return fmt.Errorf(ErrStemcellOSInfoMustBeValid)
 	}
 
 	if kilnfile.Stemcell.Version == "" {

--- a/internal/commands/find_stemcell_version_test.go
+++ b/internal/commands/find_stemcell_version_test.go
@@ -112,7 +112,7 @@ release_sources:
 			})
 			It("returns the stemcell os info missing error message", func() {
 				Expect(executeErr).To(HaveOccurred())
-				Expect(executeErr).To(MatchError(ContainSubstring(commands.ErrStemcellOSInfoMustBeValid)))
+				Expect(executeErr).To(MatchError(ContainSubstring("stemcell slug not set")))
 			})
 		})
 

--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -194,7 +194,25 @@ func (lock BOSHReleaseTarballLock) ParseVersion() (*semver.Version, error) {
 }
 
 type Stemcell struct {
-	Alias   string `yaml:"alias,omitempty"`
-	OS      string `yaml:"os"`
-	Version string `yaml:"version"`
+	Alias        string `yaml:"alias,omitempty"`
+	OS           string `yaml:"os"`
+	Version      string `yaml:"version"`
+	TanzuNetSlug string `yaml:"slug,omitempty"`
+}
+
+func (stemcell Stemcell) ProductSlug() (string, error) {
+	if stemcell.TanzuNetSlug != "" {
+		return stemcell.TanzuNetSlug, nil
+	}
+	// fall back behavior for compatability
+	switch stemcell.OS {
+	case "ubuntu-xenial":
+		return "stemcells-ubuntu-xenial", nil
+	case "ubuntu-jammy":
+		return "stemcells-ubuntu-jammy", nil
+	case "windows2019":
+		return "stemcells-windows-server", nil
+	default:
+		return "", fmt.Errorf("stemcell slug not set for os %s", stemcell.OS)
+	}
 }


### PR DESCRIPTION
For a while we have maintained a switch statement that mapped stemcell slugs like "ubuntu-jammy/1.2" to product slugs like "stemcells-ubuntu-jammy". This was annoying but not that big of an issue because it we do it every year or so. Instead of continuing this pattern, lets add a field to the Kilnfile so the CLI does not need to change when a new stemcell is released.

This change helps me with my buildpack work because, I want to be able to compile releases against stemcells and I want the particular stemcell to be specified in the tile source. I don't want to maintain the same switch statement in both Kiln and in the buildpack. I intend to import these functions into the buildpack.