### PR TITLE
add additional logs when removing releases

### DIFF
--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -164,9 +164,9 @@ nextRelease:
 				missing = append(missing[:j], missing[j+1:]...)
 				continue nextRelease
 			} else if rel.Lock.Name == lock.Name && rel.Lock.Version == lock.Version {
-				fmt.Printf("release: [ %s ] sha mismatch: [ %s ]\n", lock.Name, rel.Lock.SHA1)
+				fmt.Printf("Local release: [ %s ] sha mismatch: [ %s ]\n", lock.Name, rel.Lock.SHA1)
 			} else if rel.Lock.Name == lock.Name && rel.Lock.SHA1 == lock.SHA1 {
-				fmt.Printf("release: [ %s ] version mismatch: [ %s ]\n", lock.Name, rel.Lock.Version)
+				fmt.Printf("Local release: [ %s ] version mismatch: [ %s ]\n", lock.Name, rel.Lock.Version)
 			}
 		}
 

--- a/internal/commands/fetch.go
+++ b/internal/commands/fetch.go
@@ -163,6 +163,10 @@ nextRelease:
 				intersection = append(intersection, rel)
 				missing = append(missing[:j], missing[j+1:]...)
 				continue nextRelease
+			} else if rel.Lock.Name == lock.Name && rel.Lock.Version == lock.Version {
+				fmt.Printf("release: [ %s ] sha mismatch: [ %s ]\n", lock.Name, rel.Lock.SHA1)
+			} else if rel.Lock.Name == lock.Name && rel.Lock.SHA1 == lock.SHA1 {
+				fmt.Printf("release: [ %s ] version mismatch: [ %s ]\n", lock.Name, rel.Lock.Version)
 			}
 		}
 


### PR DESCRIPTION
when a release is removed, it is difficult to understand the reason why. this adds some helpful messages to better communicate if a bad sha or a bad version is the reason for deleting a mismatched release