### PR TITLE
kiln test: Allow for configuration of ops-manifest dollar overrides

### DIFF
--- a/pkg/planitest/internal/ops_manifest_runner_test.go
+++ b/pkg/planitest/internal/ops_manifest_runner_test.go
@@ -63,14 +63,16 @@ var _ = Describe("OMRunner", func() {
 
 		When("the runner was instantiated with additional arguments", func() {
 			const (
-				tasMetadataPath = "/path/to/tas/metadata.yml"
-				tasConfigPath   = "/path/to/tas/config.yml"
+				tasMetadataPath     = "/path/to/tas/metadata.yml"
+				tasConfigPath       = "/path/to/tas/config.yml"
+				dollarOverridesPath = "/path/to/dollar/overrides.yml"
 			)
 
 			BeforeEach(func() {
 				opsManifestRunner = internal.NewOpsManifestRunner(cmdRunner, internal.RealIO,
 					"--tas-metadata-path", tasMetadataPath,
 					"--tas-config-file", tasConfigPath,
+					"--dollar-accessor-values-file", dollarOverridesPath,
 				)
 			})
 
@@ -84,7 +86,7 @@ var _ = Describe("OMRunner", func() {
 				Expect(cmdRunner.RunCallCount()).To(Equal(1))
 				command, args := cmdRunner.RunArgsForCall(0)
 				Expect(command).To(Equal("ops-manifest"))
-				Expect(args).To(HaveLen(8))
+				Expect(args).To(HaveLen(10))
 				Expect(args[0]).To(ContainSubstring("--config-file"))
 				Expect(args[1]).To(HaveSuffix(".yml"))
 				Expect(args[2]).To(ContainSubstring("--metadata-path"))
@@ -93,6 +95,8 @@ var _ = Describe("OMRunner", func() {
 				Expect(args[5]).To(Equal(tasMetadataPath))
 				Expect(args[6]).To(Equal("--tas-config-file"))
 				Expect(args[7]).To(Equal(tasConfigPath))
+				Expect(args[8]).To(Equal("--dollar-accessor-values-file"))
+				Expect(args[9]).To(Equal(dollarOverridesPath))
 
 				Expect(manifest).To(Equal(map[string]any{
 					"name": "cf-some-guid",

--- a/pkg/planitest/product_service.go
+++ b/pkg/planitest/product_service.go
@@ -54,6 +54,8 @@ func NewProductService(config ProductConfig) (*ProductService, error) {
 func opsManifestAdditionalArgs() []string {
 	tasMetadataPath := os.Getenv("TAS_METADATA_PATH")
 	tasConfigFile := os.Getenv("TAS_CONFIG_FILE")
+	dollarOverridesFile := os.Getenv("DOLLAR_OVERRIDES_FILE")
+
 	var args []string
 
 	if tasMetadataPath != "" {
@@ -62,6 +64,10 @@ func opsManifestAdditionalArgs() []string {
 
 	if tasConfigFile != "" {
 		args = append(args, "--tas-config-file", tasConfigFile)
+	}
+
+	if dollarOverridesFile != "" {
+		args = append(args, "--dollar-accessor-values-file", dollarOverridesFile)
 	}
 
 	return args


### PR DESCRIPTION
file.

ops-manifest has an [option](https://github.com/pivotal-cf/ops-manager/blob/releases/3.0/gems/ops-manifest/exe/ops-manifest) to override the dollar overrides file. This file is used when tile configuration references $ properties (e.g $runtime)
This commit just adds the possibility to configure kiln test to pass that value to ops-manager in the same way it passes tile-config and tile-manifest overrides.