### PR TITLE
Kiln validate resource type allow list

### DIFF
--- a/internal/commands/update_release.go
+++ b/internal/commands/update_release.go
@@ -78,7 +78,6 @@ func (u UpdateRelease) Execute(args []string) error {
 			StemcellOS:       kilnfileLock.Stemcell.OS,
 			GitHubRepository: releaseSpec.GitHubRepository,
 		}, false)
-
 		if err != nil {
 			if component.IsErrNotFound(err) {
 				return fmt.Errorf("error finding the release: %w", err)
@@ -99,7 +98,6 @@ func (u UpdateRelease) Execute(args []string) error {
 			StemcellVersion:  kilnfileLock.Stemcell.Version,
 			GitHubRepository: releaseSpec.GitHubRepository,
 		})
-
 		if err != nil {
 			if component.IsErrNotFound(err) {
 				return fmt.Errorf("error finding the release: %w", err)

--- a/internal/commands/update_stemcell.go
+++ b/internal/commands/update_stemcell.go
@@ -48,7 +48,6 @@ func (update UpdateStemcell) Execute(args []string) error {
 
 	kilnStemcellVersion := kilnfile.Stemcell.Version
 	releaseVersionConstraint, err = semver.NewConstraint(kilnStemcellVersion)
-
 	if err != nil {
 		return fmt.Errorf("invalid stemcell constraint in kilnfile: %w", err)
 	}

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/go-git/go-billy/v5"
@@ -40,15 +39,7 @@ func (v Validate) Execute(args []string) error {
 		return fmt.Errorf("failed to load kilnfiles: %w", err)
 	}
 
-	if len(v.Options.ReleaseSourceTypeAllowList) > 0 {
-		for _, s := range kf.ReleaseSources {
-			if !slices.Contains(v.Options.ReleaseSourceTypeAllowList, s.Type) {
-				return fmt.Errorf("release source type not allowed: %s", s.Type)
-			}
-		}
-	}
-
-	errs := cargo.Validate(kf, lock)
+	errs := cargo.Validate(kf, lock, cargo.ValidateResourceTypeAllowList(v.Options.ReleaseSourceTypeAllowList...))
 	if len(errs) > 0 {
 		return errorList(errs)
 	}

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pivotal-cf/kiln/internal/commands"
 )
 
-var _ = FDescribe("validate", func() {
+var _ = Describe("validate", func() {
 	var (
 		validate  commands.Validate
 		directory billy.Filesystem

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pivotal-cf/kiln/internal/commands"
 )
 
-var _ = Describe("validate", func() {
+var _ = FDescribe("validate", func() {
 	var (
 		validate  commands.Validate
 		directory billy.Filesystem
@@ -62,6 +62,11 @@ release_sources:
 				Expect(err).To(MatchError(ContainSubstring("release source type not allowed: github")))
 			})
 		})
+		When("the allow list is empty", func() {
+			It("it does not fail", func() {
+				err := validate.Execute([]string{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
 	})
-
 })

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -30,6 +30,7 @@ var _ = Describe("validate", func() {
 		BeforeEach(func() {
 			f, err := directory.Create("Kilnfile")
 			Expect(err).NotTo(HaveOccurred())
+			// language=yaml
 			_, _ = io.WriteString(f, `---
 release_sources:
   - type: "bosh.io"

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -1,0 +1,66 @@
+package commands_test
+
+import (
+	"io"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+
+	"github.com/pivotal-cf/kiln/internal/commands"
+)
+
+var _ = Describe("validate", func() {
+	var (
+		validate  commands.Validate
+		directory billy.Filesystem
+	)
+
+	BeforeEach(func() {
+		directory = memfs.New()
+	})
+
+	JustBeforeEach(func() {
+		validate = commands.NewValidate(directory)
+	})
+
+	When("the kilnfile has two release_sources", func() {
+		BeforeEach(func() {
+			f, err := directory.Create("Kilnfile")
+			Expect(err).NotTo(HaveOccurred())
+			_, _ = io.WriteString(f, `---
+release_sources:
+  - type: "bosh.io"
+  - type: "github"
+`)
+			_ = f.Close()
+		})
+
+		BeforeEach(func() {
+			f, err := directory.Create("Kilnfile.lock")
+			Expect(err).NotTo(HaveOccurred())
+			_ = f.Close()
+		})
+
+		When("both types are in the allow list", func() {
+			It("it does fail", func() {
+				err := validate.Execute([]string{
+					"--allow-release-source-type=bosh.io",
+					"--allow-release-source-type=github",
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("both one of the types is not in the allow list", func() {
+			It("it does fail", func() {
+				err := validate.Execute([]string{
+					"--allow-release-source-type=bosh.io",
+				})
+				Expect(err).To(MatchError(ContainSubstring("release source type not allowed: github")))
+			})
+		})
+	})
+
+})

--- a/pkg/cargo/validate.go
+++ b/pkg/cargo/validate.go
@@ -11,8 +11,13 @@ type ValidationOptions struct {
 	resourceTypeAllowList []string
 }
 
+func NewValidateOptions() ValidationOptions {
+	return ValidationOptions{}
+}
+
+// ValidateResourceTypeAllowList calls ValidationOptions.SetValidateResourceTypeAllowList on the result of NewValidateOptions
 func ValidateResourceTypeAllowList(allowList ...string) ValidationOptions {
-	return ValidationOptions{}.SetValidateResourceTypeAllowList(allowList)
+	return NewValidateOptions().SetValidateResourceTypeAllowList(allowList)
 }
 
 func (o ValidationOptions) SetValidateResourceTypeAllowList(allowList []string) ValidationOptions {

--- a/pkg/cargo/validate.go
+++ b/pkg/cargo/validate.go
@@ -2,9 +2,10 @@ package cargo
 
 import (
 	"fmt"
-	"github.com/Masterminds/semver/v3"
 	"slices"
 	"text/template/parse"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 type ValidationOptions struct {

--- a/pkg/cargo/validate_test.go
+++ b/pkg/cargo/validate_test.go
@@ -1,6 +1,7 @@
 package cargo
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -325,5 +326,290 @@ func TestValidateWithOptions(t *testing.T) {
 				assert.ErrorContains(t, errs[0], "release source type not allowed: farm")
 			}
 		})
+	})
+
+	t.Run("when a release_source is not configured properly", func(t *testing.T) {
+		for _, tt := range []struct {
+			Name    string
+			Sources []ReleaseSourceConfig
+			Error   func(t *testing.T, errs []error)
+		}{
+			{
+				Name: "artifactory host is empty",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type: BOSHReleaseTarballSourceTypeArtifactory,
+						ID:   "",
+						// ArtifactoryHost: "http://example.com",
+						Username:     "bot",
+						Password:     "beep boop",
+						Repo:         "secret-stash",
+						PathTemplate: "some-path",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "missing required field artifactory_host")
+				},
+			},
+			{
+				Name: "artifactory password is empty",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						// Password: "beep boop",
+						Repo:         "secret-stash",
+						PathTemplate: "some-path",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "missing required field password")
+				},
+			},
+			{
+				Name: "artifactory username is empty",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						// Username:        "bot",
+						Password:     "beep boop",
+						Repo:         "secret-stash",
+						PathTemplate: "some-path",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "missing required field username")
+				},
+			},
+			{
+				Name: "artifactory repo is empty",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						// Repo:     "secret-stash",
+						PathTemplate: "some-path",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "missing required field repo")
+				},
+			},
+			{
+				Name: "artifactory path_template is empty",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						// PathTemplate:    "some-path",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "missing required field path_template")
+				},
+			},
+			{
+				Name: "artifactory path_template is malformed",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "{{ loosing power",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "failed to parse path_template:")
+				},
+			},
+			{
+				Name: "artifactory has unexpected field bucket",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "ok",
+
+						Bucket: "UNEXPECTED",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "unexpected field bucket")
+				},
+			},
+			{
+				Name: "artifactory has unexpected field region",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "ok",
+
+						Region: "UNEXPECTED",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "unexpected field region")
+				},
+			},
+			{
+				Name: "artifactory has unexpected field access_key_id",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "ok",
+
+						AccessKeyId: "UNEXPECTED",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "unexpected field access_key_id")
+				},
+			},
+			{
+				Name: "artifactory has unexpected field secret_access_key",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "ok",
+
+						SecretAccessKey: "UNEXPECTED",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "unexpected field secret_access_key")
+				},
+			},
+			{
+				Name: "artifactory has unexpected field role_arn",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "ok",
+
+						RoleARN: "UNEXPECTED",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "unexpected field role_arn")
+				},
+			},
+			{
+				Name: "artifactory has unexpected field endpoint",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "ok",
+
+						Endpoint: "UNEXPECTED",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "unexpected field endpoint")
+				},
+			},
+			{
+				Name: "artifactory has unexpected field org",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "ok",
+
+						Org: "UNEXPECTED",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "unexpected field org")
+				},
+			},
+			{
+				Name: "artifactory has unexpected field github_token",
+				Sources: []ReleaseSourceConfig{
+					{
+						Type:            BOSHReleaseTarballSourceTypeArtifactory,
+						ID:              "",
+						ArtifactoryHost: "http://example.com",
+						Username:        "bot",
+						Password:        "beep boop",
+						Repo:            "secret-stash",
+						PathTemplate:    "ok",
+
+						GithubToken: "UNEXPECTED",
+					},
+				},
+				Error: func(t *testing.T, errs []error) {
+					require.Len(t, errs, 1)
+					assert.ErrorContains(t, errs[0], "unexpected field github_token")
+				},
+			},
+		} {
+			t.Run(tt.Name, func(t *testing.T) {
+				k := Kilnfile{
+					ReleaseSources: tt.Sources,
+				}
+				errs := Validate(k, KilnfileLock{})
+				tt.Error(t, errs)
+			})
+		}
 	})
 }

--- a/pkg/cargo/validate_test.go
+++ b/pkg/cargo/validate_test.go
@@ -1,8 +1,9 @@
 package cargo
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	. "github.com/onsi/gomega"
 

--- a/pkg/planitest/internal/config.go
+++ b/pkg/planitest/internal/config.go
@@ -43,7 +43,6 @@ func MergeAdditionalProductProperties(configFile io.Reader, additionalProperties
 
 	var inputConfig ProductConfiguration
 	err = yaml.Unmarshal(yamlInput, &inputConfig)
-
 	if err != nil {
 		return nil, fmt.Errorf("could not parse config file: %s", err)
 	}

--- a/pkg/planitest/internal/om_runner.go
+++ b/pkg/planitest/internal/om_runner.go
@@ -89,7 +89,6 @@ func (o OMRunner) ResetAndConfigure(productName string, productVersion string, c
 		"--product-name", productName,
 		"--product-version", productVersion,
 	)
-
 	if err != nil {
 		return fmt.Errorf("Unable to stage product %q, version %q: %s: %s",
 			productName, productVersion, err, errOutput)
@@ -114,7 +113,6 @@ func (o OMRunner) ResetAndConfigure(productName string, productVersion string, c
 		"configure-product",
 		"--config", configFile.Name(),
 	)
-
 	if err != nil {
 		return fmt.Errorf("Unable to configure product %q: %s: %s", productName, err, errOutput)
 	}


### PR DESCRIPTION
Golden Path requires tile authors to only use artifactory. This new flag allows us to upstream the requirement to Kiln. 

This doesn't introduce any breaking changes; new behavior is effectively feature flagged.

Story Id: TPCF-10575
