### PR TITLE
refactor(test): fail integration tests when docker daemon is out of date

### DIFF
--- a/internal/test/container.go
+++ b/internal/test/container.go
@@ -39,6 +39,10 @@ import (
 const (
 	authSockEnvVarName    = "SSH_AUTH_SOCK"
 	sshPasswordEnvVarName = "SSH_PASSWORD"
+
+	// MinimumDockerServerVersion the test was failing with an older version this may be a bit conservative.
+	// If the integration tests pass on your machine with an older version, feel free to PR a less conservative value.
+	MinimumDockerServerVersion = "> 24.0.0"
 )
 
 func Run(ctx context.Context, w io.Writer, configuration Configuration) error {

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Masterminds/semver/v3"
+	"github.com/docker/docker/client"
+
 	"github.com/pivotal-cf/kiln/internal/commands"
 	"github.com/pivotal-cf/kiln/internal/test"
 )
@@ -18,6 +21,8 @@ import (
 var _ commands.TileTestFunction = test.Run
 
 func TestDockerIntegration(t *testing.T) {
+	checkDaemonVersion(t)
+
 	t.Run("the test succeeds", func(t *testing.T) {
 		_, githubWorkspaceEnvVarFound := os.LookupEnv("GITHUB_WORKSPACE")
 		if testing.Short() || githubWorkspaceEnvVarFound {
@@ -67,4 +72,26 @@ func TestDockerIntegration(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, outBuffer.String(), "FAIL_TEST is true")
 	})
+}
+
+func checkDaemonVersion(t *testing.T) {
+	t.Helper()
+
+	constraints, err := semver.NewConstraint(test.MinimumDockerServerVersion)
+	require.NoError(t, err)
+
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	info, err := dockerClient.ServerVersion(ctx)
+	require.NoError(t, err)
+
+	v := semver.MustParse(info.Version)
+
+	ok, reasons := constraints.Validate(v)
+	for _, reason := range reasons {
+		t.Log(reason.Error())
+	}
+	require.True(t, ok, "kiln test requires a newer version of Docker")
 }


### PR DESCRIPTION
I thought there was a problem with kiln when it was just my machine.
This test surfaces the daemon being out of date.

This is my error log.
```
=== RUN   TestDockerIntegration
=== RUN   TestDockerIntegration/the_test_succeeds
kiln test: 2023/09/05 11:20:55 connecting to ssh socket "/private/tmp/com.apple.launchd.jplCwFZ1Ie/Listeners"
kiln test: 2023/09/05 11:20:55 ensuring ssh agent keys are configured
kiln test: 2023/09/05 11:20:55 pinging docker daemon
kiln test: 2023/09/05 11:20:55 completed session setup
kiln test: 2023/09/05 11:20:55 creating test image
    integration_test.go:41: 
                Error Trace:    /Users/hunterch/workspace/tile-srp/kiln/internal/test/integration_test.go:41
                Error:          Received unexpected error:
                                failed to load cache key: failed to fetch remote https://ssh/://git@github.com/pivotal-cf/ops-manager.git: exit status 128
                Test:           TestDockerIntegration/the_test_succeeds
=== RUN   TestDockerIntegration/the_test_fails
kiln test: 2023/09/05 11:20:56 connecting to ssh socket "/private/tmp/com.apple.launchd.jplCwFZ1Ie/Listeners"
kiln test: 2023/09/05 11:20:56 ensuring ssh agent keys are configured
kiln test: 2023/09/05 11:20:56 pinging docker daemon
kiln test: 2023/09/05 11:20:56 completed session setup
kiln test: 2023/09/05 11:20:56 creating test image
    integration_test.go:68: 
                Error Trace:    /Users/hunterch/workspace/tile-srp/kiln/internal/test/integration_test.go:68
                Error:          "kiln test: 2023/09/05 11:20:56 connecting to ssh socket \"/private/tmp/com.apple.launchd.jplCwFZ1Ie/Listeners\"\nkiln test: 2023/09/05 11:20:56 ensuring ssh agent keys are configured\nkiln test: 2023/09/05 11:20:56 pinging docker daemon\nkiln test: 2023/09/05 11:20:56 completed session setup\nkiln test: 2023/09/05 11:20:56 creating test image\n" does not contain "FAIL_TEST is true"
                Test:           TestDockerIntegration/the_test_fails
--- FAIL: TestDockerIntegration (2.32s)
    --- FAIL: TestDockerIntegration/the_test_succeeds (1.64s)
    --- FAIL: TestDockerIntegration/the_test_fails (0.68s)
FAIL
FAIL    github.com/pivotal-cf/kiln/internal/test        2.623s
FAIL
```

We may want to add this to the test command itself but for now this makes test failures clearer.