### PR TITLE
Fix/artifactory url normalization

### DIFF
--- a/internal/component/artifactory.go
+++ b/internal/component/artifactory.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -68,7 +69,13 @@ func NewArtifactoryReleaseSource(c cargo.ReleaseSourceConfig) *ArtifactoryReleas
 }
 
 func (ars *ArtifactoryReleaseSource) DownloadRelease(releaseDir string, remoteRelease cargo.BOSHReleaseTarballLock) (Local, error) {
-	downloadURL := ars.ArtifactoryHost + "/artifactory/" + ars.Repo + "/" + remoteRelease.RemotePath
+	u, err := url.Parse(ars.ArtifactoryHost)
+	downloadURL := ars.ArtifactoryHost
+	if path.Base(u.Path) != "artifactory" {
+		downloadURL += "/artifactory"
+	}
+	downloadURL += "/" + ars.Repo + "/" + remoteRelease.RemotePath
+
 	ars.logger.Printf(logLineDownload, remoteRelease.Name, ReleaseSourceTypeArtifactory, ars.ID)
 	resp, err := ars.Client.Get(downloadURL)
 	if err != nil {

--- a/internal/component/artifactory.go
+++ b/internal/component/artifactory.go
@@ -70,6 +70,9 @@ func NewArtifactoryReleaseSource(c cargo.ReleaseSourceConfig) *ArtifactoryReleas
 
 func (ars *ArtifactoryReleaseSource) DownloadRelease(releaseDir string, remoteRelease cargo.BOSHReleaseTarballLock) (Local, error) {
 	u, err := url.Parse(ars.ArtifactoryHost)
+	if err != nil {
+		return Local{}, fmt.Errorf("error parsing artifactory host: %w", err)
+	}
 	downloadURL := ars.ArtifactoryHost
 	if path.Base(u.Path) != "artifactory" {
 		downloadURL += "/artifactory"

--- a/internal/component/artifactory_test.go
+++ b/internal/component/artifactory_test.go
@@ -144,10 +144,6 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					source = component.NewArtifactoryReleaseSource(config)
 					source.Client = server.Client()
 				})
-				server = httptest.NewServer(artifactoryRouter)
-				config.ArtifactoryHost = server.URL
-				source = component.NewArtifactoryReleaseSource(config)
-				source.Client = server.Client()
 
 				It("downloads the release", func() { // teesting DownloadRelease
 					By("calling FindReleaseVersion")

--- a/internal/component/artifactory_test.go
+++ b/internal/component/artifactory_test.go
@@ -138,6 +138,30 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 				Expect(resultErr).NotTo(HaveOccurred())
 				Expect(local.LocalPath).To(BeAnExistingFile())
 			})
+			When("the server URL ends in /artifactory", func() {
+				JustBeforeEach(func() {
+					config.ArtifactoryHost = server.URL + "/artifactory"
+					source = component.NewArtifactoryReleaseSource(config)
+					source.Client = server.Client()
+				})
+				server = httptest.NewServer(artifactoryRouter)
+				config.ArtifactoryHost = server.URL
+				source = component.NewArtifactoryReleaseSource(config)
+				source.Client = server.Client()
+
+				It("downloads the release", func() { // teesting DownloadRelease
+					By("calling FindReleaseVersion")
+					local, resultErr := source.DownloadRelease(releasesDirectory, cargo.BOSHReleaseTarballLock{
+						Name:         "mango",
+						Version:      "2.3.4",
+						RemotePath:   "bosh-releases/smoothie/9.9/mango/mango-2.3.4-smoothie-9.9.tgz",
+						RemoteSource: "some-mango-tree",
+					})
+
+					Expect(resultErr).NotTo(HaveOccurred())
+					Expect(local.LocalPath).To(BeAnExistingFile())
+				})
+			})
 		})
 	})
 	When("uploading releases", func() { // testing UploadRelease

--- a/internal/component/artifactory_test.go
+++ b/internal/component/artifactory_test.go
@@ -145,7 +145,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					source.Client = server.Client()
 				})
 
