### PR TITLE
improve interpolate is not adding kiln_metadata

### DIFF
--- a/internal/builder/interpolator.go
+++ b/internal/builder/interpolator.go
@@ -51,6 +51,7 @@ type InterpolateInput struct {
 	RuntimeConfigs     map[string]any
 	StubReleases       bool
 	MetadataGitSHA     string
+	SkipKilnMetadata   bool
 }
 
 func NewInterpolator() Interpolator {
@@ -68,8 +69,10 @@ func (i Interpolator) Interpolate(input InterpolateInput, name string, templateY
 		return nil, err // un-tested
 	}
 
+	if input.SkipKilnMetadata {
+		return prettyMetadata, nil
+	}
 	km := newKilnMetadata(input)
-
 	return setKilnMetadata(prettyMetadata, km)
 }
 

--- a/internal/builder/interpolator_test.go
+++ b/internal/builder/interpolator_test.go
@@ -50,7 +50,8 @@ selected_value: $( release "some-release" | select "version" )
 		interpolator = builder.NewInterpolator()
 
 		input = builder.InterpolateInput{
-			Version: "3.4.5",
+			SkipKilnMetadata: true,
+			Version:          "3.4.5",
 			BOSHVariables: map[string]any{
 				"some-bosh-variable": builder.Metadata{
 					"name": "some-bosh-variable",
@@ -188,7 +189,7 @@ some_bosh_variables:
 some_regex_replace:
 - https://some-link/3-4-5/index.html
 
-selected_value: 1.2.3	
+selected_value: 1.2.3
 `))
 		Expect(string(interpolatedYAML)).To(ContainSubstring("file: some-release-1.2.3.tgz\n"))
 	})
@@ -200,6 +201,7 @@ some_form_types:
 - $( form "some-form" )`
 
 		input = builder.InterpolateInput{
+			SkipKilnMetadata: true,
 			Variables: map[string]any{
 				"some-form-variable": "variable-form-label",
 			},
@@ -225,6 +227,7 @@ some_form_types:
 
 		BeforeEach(func() {
 			input = builder.InterpolateInput{
+				SkipKilnMetadata: true,
 				ReleaseManifests: map[string]any{
 					"some-release": proofing.Release{
 						Name:    "some-release",
@@ -290,6 +293,7 @@ additional_stemcells_criteria:
 stemcell_criteria: $( stemcell )`
 
 			input = builder.InterpolateInput{
+				SkipKilnMetadata: true,
 				ReleaseManifests: map[string]any{
 					"some-release": proofing.Release{
 						Name:    "some-release",
@@ -330,6 +334,7 @@ some_runtime_configs:
 - $( runtime_config "some-runtime-config" )`
 
 			input = builder.InterpolateInput{
+				SkipKilnMetadata: true,
 				ReleaseManifests: map[string]any{
 					"some-release": proofing.Release{
 						Name:    "some-release",

--- a/internal/builder/kiln_metadata.go
+++ b/internal/builder/kiln_metadata.go
@@ -38,11 +38,6 @@ func setKilnMetadata(in []byte, kilnMetadata KilnMetadata) ([]byte, error) {
 		return nil, fmt.Errorf("failed to parse product template: %w", err)
 	}
 
-	_, hasMetadataVersionKey := yamlnode.LookupKey(&productTemplate, "metadata_version")
-	if !hasMetadataVersionKey {
-		return in, nil
-	}
-
 	kilnMetadataValueNode, fieldExists := yamlnode.LookupKey(&productTemplate, "kiln_metadata")
 	if fieldExists {
 		fmt.Println(`WARNING: the metadata field "kiln_metadata" is owned by Kiln. You are setting it in your "base.yml". You should not set it anymore.`)


### PR DESCRIPTION
I found that we did not have the kiln version and commit shas in quite a few tile metadatas. This should fix that.