### PR TITLE
Bumps ruby version to 3.2.5

### DIFF
--- a/internal/test/Dockerfile
+++ b/internal/test/Dockerfile
@@ -3,11 +3,11 @@
 FROM golang as go-image
 FROM pivotalcfreleng/kiln:v0.77.0 as kiln
 
-FROM ruby:3.2.0 as builder
+FROM ruby:3.2.5 as builder
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 ADD git@github.com:pivotal-cf/ops-manager.git#v2.10.66 /tmp/ops-manager
 
-FROM ruby:3.2.0
+FROM ruby:3.2.5
 
 # Install Go
 COPY --from=go-image /usr/local/go/ /usr/local/go/


### PR DESCRIPTION
Experienced issues when trying to run kiln test - investigation showed a failure during the step to build the dockerfile based on a CGO error:

```
usr/lib/gcc/x86_64-linux-gnu/10/cc1: error while loading shared libraries: usr/lib/x86_64-linux-gnu/libisl.so.23: file too short
```

One approach was to disable CGO, via CGO_ENABLED=0

This ruby bump felt like a better approach, but CGO could be considered as part of the PR review if there are concerns related to compatibility between the new ruby patch and the pinned OpsMan version

[TPCF-24856](https://jira.eng.vmware.com/browse/TPCF-24856)

Authored-by: Ryan Wittrup <rwittrup@vmware.com>