### PR TITLE
Update dockerfile syntax to recommended value

### DIFF
--- a/internal/test/Dockerfile
+++ b/internal/test/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master-labs
+# syntax=docker/dockerfile:1
 
 FROM golang as go-image
 FROM pivotalcfreleng/kiln:v0.77.0 as kiln


### PR DESCRIPTION
Avoids the issue:

> $ kiln test
> could not execute "test": failed to read downloaded context: failed to load cache key: Get "http://build-context-kynariop8p16gn9g8regr8efz": context not found