### PR TITLE
component: consistently handle not found errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pivotal-cf/kiln
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/internal/component/artifactory_test.go
+++ b/internal/component/artifactory_test.go
@@ -253,7 +253,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 			})
 		})
 		It("returns ErrNotFound", func() {
-			_, err := source.FindReleaseVersion(component.Spec{
+			_, err := source.FindReleaseVersion(cargo.BOSHReleaseTarballSpecification{
 				Name:            "missing-release",
 				Version:         "1.2.3",
 				StemcellOS:      "ubuntu-jammy",

--- a/internal/component/errors.go
+++ b/internal/component/errors.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -8,11 +9,7 @@ import (
 const ErrNotFound stringError = "not found"
 
 func IsErrNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	e, ok := err.(stringError)
-	return ok && e == ErrNotFound
+	return errors.Is(err, ErrNotFound)
 }
 
 type stringError string

--- a/internal/component/github_release_source.go
+++ b/internal/component/github_release_source.go
@@ -218,7 +218,7 @@ func (grs *GithubReleaseSource) getLockFromRelease(ctx context.Context, r *githu
 		}, nil
 	}
 
-	return cargo.BOSHReleaseTarballLock{}, fmt.Errorf("no matching GitHub release asset file name equal to %q", expectedAssetName)
+	return cargo.BOSHReleaseTarballLock{}, errors.Join(ErrNotFound, fmt.Errorf("no matching GitHub release asset file name equal to %q", expectedAssetName))
 }
 
 func (grs *GithubReleaseSource) getReleaseSHA1(ctx context.Context, s cargo.BOSHReleaseTarballSpecification, id int64) (string, error) {


### PR DESCRIPTION
When a github-release source is not found, kiln aborts early without trying additional release sources.

This change ensures the github release source reports "ErrNotFound" so that subsequent release sources can be tried.

Bumped go.mod -go=1.20 to pull in "errors.Join".  kiln is already built with Go 1.20 so this seems reasonable.