### PR TITLE
feat: make find-release-version output match Kilnfile.lock

### DIFF
--- a/internal/commands/find_release_version.go
+++ b/internal/commands/find_release_version.go
@@ -24,13 +24,6 @@ type FindReleaseVersion struct {
 	}
 }
 
-type releaseVersionOutput struct {
-	Version    string `json:"version"`
-	RemotePath string `json:"remote_path"`
-	Source     string `json:"source"`
-	SHA        string `json:"sha"`
-}
-
 func NewFindReleaseVersion(outLogger *log.Logger, multiReleaseSourceProvider MultiReleaseSourceProvider) *FindReleaseVersion {
 	return &FindReleaseVersion{
 		outLogger:   outLogger,
@@ -64,11 +57,12 @@ func (cmd *FindReleaseVersion) Execute(args []string) error {
 		return err
 	}
 
-	releaseVersionJson, _ := json.Marshal(releaseVersionOutput{
-		Version:    releaseRemote.Version,
-		RemotePath: releaseRemote.RemotePath,
-		Source:     releaseRemote.RemoteSource,
-		SHA:        releaseRemote.SHA1,
+	releaseVersionJson, _ := json.Marshal(cargo.BOSHReleaseTarballLock{
+		Name:         releaseRemote.Name,
+		Version:      releaseRemote.Version,
+		RemotePath:   releaseRemote.RemotePath,
+		RemoteSource: releaseRemote.RemoteSource,
+		SHA1:         releaseRemote.SHA1,
 	})
 	cmd.outLogger.Println(string(releaseVersionJson))
 	return err

--- a/internal/commands/find_release_version.go
+++ b/internal/commands/find_release_version.go
@@ -7,9 +7,9 @@ import (
 	"log"
 
 	"github.com/pivotal-cf/jhanda"
-
 	"github.com/pivotal-cf/kiln/internal/commands/flags"
 	"github.com/pivotal-cf/kiln/pkg/cargo"
+	"gopkg.in/yaml.v3"
 )
 
 type FindReleaseVersion struct {
@@ -20,6 +20,7 @@ type FindReleaseVersion struct {
 		flags.Standard
 		Release    string `short:"r" long:"release" description:"release name"`
 		NoDownload bool   `long:"no-download" description:"do not download any files"`
+		Format     string `short:"o" long:"output" description:"output format json/yaml"`
 	}
 }
 
@@ -54,6 +55,12 @@ func (cmd *FindReleaseVersion) Execute(args []string) error {
 
 	releaseRemote, err := releaseSource.FindReleaseVersion(spec, cmd.Options.NoDownload)
 	if err != nil {
+		return err
+	}
+
+	if cmd.Options.Format == `yaml` {
+		releaseVersionYaml, err := yaml.Marshal(releaseRemote)
+		cmd.outLogger.Println(string(releaseVersionYaml))
 		return err
 	}
 

--- a/internal/commands/find_release_version_test.go
+++ b/internal/commands/find_release_version_test.go
@@ -109,9 +109,10 @@ releases:
 						Expect(args.StemcellOS).To(Equal("some-os"))
 						Expect(args.Version).To(Equal(""))
 						Expect((&writer).String()).To(ContainSubstring("\"74.12.5\""))
+						Expect((&writer).String()).To(ContainSubstring("\"name\":\"has-no-constraint\""))
 						Expect((&writer).String()).To(ContainSubstring("\"remote_path\":\"remote_url\""))
-						Expect((&writer).String()).To(ContainSubstring("\"source\":\"bosh.io\""))
-						Expect((&writer).String()).To(ContainSubstring("\"sha\":\"some-sha\""))
+						Expect((&writer).String()).To(ContainSubstring("\"remote_source\":\"bosh.io\""))
+						Expect((&writer).String()).To(ContainSubstring("\"sha1\":\"some-sha\""))
 					})
 				})
 			})
@@ -179,6 +180,37 @@ releases:
 				Expect(executeErr).NotTo(HaveOccurred())
 				_, noDownload := fakeReleasesSource.FindReleaseVersionArgsForCall(0)
 				Expect(noDownload).To(BeFalse())
+			})
+		})
+
+		When("--output yaml is specified", func() {
+			BeforeEach(func() {
+				releaseName = "has-no-constraint"
+				fakeReleasesSource.FindReleaseVersionReturns(cargo.BOSHReleaseTarballLock{
+					Name: releaseName, Version: "74.12.5",
+					RemotePath:   "remote_url",
+					RemoteSource: "bosh.io",
+					SHA1:         "some-sha",
+				}, nil)
+				fetchExecuteArgs = []string{
+					"--kilnfile", someKilnfilePath,
+					"--release", releaseName,
+					"--output", "yaml",
+				}
+			})
+
+			It("returns the latest release version", func() {
+				Expect(executeErr).NotTo(HaveOccurred())
+				args, _ := fakeReleasesSource.FindReleaseVersionArgsForCall(0)
+				Expect(args.StemcellVersion).To(Equal("4.5.6"))
+				Expect(args.StemcellOS).To(Equal("some-os"))
+				Expect(args.Version).To(Equal(""))
+				logger.Printf("output is: %s", (&writer).String())
+				Expect((&writer).String()).To(ContainSubstring("version: 74.12.5"))
+				Expect((&writer).String()).To(ContainSubstring("name: has-no-constraint"))
+				Expect((&writer).String()).To(ContainSubstring("remote_path: remote_url"))
+				Expect((&writer).String()).To(ContainSubstring("remote_source: bosh.io"))
+				Expect((&writer).String()).To(ContainSubstring("sha1: some-sha"))
 			})
 		})
 	})

--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -175,15 +175,15 @@ type ReleaseSourceConfig struct {
 // All fields must be comparable because this struct may be
 // used as a key type in a map. Don't add array or map fields.
 type BOSHReleaseTarballLock struct {
-	Name    string `yaml:"name"`
-	SHA1    string `yaml:"sha1"`
-	Version string `yaml:"version,omitempty"`
+	Name    string `yaml:"name" json:"name"`
+	SHA1    string `yaml:"sha1" json:"sha1"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 
-	StemcellOS      string `yaml:"-"`
-	StemcellVersion string `yaml:"-"`
+	StemcellOS      string `yaml:"-" json:"-"`
+	StemcellVersion string `yaml:"-" json:"-"`
 
-	RemoteSource string `yaml:"remote_source"`
-	RemotePath   string `yaml:"remote_path"`
+	RemoteSource string `yaml:"remote_source" json:"remote_source"`
+	RemotePath   string `yaml:"remote_path" json:"remote_path"`
 }
 
 func (lock BOSHReleaseTarballLock) ReleaseSlug() boshdir.ReleaseSlug {


### PR DESCRIPTION
We from cryo just started using kiln for our tile builds. We have quite a few tiles and mostly want to bump versions in a tile to latest since we don't ship many releases in a tile.
I found the output of the find-release-version command somewhat confusing because it doesn't really match the structure of the Kilnfile.lock so I figured I'd try to PR this in.

What does this do? It drops the `releaseVersionOutput` that wasn't used anywhere else and just uses `BOSHReleaseTarballLock` to generate the output.

It adds the option to output yaml (in case you want to use the output and put it into the lockfile..)

it also updates the `BOSHReleaseTarballLock` with json tags so marshalling produces the expected output.

Authored-by: Konstantin Kiess <kkiess@vmware.com>