### PR TITLE
Converge on the new version of Go Github

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
-	github.com/google/go-github/v40 v40.0.0
-	github.com/google/go-github/v50 v50.2.0
+	github.com/google/go-github/v65 v65.0.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/masterminds/sprig v2.22.0+incompatible
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
@@ -78,6 +77,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-github/v50 v50.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,15 +301,14 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v40 v40.0.0 h1:oBPVDaIhdUmwDWRRH8XJ/dZG+Rn755i08+Hp1uJHlR0=
-github.com/google/go-github/v40 v40.0.0/go.mod h1:G8wWKTEjUCL0zdbaQvpwDk0hqf6KZgPQH+ssJa+/NVc=
 github.com/google/go-github/v50 v50.0.0/go.mod h1:Ev4Tre8QoKiolvbpOSG3FIi4Mlon3S2Nt9W5JYqKiwA=
 github.com/google/go-github/v50 v50.2.0 h1:j2FyongEHlO9nxXLc+LP3wuBSVU9mVxfpdYUexMpIfk=
 github.com/google/go-github/v50 v50.2.0/go.mod h1:VBY8FB6yPIjrtKhozXv4FQupxKLS6H4m6xFZlT43q8Q=
+github.com/google/go-github/v65 v65.0.0 h1:pQ7BmO3DZivvFk92geC0jB0q2m3gyn8vnYPgV7GSLhQ=
+github.com/google/go-github/v65 v65.0.0/go.mod h1:DvrqWo5hvsdhJvHd4WyVF9ttANN3BniqjP8uTFMNb60=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/internal/commands/generate_osm_manifest.go
+++ b/internal/commands/generate_osm_manifest.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/google/go-github/v50/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/kiln/internal/commands/flags"
 	"github.com/pivotal-cf/kiln/internal/component"

--- a/internal/commands/generate_osm_manifest_test.go
+++ b/internal/commands/generate_osm_manifest_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v50/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 
 	"github.com/pivotal-cf/kiln/internal/commands"

--- a/internal/commands/release_notes.go
+++ b/internal/commands/release_notes.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/pivotal-cf/jhanda"
 
 	"github.com/pivotal-cf/kiln/internal/gh"

--- a/internal/commands/release_notes_test.go
+++ b/internal/commands/release_notes_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/pivotal-cf/jhanda"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"

--- a/internal/component/fakes/release_by_tag_getter.go
+++ b/internal/component/fakes/release_by_tag_getter.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/pivotal-cf/kiln/internal/component"
 )
 

--- a/internal/component/fakes/release_by_tag_getter_asset_downloader.go
+++ b/internal/component/fakes/release_by_tag_getter_asset_downloader.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/pivotal-cf/kiln/internal/component"
 )
 

--- a/internal/component/fakes/releases_lister.go
+++ b/internal/component/fakes/releases_lister.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/pivotal-cf/kiln/internal/component"
 )
 

--- a/internal/component/fakes_internal/release_by_tag_getter_asset_downloader.go
+++ b/internal/component/fakes_internal/release_by_tag_getter_asset_downloader.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 )
 
 type ReleaseByTagGetterAssetDownloader struct {

--- a/internal/component/fakes_internal/repository_release_lister.go
+++ b/internal/component/fakes_internal/repository_release_lister.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 )
 
 type RepositoryReleaseLister struct {

--- a/internal/component/github_release_source.go
+++ b/internal/component/github_release_source.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"golang.org/x/oauth2"
 
 	"github.com/pivotal-cf/kiln/internal/gh"

--- a/internal/component/github_release_source_internal_test.go
+++ b/internal/component/github_release_source_internal_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 
 	. "github.com/onsi/gomega"
 

--- a/internal/component/github_release_source_test.go
+++ b/internal/component/github_release_source_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	. "github.com/onsi/gomega"
 
 	"github.com/pivotal-cf/kiln/internal/component"

--- a/internal/gh/client.go
+++ b/internal/gh/client.go
@@ -3,7 +3,7 @@ package gh
 import (
 	"context"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/cargo/bump.go
+++ b/pkg/cargo/bump.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 
 	"github.com/pivotal-cf/kiln/internal/gh"
 )

--- a/pkg/cargo/bump_internal_test.go
+++ b/pkg/cargo/bump_internal_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 )
 
 func TestInternal_deduplicateReleasesWithTheSameTagName(t *testing.T) {

--- a/pkg/cargo/bump_test.go
+++ b/pkg/cargo/bump_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 
 	. "github.com/onsi/gomega"
 

--- a/pkg/notes/internal/fakes/issue_getter.go
+++ b/pkg/notes/internal/fakes/issue_getter.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 )
 
 type IssueGetter struct {

--- a/pkg/notes/internal/fakes/issues_by_repo_lister.go
+++ b/pkg/notes/internal/fakes/issues_by_repo_lister.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 )
 
 type IssuesByRepoLister struct {

--- a/pkg/notes/internal/fakes/issues_service.go
+++ b/pkg/notes/internal/fakes/issues_service.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 )
 
 type IssuesService struct {

--- a/pkg/notes/internal/fakes/milestone_lister.go
+++ b/pkg/notes/internal/fakes/milestone_lister.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 )
 
 type MilestoneLister struct {

--- a/pkg/notes/internal/fakes/releases_service.go
+++ b/pkg/notes/internal/fakes/releases_service.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
 

--- a/pkg/notes/notes_data.go
+++ b/pkg/notes/notes_data.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/storer"
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	"gopkg.in/yaml.v2"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"

--- a/pkg/notes/notes_data_test.go
+++ b/pkg/notes/notes_data_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 	"github.com/pivotal-cf/kiln/pkg/notes/internal/fakes"

--- a/pkg/notes/notes_page_test.go
+++ b/pkg/notes/notes_page_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 )

--- a/pkg/notes/notes_template_test.go
+++ b/pkg/notes/notes_template_test.go
@@ -6,7 +6,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/google/go-github/v40/github"
+	"github.com/google/go-github/v65/github"
 	. "github.com/onsi/gomega"
 
 	"github.com/pivotal-cf/kiln/pkg/cargo"


### PR DESCRIPTION
bump go-github from v50 and v40 to v65