### PR TITLE
Kiln bake logs confusing error when the tarball is empty (this happens sometimes when fetch fails)

### DIFF
--- a/pkg/cargo/bosh_release.go
+++ b/pkg/cargo/bosh_release.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -135,6 +136,13 @@ func OpenBOSHReleaseTarball(tarballPath string) (BOSHReleaseTarball, error) {
 	file, err := os.Open(tarballPath)
 	if err != nil {
 		return BOSHReleaseTarball{}, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return BOSHReleaseTarball{}, err
+	}
+	if info.Size() == 0 {
+		return BOSHReleaseTarball{}, fmt.Errorf("BOSH release tarball %s is an empty file", filepath.Base(tarballPath))
 	}
 	defer closeAndIgnoreError(file)
 	return ReadBOSHReleaseTarball(tarballPath, file)

--- a/pkg/cargo/bosh_release_test.go
+++ b/pkg/cargo/bosh_release_test.go
@@ -160,6 +160,32 @@ func TestReadProductTemplatePartFromBOSHReleaseTarball(t *testing.T) {
 	})
 }
 
+func TestOpenBOSHReleaseTarball(t *testing.T) {
+	t.Run("release tarball does not exist", func(t *testing.T) {
+		temporaryTestDirectory := t.TempDir()
+
+		releaseFilepath := filepath.Join(temporaryTestDirectory, "release.tgz")
+
+		_, err := cargo.OpenBOSHReleaseTarball(releaseFilepath)
+
+		require.Error(t, err)
+	})
+
+	t.Run("release tarball is empty not exist", func(t *testing.T) {
+		temporaryTestDirectory := t.TempDir()
+
+		releaseFilepath := filepath.Join(temporaryTestDirectory, "release.tgz")
+		{
+			f, err := os.Create(releaseFilepath)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+		}
+
+		_, err := cargo.OpenBOSHReleaseTarball(releaseFilepath)
+		require.EqualError(t, err, "BOSH release tarball release.tgz is an empty file")
+	})
+}
+
 func closeAndIgnoreError(c io.Closer) {
 	_ = c.Close()
 }


### PR DESCRIPTION
A confusing error happens sometimes when fetch fails. This change makes the error mesage clearer.

Instead of the error
> could not execute "bake": failed to parse releases: EOF

the user should see

> could not execute "bake": failed to parse releases: BOSH release tarball some-release-1.2.3.tgz is an empty file


We should also make sure fetch is cleaning up after itself on failure.