### PR TITLE
feat: Make kiln test verbose by default

### DIFF
--- a/internal/commands/test_tile.go
+++ b/internal/commands/test_tile.go
@@ -17,7 +17,8 @@ type TileTestFunction func(ctx context.Context, w io.Writer, configuration test.
 type TileTest struct {
 	Options struct {
 		TilePath   string `             long:"tile-path"                default:"."                             description:"Path to the Tile directory (e.g., ~/workspace/tas/ist)."`
-		Verbose    bool   `short:"v"    long:"verbose"                  default:"false"                         description:"Print info lines. This doesn't affect Ginkgo output."`
+		Verbose    bool   `short:"v"    long:"verbose"                  default:"true"                          description:"Print info lines. This doesn't affect Ginkgo output."`
+		Silent     bool   `short:"s"    long:"silent"                   default:"false"                         description:"Hide info lines. This doesn't affect Ginkgo output."`
 		Manifest   bool   `             long:"manifest"                 default:"false"                         description:"Focus the Manifest tests."`
 		Migrations bool   `             long:"migrations"               default:"false"                         description:"Focus the Migration tests."`
 		Stability  bool   `             long:"stability"                default:"false"                         description:"Focus the Stability tests."`
@@ -50,7 +51,7 @@ func (cmd TileTest) Execute(args []string) error {
 	}
 
 	w := cmd.output
-	if !cmd.Options.Verbose {
+	if cmd.Options.Silent {
 		w = io.Discard
 	}
 

--- a/internal/commands/test_tile_test.go
+++ b/internal/commands/test_tile_test.go
@@ -59,7 +59,7 @@ var _ = Describe("kiln test", func() {
 
 			Expect(configuration.AbsoluteTileDirectory).To(BeADirectory())
 			Expect(configuration.RunAll).To(BeTrue())
-			Expect(output.String()).To(BeEmpty())
+			Expect(output.String()).To(ContainSubstring("hello"))
 		})
 	})
 	AfterEach(func() {
@@ -94,7 +94,7 @@ var _ = Describe("kiln test", func() {
 		})
 	})
 
-	When("when the verbose flag argument is passed", func() {
+	When("when the verbose flag argument is passed or the silent flag argument is not passed", func() {
 		It("runs all the tests with initalized collaborators", func() {
 			verboseFlagArgument := []string{"--verbose"}
 
@@ -115,6 +115,30 @@ var _ = Describe("kiln test", func() {
 			Expect(w).NotTo(BeNil())
 
 			Expect(output.String()).To(ContainSubstring("hello"))
+		})
+	})
+
+	When("when the silent flag argument is passed", func() {
+		It("runs all the tests without initalized collaborators", func() {
+			silentFlagArgument := []string{"--silent"}
+
+			fakeTestFunc := fakes.TestTileFunction{}
+			fakeTestFunc.Returns(nil)
+			fakeTestFunc.Stub = func(_ context.Context, w io.Writer, _ test.Configuration) error {
+				_, _ = io.WriteString(w, "hello")
+				return nil
+			}
+
+			err := commands.NewTileTestWithCollaborators(&output, fakeTestFunc.Spy).Execute(silentFlagArgument)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeTestFunc.CallCount()).To(Equal(1))
+
+			ctx, w, _ := fakeTestFunc.ArgsForCall(0)
+			Expect(ctx).NotTo(BeNil())
+			Expect(w).NotTo(BeNil())
+
+			Expect(output.String()).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
Add a new flag --silent to hide the output