### PR TITLE
add final flag to bake

### DIFF
--- a/internal/acceptance/workflows/baking_a_tile.feature
+++ b/internal/acceptance/workflows/baking_a_tile.feature
@@ -4,6 +4,7 @@ Feature: As a developer, I want to bake a tile
     And the repository has no fetched releases
     When I invoke kiln
       | bake                                      |
+      | --final                                   |
       | --variable=github_token="${GITHUB_TOKEN}" |
     Then a Tile is created
     And the Tile contains

--- a/internal/acceptance/workflows/scenario/step_funcs_exec.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_exec.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/cucumber/godog"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/cucumber/godog"
 )
 
 func outputContainsSubstring(ctx context.Context, outputName, substring string) error {
@@ -76,5 +77,5 @@ func iWriteFileWith(ctx context.Context, fileName string, lines *godog.Table) er
 	}
 
 	fileName = filepath.Join(tileDir, fileName)
-	return os.WriteFile(fileName, out.Bytes(), 0644)
+	return os.WriteFile(fileName, out.Bytes(), 0o644)
 }

--- a/internal/acceptance/workflows/scenario/step_funcs_tile_source_code.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_tile_source_code.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/cucumber/godog"
 	"io"
 	"io/fs"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/cucumber/godog"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 )

--- a/internal/commands/bake.go
+++ b/internal/commands/bake.go
@@ -168,6 +168,8 @@ type Bake struct {
 		flags.Standard
 		flags.FetchBakeOptions
 
+		IsFinal bool `long:"final" description:"this flag causes build metadata to be written to bake_records"`
+
 		Metadata                 string   `short:"m"   long:"metadata"                   default:"base.yml"         description:"path to the metadata file"`
 		ReleaseDirectories       []string `short:"rd"  long:"releases-directory"         default:"releases"         description:"path to a directory containing release tarballs"`
 		FormDirectories          []string `short:"f"   long:"forms-directory"            default:"forms"            description:"path to a directory containing forms"`
@@ -515,8 +517,10 @@ func (b Bake) Execute(args []string) error {
 		return nil
 	}
 
-	if err := b.writeBakeRecord(b.Options.Metadata, interpolatedMetadata); err != nil {
-		return err
+	if b.Options.IsFinal {
+		if err := b.writeBakeRecord(b.Options.Metadata, interpolatedMetadata); err != nil {
+			return err
+		}
 	}
 
 	err = b.tileWriter.Write(interpolatedMetadata, builder.WriteInput{

--- a/internal/commands/bake_test.go
+++ b/internal/commands/bake_test.go
@@ -5,6 +5,11 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/pivotal-cf/kiln/pkg/source"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -189,6 +194,7 @@ var _ = Describe("Bake", func() {
 	Describe("Execute", func() {
 		It("builds the tile", func() {
 			err := bake.Execute([]string{
+				"--final",
 				"--embed", "some-embed-path",
 				"--forms-directory", "some-forms-directory",
 				"--icon", "some-icon-path",
@@ -941,4 +947,17 @@ func (f *fakeWriteBakeRecordFunc) call(filePath string, productTemplate []byte) 
 	f.filePath = filePath
 	f.productTemplate = productTemplate
 	return f.err
+}
+
+func TestBakeDescription(t *testing.T) {
+	o := reflect.ValueOf(commands.Bake{}.Options).Type()
+	const fieldName = "IsFinal"
+	field, ok := o.FieldByName(fieldName)
+	if !ok {
+		t.Fatalf("expected Options struct field %s", fieldName)
+	}
+	description := field.Tag.Get("description")
+	if !strings.Contains(description, source.BakeRecordsDirectory) {
+		t.Errorf("expected description to mention bake records directory %q", source.BakeRecordsDirectory)
+	}
 }

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -21,14 +21,14 @@ import (
 var _ commands.TileTestFunction = test.Run
 
 func TestDockerIntegration(t *testing.T) {
+	_, githubWorkspaceEnvVarFound := os.LookupEnv("GITHUB_WORKSPACE")
+	if testing.Short() || githubWorkspaceEnvVarFound {
+		t.Skip("integration test is slow")
+	}
+
 	checkDaemonVersion(t)
 
 	t.Run("the test succeeds", func(t *testing.T) {
-		_, githubWorkspaceEnvVarFound := os.LookupEnv("GITHUB_WORKSPACE")
-		if testing.Short() || githubWorkspaceEnvVarFound {
-			t.Skip("integration test is slow")
-		}
-
 		wd, err := os.Getwd()
 		require.NoError(t, err)
 
@@ -47,11 +47,6 @@ func TestDockerIntegration(t *testing.T) {
 	})
 
 	t.Run("the test fails", func(t *testing.T) {
-		_, githubWorkspaceEnvVarFound := os.LookupEnv("GITHUB_WORKSPACE")
-		if testing.Short() || githubWorkspaceEnvVarFound {
-			t.Skip("integration test is slow")
-		}
-
 		wd, err := os.Getwd()
 		require.NoError(t, err)
 

--- a/pkg/notes/notes_data.go
+++ b/pkg/notes/notes_data.go
@@ -629,7 +629,6 @@ func (t *TrainstatClient) FetchTrainstatNotes(ctx context.Context, milestone str
 func (t *TrainstatClient) FetchTrainstatWinfsVersionInfo(ctx context.Context, milestone string, version string) (bumped bool, winfsVersion string, err error) {
 	baseURL := fmt.Sprintf("%s/%s", t.host, "api/v1/get_winfs_version_bump")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL, nil)
-
 	if err != nil {
 		return false, "", err
 	}

--- a/pkg/source/bake_record.go
+++ b/pkg/source/bake_record.go
@@ -3,13 +3,14 @@ package source
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/pivotal-cf/kiln/internal/builder"
 
@@ -90,7 +91,7 @@ func (b BakeRecord) WriteFile(tileSourceDirectory string) error {
 	if b.IsDevBuild() {
 		return fmt.Errorf("will not write development builds to %s directory", BakeRecordsDirectory)
 	}
-	if err := os.MkdirAll(filepath.Join(tileSourceDirectory, BakeRecordsDirectory), 0766); err != nil {
+	if err := os.MkdirAll(filepath.Join(tileSourceDirectory, BakeRecordsDirectory), 0o766); err != nil {
 		return err
 	}
 	buf, err := json.MarshalIndent(b, "", "  ")
@@ -105,7 +106,7 @@ func (b BakeRecord) WriteFile(tileSourceDirectory string) error {
 	if _, err := os.Stat(outputFilepath); err == nil {
 		return fmt.Errorf("tile bake record already exists for %s", b.Name())
 	}
-	return os.WriteFile(outputFilepath, buf, 0644)
+	return os.WriteFile(outputFilepath, buf, 0o644)
 }
 
 func ReadBakeRecords(dir fs.FS) ([]BakeRecord, error) {

--- a/pkg/source/bake_record_test.go
+++ b/pkg/source/bake_record_test.go
@@ -1,10 +1,11 @@
 package source_test
 
 import (
-	"github.com/pivotal-cf/kiln/internal/builder"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/pivotal-cf/kiln/internal/builder"
 
 	"github.com/stretchr/testify/require"
 
@@ -12,7 +13,6 @@ import (
 )
 
 func TestBuild(t *testing.T) {
-
 	t.Run("when creating a bake record from a product template", func(t *testing.T) {
 		// language=yaml
 		b, err := source.NewBakeRecord([]byte(`


### PR DESCRIPTION
The `bake --final` command should be used when baking a final tile.

Please see [feat(bake): add flag to block writing bake_record](https://github.com/pivotal-cf/kiln/pull/475/commits/14bc47c2a0642843fefa6cbed91a43ea8ff65049) to review the functionality change.

---

This PR includes two additional unrelated commits:
- the result of running gofumpt
- refactoring a test that fails when docker is not reachable even though the tests using docker are skipped