### PR TITLE
Kiln cannot parse bosh variables when given as top level array.

### DIFF
--- a/example-tile/bosh_variables/some-ca-certificate.yml
+++ b/example-tile/bosh_variables/some-ca-certificate.yml
@@ -1,5 +1,5 @@
-- name: some-ca-certificate
-  type: certificate
-  options:
-    common_name: 'ca.example.com'
-    is_ca: true
+name: some-ca-certificate
+type: certificate
+options:
+  common_name: 'ca.example.com'
+  is_ca: true

--- a/example-tile/bosh_variables/some-secret.yml
+++ b/example-tile/bosh_variables/some-secret.yml
@@ -1,2 +1,2 @@
-- name: some-secret
-  type: password
+name: some-secret
+type: password


### PR DESCRIPTION
Resolves #369 