### PR TITLE
Fixes bug when reading tile_name variable

### DIFF
--- a/internal/commands/bake.go
+++ b/internal/commands/bake.go
@@ -437,7 +437,7 @@ func (b Bake) Execute(args []string) error {
 		// TODO remove when stemcell tarball is deprecated
 		stemcellManifest, err = b.stemcell.FromTarball(b.Options.StemcellTarball)
 	} else if b.Options.Kilnfile != "" {
-		if err := bakeArgumentsFromKilnfileConfiguration(&b.Options, templateVariables); err != nil {
+		if err := BakeArgumentsFromKilnfileConfiguration(&b.Options, templateVariables); err != nil {
 			return fmt.Errorf("failed to parse releases: %s", err)
 		}
 		templateVariables, err = b.templateVariables.FromPathsAndPairs(b.Options.VariableFiles, b.Options.Variables)
@@ -590,7 +590,7 @@ func (b Bake) Usage() jhanda.Usage {
 	}
 }
 
-func bakeArgumentsFromKilnfileConfiguration(options *BakeOptions, variables map[string]any) error {
+func BakeArgumentsFromKilnfileConfiguration(options *BakeOptions, variables map[string]any) error {
 	if options.Kilnfile == "" {
 		return nil
 	}
@@ -610,7 +610,7 @@ func bakeArgumentsFromKilnfileConfiguration(options *BakeOptions, variables map[
 	}
 	if tileName, ok := variables[builder.TileNameVariable]; ok {
 		name, ok := tileName.(string)
-		if ok {
+		if !ok {
 			return fmt.Errorf("%s value must be a string got value %#[2]v with type %[2]T", builder.TileNameVariable, tileName)
 		}
 		if index := slices.IndexFunc(kf.BakeConfigurations, func(configuration cargo.BakeConfiguration) bool {


### PR DESCRIPTION
Our team recently experienced CI failures when trying to bake a tile, after passing in the [tas variables file](https://github.com/pivotal/tas/blob/main/tas/variables/srt.yml)

That file has the properties:
`tile_name: SRT`

The result was a strange error: 'tile_name value must be a string got value "SRT" with type string'

After investigating more, we found [this commit](https://github.com/pivotal-cf/kiln/commit/ce05d124b98f985d14c700afebfb8a9d0eb13e8d#diff-cf90d1c4858c9124c40badad400dbe3aafed9ad0c7a3c72b36e14532b6d6bf25R588) included a small typo in how the 'ok' value is handled

Worth noting - it was very hard to test this via the existing Bake tests. Because of this, we needed to export the function to be able to test it properly, but we know this is probably not ideal.

Our hope is you can help to review this and find a better way to test via the existing fixturing, or be able to confirm that making it public is acceptable