### PR TITLE
fix: Don't override pre ga release notes

### DIFF
--- a/internal/commands/release_notes.go
+++ b/internal/commands/release_notes.go
@@ -32,6 +32,7 @@ type ReleaseNotes struct {
 		GithubToken  string `long:"github-token" short:"g" description:"auth token for fetching issues merged between releases" env:"GITHUB_TOKEN"`
 		Kilnfile     string `long:"kilnfile"     short:"k" description:"path to Kilnfile"`
 		DocsFile     string `long:"update-docs"  short:"u" description:"path to docs file to update"`
+		Window       string `long:"window"       short:"w" description:"GA window for release notes" default:"ga"`
 		notes.IssuesQuery
 		notes.TrainstatQuery
 	}
@@ -101,6 +102,7 @@ func (r ReleaseNotes) Execute(args []string) error {
 		return err
 	}
 	data.ReleaseDate, _ = r.parseReleaseDate()
+	data.Window = r.Options.Window
 
 	if r.Options.DocsFile == "" {
 		return r.writeNotes(r.Writer, data)

--- a/pkg/notes/notes_data.go
+++ b/pkg/notes/notes_data.go
@@ -52,6 +52,7 @@ type Data struct {
 	TrainstatNotes []string
 
 	Stemcell cargo.Stemcell
+	Window   string
 }
 
 //func (notes Data) Strings() string {
@@ -64,11 +65,15 @@ func (notes Data) WriteVersionNotes() (TileRelease, error) {
 	if err != nil {
 		return TileRelease{}, err
 	}
-	v, err := notes.Version.SetPrerelease("")
-	if err != nil {
-		return TileRelease{}, err
+
+	if notes.Window == "ga" {
+		v, err := notes.Version.SetPrerelease("")
+		if err != nil {
+			return TileRelease{}, err
+		}
+		notes.Version = &v
 	}
-	notes.Version = &v
+
 	var buf bytes.Buffer
 	err = noteTemplate.Execute(&buf, notes)
 	if err != nil {

--- a/pkg/notes/notes_data_test.go
+++ b/pkg/notes/notes_data_test.go
@@ -440,6 +440,7 @@ func TestData_WriteVersionNotes(t *testing.T) {
 		please := NewWithT(t)
 		data := Data{
 			Version: semver.MustParse("4.0.0+LTS-T"),
+			Window:  "ga",
 		}
 
 		releaseNotes, err := data.WriteVersionNotes()
@@ -450,10 +451,11 @@ func TestData_WriteVersionNotes(t *testing.T) {
 		please.Expect(releaseNotes.Notes).To(ContainSubstring("### <a id='4.0.0'></a> 4.0.0+LTS-T"))
 	})
 
-	t.Run("version has a build pre-release suffix", func(t *testing.T) {
+	t.Run("version has a build pre-release suffix and window is ga", func(t *testing.T) {
 		please := NewWithT(t)
 		data := Data{
 			Version: semver.MustParse("4.0.0-build.3"),
+			Window:  "ga",
 		}
 
 		releaseNotes, err := data.WriteVersionNotes()
@@ -462,10 +464,24 @@ func TestData_WriteVersionNotes(t *testing.T) {
 		please.Expect(releaseNotes.Notes).To(ContainSubstring("### <a id='4.0.0'></a> 4.0.0"))
 	})
 
+	t.Run("version has a build pre-release suffix and window is not ga", func(t *testing.T) {
+		please := NewWithT(t)
+		data := Data{
+			Version: semver.MustParse("4.0.0-build.3"),
+			Window:  "alpha",
+		}
+
+		releaseNotes, err := data.WriteVersionNotes()
+		please.Expect(err).NotTo(HaveOccurred())
+
+		please.Expect(releaseNotes.Notes).To(ContainSubstring("### <a id='4.0.0-build.3'></a> 4.0.0-build.3"))
+	})
+
 	t.Run("version has a build pre-release and build metadata", func(t *testing.T) {
 		please := NewWithT(t)
 		data := Data{
 			Version: semver.MustParse("4.0.0-build.3+LTS-T"),
+			Window:  "ga",
 		}
 
 		releaseNotes, err := data.WriteVersionNotes()


### PR DESCRIPTION
- Add window flag to release-notes command

Authored-by: Pablo Rodas <prodas@vmware.com>
