### PR TITLE
Add option to update releases while updating stemcell

### DIFF
--- a/internal/commands/update_stemcell.go
+++ b/internal/commands/update_stemcell.go
@@ -21,7 +21,7 @@ type UpdateStemcell struct {
 
 		Version        string `short:"v"   long:"version"               required:"true"    description:"desired version of stemcell"`
 		ReleasesDir    string `short:"rd"  long:"releases-directory"    default:"releases" description:"path to a directory to download releases into"`
-		UpdateReleases bool   `long:"update-releases"   description:"finds latest matching releases for new stemcell version"`
+		UpdateReleases bool   `short:"ur"  long:"update-releases"                          description:"finds latest matching releases for new stemcell version"`
 	}
 	FS                         billy.Filesystem
 	MultiReleaseSourceProvider MultiReleaseSourceProvider


### PR DESCRIPTION
In our automated system we always use the latest version of a stemcell and dependent compiled releases and have automation that attempts to keep the Kilnfile.lock current using `update-stemcell` and `find-release-version` / `update-release`.

On occasion:
   when a new release and stemcell are created close together
      and while trying to update the stemcell
           the current release version in the Kilnfile.lock may not have a matching compiled release for the new stemcell.

Scenario example:
- compiled release exists for: release-v1-stemcell-v1
- release bumped: release-v2-stemcell-v1
- new stemcell available but build fails for: release-v2-stemcell-v2
- release bumped, build succeeds: release-v3-stemcell-v2

This leaves the following compiled releases available:
- release-v1-stemcell-v1
- release-v2-stemcell-v1
- release-v3-stemcell-v2

Since release-v2-stemcell-v2 is missing, `kiln update-stemcell` cannot update the `Kilnfile.lock`

The proposed change in this PR adds an optional `--update-releases` flag to `update-stemcell` to match the latest release for the specified stemcell given the version constraints in the `Kilnfile` and allow the prior scenario to update the `Kilnfile.lock`

Existing functionality without the `--update-releases` flag is retained.