-				It("downloads the release", func() { // teesting DownloadRelease
+				It("downloads the release", func() {
 					By("calling FindReleaseVersion")
 					local, resultErr := source.DownloadRelease(releasesDirectory, cargo.BOSHReleaseTarballLock{
 						Name:         "mango",
@@ -164,7 +164,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					source = component.NewArtifactoryReleaseSource(config)
 					source.Client = server.Client()
 				})
-				It("returns an error", func() { // teesting DownloadRelease
+				It("returns an error", func() {
 					local, resultErr := source.DownloadRelease(releasesDirectory, cargo.BOSHReleaseTarballLock{
 						Name:         "mango",
 						Version:      "2.3.4",

--- a/internal/component/artifactory_test.go
+++ b/internal/component/artifactory_test.go
@@ -158,6 +158,24 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					Expect(local.LocalPath).To(BeAnExistingFile())
 				})
 			})
+			When("the server URL is malformed", func() {
+				JustBeforeEach(func() {
+					config.ArtifactoryHost = ":improper-url/formatting"
+					source = component.NewArtifactoryReleaseSource(config)
+					source.Client = server.Client()
+				})
+				It("returns an error", func() { // teesting DownloadRelease
+					local, resultErr := source.DownloadRelease(releasesDirectory, cargo.BOSHReleaseTarballLock{
+						Name:         "mango",
+						Version:      "2.3.4",
+						RemotePath:   "bosh-releases/smoothie/9.9/mango/mango-2.3.4-smoothie-9.9.tgz",
+						RemoteSource: "some-mango-tree",
+					})
+
+					Expect(resultErr).To(HaveOccurred())
+					Expect(local).To(Equal(component.Local{}))
+				})
+			})
 		})
 	})
 	When("uploading releases", func() { // testing UploadRelease


### PR DESCRIPTION
We were blocked from using `kiln` with other Artifactory servers, in our case development servers, due to `find-release-version` and `update-release-version` behaving differently from `fetch` for `artifactory` release sources.

The issue was found in `internal/component/artifactory.go` `DownloadRelease` where `/artifactory` is always appended to the server url:

```go
downloadURL := ars.ArtifactoryHost + "/artifactory/" + ars.Repo + "/" + remoteRelease.RemotePath
```

#### `find-release` fails if we don't include `/artifactory` in the Kilnfile `artifactory_host` variable

**failing**
```
➜  hello-tile git:(feat/artifactory-source) ✗ :workspace/hello-tile$ kiln find-release-version --release hello-release --no-download -vr artifactory_username="admin" -vr artifactory_password="password" -vr artifactory_host="localhost:8082"
2024/01/23 10:31:03 could not execute "find-release-version": not found
```

**working**
```shell
➜  hello-tile git:(feat/artifactory-source) ✗ :workspace/hello-tile$ kiln find-release-version --release hello-release --no-download -vr artifactory_username="admin" -vr artifactory_password="password" -vr artifactory_host="localhost:8082/artifactory"
[Artifactory release source] 2024/01/23 10:31:07 Getting hello-release file info from artifactory
{"version":"0.2.5","remote_path":"compiled-releases/hello-release/hello-release-0.2.5-ubuntu-jammy-1.260.tgz","source":"artifactory","sha":"2c40c91568fd98a815c246916aa2b8ee80bce8cd"}
```

#### `fetch`, however automatically appends `/artifactory`, causing 404s due to requests containing `/artifactory/artifactory`:


**failing**
```
➜  hello-tile git:(feat/artifactory-source) ✗ :workspace/hello-tile$ kiln fetch -vr artifactory_username="admin" -vr artifactory_password="password" -vr artifactory_host="localhost:8082/artifactory"
Warning: The "allow-only-publishable-releases" flag was not set. Some fetched releases may be intended for development/testing only. EXERCISE CAUTION WHEN PUBLISHING A TILE WITH THESE RELEASES!
Gathering releases...
Found 2 missing releases to download
[Artifactory release source] 2024/01/23 10:31:36 downloading hello-release from artifactory release source artifactory
2024/01/23 10:31:36 could not execute "fetch": download failed: error from release source "artifactory": failed to download hello-release release from artifactory with error code 404
```

**working**
```
➜  hello-tile git:(feat/artifactory-source) ✗ :workspace/hello-tile$ kiln fetch -vr artifactory_username="admin" -vr artifactory_password="password" -vr artifactory_host="localhost:8082"
Warning: The "allow-only-publishable-releases" flag was not set. Some fetched releases may be intended for development/testing only. EXERCISE CAUTION WHEN PUBLISHING A TILE WITH THESE RELEASES!
Gathering releases...
Found 2 missing releases to download
[Artifactory release source] 2024/01/23 10:32:29 downloading hello-release from artifactory release source artifactory
[Artifactory release source] 2024/01/23 10:32:30 downloading bpm from artifactory release source artifactory
...
```

Thank you