### PR TITLE
make find-release-version output match Kilnfile.lock

### DIFF
--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -127,15 +127,15 @@ type ReleaseSourceConfig struct {
 // All fields must be comparable because this struct may be
 // used as a key type in a map. Don't add array or map fields.
 type BOSHReleaseTarballLock struct {
-	Name    string `yaml:"name"`
-	SHA1    string `yaml:"sha1"`
-	Version string `yaml:"version,omitempty"`
+	Name    string `yaml:"name" json:"name"`
+	SHA1    string `yaml:"sha1" json:"sha1"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 
-	StemcellOS      string `yaml:"-"`
-	StemcellVersion string `yaml:"-"`
+	StemcellOS      string `yaml:"-" json:"-"`
+	StemcellVersion string `yaml:"-" json:"-"`
 
-	RemoteSource string `yaml:"remote_source"`
-	RemotePath   string `yaml:"remote_path"`
+	RemoteSource string `yaml:"remote_source" json:"remote_source"`
+	RemotePath   string `yaml:"remote_path" json:"remote_path"`
 }
 
 func (lock BOSHReleaseTarballLock) ReleaseSlug() boshdir.ReleaseSlug {


### PR DESCRIPTION
We from cryo just started using kiln for our tile builds. We have quite a few tiles and mostly want to bump versions in a tile to latest since we don't ship many releases in a tile.
I found the output of the find-release-version command somewhat confusing because it doesn't really match the structure of the Kilnfile.lock so I figured I'd try to PR this in.

What does this do? It drops the `releaseVersionOutput` that wasn't used anywhere else and just uses `BOSHReleaseTarballLock` to generate the output.

It adds the option to output yaml (in case you want to use the output and put it into the lockfile..)

it also updates the `BOSHReleaseTarballLock` with json tags so marshalling produces the expected output.