### PR TITLE
for update-stemcell, only download releases if necessary 

### DIFF
--- a/internal/component/artifactory_release_source.go
+++ b/internal/component/artifactory_release_source.go
@@ -178,13 +178,20 @@ func (ars *ArtifactoryReleaseSource) GetMatchedRelease(spec cargo.BOSHReleaseTar
 	default:
 		return cargo.BOSHReleaseTarballLock{}, fmt.Errorf("unexpected http status: %s", http.StatusText(response.StatusCode))
 	}
-
-	return cargo.BOSHReleaseTarballLock{
+	
+	matchedRelease := cargo.BOSHReleaseTarballLock{
 		Name:         spec.Name,
 		Version:      spec.Version,
 		RemotePath:   remotePath,
 		RemoteSource: ars.ID,
-	}, nil
+	}
+
+	matchedRelease.SHA1, err = ars.getFileSHA1(matchedRelease)
+	if err != nil {
+		return cargo.BOSHReleaseTarballLock{}, err
+	}
+
+	return matchedRelease, nil
 }
 
 // FindReleaseVersion may use any of the fields on Requirement to return the best matching

--- a/internal/component/artifactory_release_source_test.go
+++ b/internal/component/artifactory_release_source_test.go
@@ -106,6 +106,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					// StemcellVersion: "9.9",
 					RemotePath:   "bosh-releases/smoothie/9.9/mango/mango-2.3.4-smoothie-9.9.tgz",
 					RemoteSource: "some-mango-tree",
+					SHA1:         "some-sha",
 				}))
 			})
 

--- a/internal/component/bosh_io_release_source_test.go
+++ b/internal/component/bosh_io_release_source_test.go
@@ -47,7 +47,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `null`))
 
 				path, _ = regexp.Compile(`/api/v1/releases/github.com/\S+/uaa.*`)
-				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"version": "73.3.0"}]`))
+				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"version": "73.3.0", "sha1":"b6e8a9cbc8724edcecb8658fa9459ee6c8fc259e"}]`))
 
 				path, _ = regexp.Compile(`/api/v1/releases/github.com/\S+/metrics.*`)
 				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"version": "2.3.0"}]`))
@@ -74,6 +74,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 					Version:      "73.3.0",
 					RemotePath:   uaaURL,
 					RemoteSource: component.ReleaseSourceTypeBOSHIO,
+					SHA1:         "b6e8a9cbc8724edcecb8658fa9459ee6c8fc259e",
 				}))
 
 				foundRelease, err = releaseSource.GetMatchedRelease(rabbitmqRequirement)
@@ -299,7 +300,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 				testServer = ghttp.NewServer()
 
 				path, _ := regexp.Compile(`/api/v1/releases/github.com/\S+/cf-rabbitmq.*`)
-				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"name":"github.com/cloudfoundry/cf-rabbitmq-release","version":"309.0.5","url":"https://bosh.io/d/github.com/cloudfoundry/cf-rabbitmq-release?v=309.0.0","sha1":"5df538657c2cc830bda679420a9b162682018ded"},{"name":"github.com/cloudfoundry/cf-rabbitmq-release","version":"308.0.0","url":"https://bosh.io/d/github.com/cloudfoundry/cf-rabbitmq-release?v=308.0.0","sha1":"56202c9a466a8394683ae432ee2dea21ef6ef865"}]`))
+				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"name":"github.com/cloudfoundry/cf-rabbitmq-release","version":"309.0.5","url":"https://bosh.io/d/github.com/cloudfoundry/cf-rabbitmq-release?v=309.0.0","sha1":"5df538657c2cc830bda679420a9b162682018ded","sha256": "49cad4a9758026cbae7a26f77921300595459dfa6bc0ca5332fc6ba52bd336b8"},{"name":"github.com/cloudfoundry/cf-rabbitmq-release","version":"308.0.0","url":"https://bosh.io/d/github.com/cloudfoundry/cf-rabbitmq-release?v=308.0.0","sha1":"56202c9a466a8394683ae432ee2dea21ef6ef865","sha256":"5970d4211d236896d9366b150a66e38cbbd757fed31895962e499bb5458e0937"}]`))
 
 				releaseSource = component.NewBOSHIOReleaseSource(cargo.ReleaseSourceConfig{ID: ID, Publishable: false}, testServer.URL(), logger)
 			})


### PR DESCRIPTION
implements #492 

* Only download releases if determining the SHA1 remotely was not possible.
* Updates artifactory `GetMatchedRelease` to include remote SHA1 of matched release from remote
* Updates bosh.io `GetMatchedRelease` to include remote SHA1 of matched release from remote
* Other release sources do not appear to support determining the remote SHA1.