### PR TITLE
fix: fix syntax directive version (branch version)

### DIFF
--- a/internal/test/Dockerfile
+++ b/internal/test/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.10
 
 FROM golang as go-image
 FROM pivotalcfreleng/kiln:v0.77.0 as kiln


### PR DESCRIPTION
kiln test does not work with buildkit version 1.11+. It errors with cache key not found.

Note: This PR is a recreation of #514 using a branch in an attempt to get the unit tests to run.
