### PR TITLE
Use tile name field for bake output filename

### DIFF
--- a/internal/acceptance/workflows/scenario/step_funcs_tile.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_tile.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
-	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"
@@ -23,12 +23,18 @@ import (
 
 // aTileIsCreated asserts the output tile exists
 func aTileIsCreated(ctx context.Context) error {
-	tilePath, err := defaultFilePathForTile(ctx)
+	p, err := tileRepoPath(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = os.Stat(tilePath)
-	return err
+	matches, err := filepath.Glob(filepath.Join(p, "*.pivotal"))
+	if err != nil {
+		return err
+	}
+	if len(matches) == 0 {
+		return errors.New("no tile found")
+	}
+	return nil
 }
 
 // theTileContains checks that the filePaths exist in the tile

--- a/internal/commands/bake.go
+++ b/internal/commands/bake.go
@@ -348,27 +348,23 @@ func (b *Bake) loadFlags(args []string) error {
 	}
 
 	if shouldReadVersionFile(b, args) {
-		fileInfo, err := b.fs.Stat("version")
-		// TODO: test this
-		if fileInfo != nil && err == nil {
-			var file File
-			file, err = b.fs.Open(fileInfo.Name())
-			if err != nil && file == nil {
-				return err
-			}
+		file, err := b.fs.Open("version")
+		if err == nil {
 			defer closeAndIgnoreError(file)
-
-			versionBuf := make([]byte, fileInfo.Size())
-			_, _ = file.Read(versionBuf)
+			versionBuf, _ := io.ReadAll(file)
 			b.Options.Version = strings.TrimSpace(string(versionBuf))
 		}
 	}
 
 	if shouldGenerateTileFileName(b, args) {
-		b.Options.OutputFile = "tile.pivotal"
-		if b.Options.Version != "" {
-			b.Options.OutputFile = "tile-" + b.Options.Version + ".pivotal"
+		prefix := "tile"
+		if b.Options.TileName != "" {
+			prefix = b.Options.TileName
 		}
+		if b.Options.Version != "" {
+			prefix += "-" + b.Options.Version
+		}
+		b.Options.OutputFile = prefix + ".pivotal"
 	}
 
 	if shouldNotUseDefaultKilnfileFlag(args) {

--- a/internal/commands/bake_test.go
+++ b/internal/commands/bake_test.go
@@ -398,6 +398,18 @@ var _ = Describe("Bake", func() {
 			Expect(string(fakeBakeRecordFunc.productTemplate)).To(Equal("some-interpolated-metadata"), "it gives the bake recorder the product template")
 		})
 
+		FContext("when the output flag is not set", func() {
+			When("the tile-name flag is not provided", func() {
+				It("uses the tile as the filename prefix", func() {
+					err := bake.Execute([]string{})
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(fakeTileWriter.WriteCallCount()).To(Equal(1))
+					_, input := fakeTileWriter.WriteArgsForCall(0)
+					Expect(input.OutputFile).To(Equal(filepath.Join("tile-v1.2.3.pivotal")))
+				})
+			})
+		})
+
 		Context("when bake configuration is in the Kilnfile", func() {
 			BeforeEach(func() {
 				bake = bake.WithKilnfileFunc(func(s string) (cargo.Kilnfile, error) {
@@ -448,6 +460,7 @@ var _ = Describe("Bake", func() {
 			When("a the tile flag is passed", func() {
 				It("it uses the value from the bake configuration with the correct name", func() {
 					err := bake.Execute([]string{
+						"bake",
 						"--tile-name=p-each",
 					})
 					Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
Much of the scripting around Kiln in CI is to make the name match some expected pattern. Many of those scripts end up doing something like "p-lum-1.2.3.pivotal" where "p-lum" is the tile name.

This change makes it so Kiln uses the tile name instead of "tile-" as the default tile prefix.