### PR TITLE
Reduce memory usage when calculating release shasum

### DIFF
--- a/pkg/cargo/bosh_release.go
+++ b/pkg/cargo/bosh_release.go
@@ -155,7 +155,7 @@ func ReadBOSHReleaseTarball(tarballPath string, r io.Reader) (BOSHReleaseTarball
 	if err != nil {
 		return BOSHReleaseTarball{}, err
 	}
-	_, err = io.ReadAll(r)
+	_, err = io.CopyBuffer(io.Discard, r, make([]byte, 1024 * 64))
 	return BOSHReleaseTarball{
 		Manifest: m,
 		SHA1:     hex.EncodeToString(sum.Sum(nil)),


### PR DESCRIPTION
Reads in boshreleases a chunk at a time + does a streaming sha1sum while discarding the memory, rather than reading the entirety of the boshrelease into memory and then discarding.