### PR TITLE
Add a without-download flag to update-stemcell to skip release downloads

### DIFF
--- a/internal/acceptance/workflows/scenario/initialize.go
+++ b/internal/acceptance/workflows/scenario/initialize.go
@@ -55,6 +55,8 @@ func InitializeKiln(ctx *godog.ScenarioContext) { initializeKiln(ctx) }
 func initializeKiln(ctx scenarioContext) {
 	ctx.Step(regexp.MustCompile(`^I invoke kiln$`), iInvokeKiln)
 	ctx.Step(regexp.MustCompile(`^I try to invoke kiln$`), iTryToInvokeKiln)
+	ctx.Step(regexp.MustCompile(`^the "([^"]*)" release tarball exists$`), theReleaseTarballExists)
+	ctx.Step(regexp.MustCompile(`^the "([^"]*)" release tarball does not exist$`), theReleaseTarballDoesNotExist)
 }
 
 func InitializeRegex(ctx *godog.ScenarioContext) { initializeRegex(ctx) }

--- a/internal/acceptance/workflows/scenario/step_funcs_kiln.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_kiln.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -16,6 +17,36 @@ func iInvokeKiln(ctx context.Context, table *godog.Table) (context.Context, erro
 
 func iTryToInvokeKiln(ctx context.Context, table *godog.Table) (context.Context, error) {
 	return invokeKiln(ctx, false, argsFromTable(table)...)
+}
+
+func theReleaseTarballExists(ctx context.Context, tarballName string) error {
+	tileDir, err := tileRepoPath(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get tile repo path: %w", err)
+	}
+
+	releasePath := filepath.Join(tileDir, "releases", tarballName)
+	_, err = os.Stat(releasePath)
+	return err
+}
+
+func theReleaseTarballDoesNotExist(ctx context.Context, tarballName string) error {
+	tileDir, err := tileRepoPath(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get tile repo path: %w", err)
+	}
+
+	releasePath := filepath.Join(tileDir, "releases", tarballName)
+	_, err = os.Stat(releasePath)
+	if err == nil {
+		return fmt.Errorf("release tarball %q exists", tarballName)
+	}
+
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
 }
 
 func kilnValidateSucceeds(ctx context.Context) (context.Context, error) {

--- a/internal/acceptance/workflows/updating_releases.feature
+++ b/internal/acceptance/workflows/updating_releases.feature
@@ -11,6 +11,7 @@ Feature: As a dependabot, I want to update a BOSH Release
 
   Scenario: Find a version on bosh.io
     Given I have a tile source directory "testdata/tiles/v2"
+    And the repository has no fetched releases
     And I set the version constraint to "1.1.18" for release "bpm"
     When I invoke kiln
       | find-release-version                      |
@@ -18,15 +19,30 @@ Feature: As a dependabot, I want to update a BOSH Release
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
     Then stdout contains substring: "1.1.18"
 
-  Scenario: Update a component to a new release
+  Scenario: Update a component to a new release with download
     Given I have a tile source directory "testdata/tiles/v2"
+    And the repository has no fetched releases
     And the Kilnfile.lock specifies version "0.2.3" for release "hello-release"
-    And GitHub repository "crhntr/hello-release" has release with tag "v0.2.3"
+    And GitHub repository "crhntr/hello-release" has release with tag "0.3.0"
     When I invoke kiln
       | update-release                            |
       | --name=hello-release                      |
-      | --version=v0.2.3                          |
+      | --version=0.3.0                           |
+      | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
+    Then the Kilnfile.lock specifies version "0.3.0" for release "hello-release"
+    And kiln validate succeeds
+    And the "hello-release-0.3.0.tgz" release tarball exists
+
+  Scenario: Update a component to a new release without download
+    Given I have a tile source directory "testdata/tiles/v2"
+    And the repository has no fetched releases
+    And the Kilnfile.lock specifies version "1.2.12" for release "bpm"
+    When I invoke kiln
+      | update-release                            |
+      | --name=bpm                                |
+      | --version=1.2.13                          |
       | --without-download                        |
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
-    Then the Kilnfile.lock specifies version "0.2.3" for release "hello-release"
+    Then the Kilnfile.lock specifies version "1.2.13" for release "bpm"
     And kiln validate succeeds
+    And the "bpm-1.2.13.tgz" release tarball does not exist

--- a/internal/acceptance/workflows/updating_stemcell.feature
+++ b/internal/acceptance/workflows/updating_stemcell.feature
@@ -13,12 +13,45 @@ Feature: As a dependabot, I want to update a stemcell
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
     Then stdout contains substring: "1.340"
 
-  Scenario: Update the stemcell
+  Scenario: Update the stemcell with download
     Given I have a tile source directory "testdata/tiles/v2"
+    And the repository has no fetched releases
     And TanzuNetwork has product "stemcells-ubuntu-jammy" with version "1.340"
     And "Kilnfile.lock" contains substring: version: "1.329"
     When I invoke kiln
       | update-stemcell                           |
-      | --version=1.340                         |
+      | --version=1.340                           |
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
     Then "Kilnfile.lock" contains substring: version: "1.340"
+    And the Kilnfile.lock specifies version "0.2.3" for release "hello-release"
+    And the "bpm-1.2.12.tgz" release tarball exists
+    And the "hello-release-0.2.3.tgz" release tarball exists
+
+  Scenario: Update the stemcell without download
+    Given I have a tile source directory "testdata/tiles/v2"
+    And the repository has no fetched releases
+    And TanzuNetwork has product "stemcells-ubuntu-jammy" with version "1.340"
+    And "Kilnfile.lock" contains substring: version: "1.329"
+    When I invoke kiln
+      | update-stemcell                           |
+      | --version=1.340                           |
+      | --without-download                        |
+      | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
+    Then "Kilnfile.lock" contains substring: version: "1.340"
+    And the Kilnfile.lock specifies version "0.2.3" for release "hello-release"
+    And the "bpm-1.2.12.tgz" release tarball does not exist
+    And the "hello-release-0.2.3.tgz" release tarball does not exist
+
+  Scenario: Update the stemcell with release updates
+    Given I have a tile source directory "testdata/tiles/v2"
+    And the repository has no fetched releases
+    And TanzuNetwork has product "stemcells-ubuntu-jammy" with version "1.340"
+    And "Kilnfile.lock" contains substring: version: "1.329"
+    When I invoke kiln
+      | update-stemcell                           |
+      | --version=1.340                           |
+      | --update-releases                         |
+      | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
+    Then "Kilnfile.lock" contains substring: version: "1.340"
+    And the Kilnfile.lock specifies version "0.3.0" for release "hello-release"
+    And the "hello-release-0.3.0.tgz" release tarball exists

--- a/internal/commands/update_release.go
+++ b/internal/commands/update_release.go
@@ -16,11 +16,11 @@ type UpdateRelease struct {
 	Options struct {
 		flags.Standard
 
-		Name                         string `short:"n" long:"name" required:"true" description:"name of release to update"`
-		Version                      string `short:"v" long:"version" required:"true" description:"desired version of release"`
-		ReleasesDir                  string `short:"rd" long:"releases-directory" default:"releases" description:"path to a directory to download releases into"`
-		AllowOnlyPublishableReleases bool   `long:"allow-only-publishable-releases" description:"include releases that would not be shipped with the tile (development builds)"`
-		WithoutDownload              bool   `long:"without-download" description:"updates releases without downloading them"`
+		Name                         string `short:"n"  long:"name"                            required:"true"    description:"name of release to update"`
+		Version                      string `short:"v"  long:"version"                         required:"true"    description:"desired version of release"`
+		ReleasesDir                  string `short:"rd" long:"releases-directory"              default:"releases" description:"path to a directory to download releases into"`
+		AllowOnlyPublishableReleases bool   `           long:"allow-only-publishable-releases" default:"false"    description:"include releases that would not be shipped with the tile (development builds)"`
+		WithoutDownload              bool   `short:"wd" long:"without-download"                default:"false"    description:"updates releases without downloading them"`
 	}
 	multiReleaseSourceProvider MultiReleaseSourceProvider
 	filesystem                 billy.Filesystem

--- a/internal/commands/update_stemcell_test.go
+++ b/internal/commands/update_stemcell_test.go
@@ -2,6 +2,7 @@ package commands_test
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -110,7 +111,8 @@ var _ = Describe("UpdateStemcell", func() {
 				switch requirement.Name {
 				case release1Name:
 					remote := cargo.BOSHReleaseTarballLock{
-						Name: release1Name, Version: release1Version,
+						Name:         release1Name,
+						Version:      release1Version,
 						RemotePath:   newRelease1RemotePath,
 						RemoteSource: publishableReleaseSourceID,
 						SHA1:         "",
@@ -118,7 +120,8 @@ var _ = Describe("UpdateStemcell", func() {
 					return remote, nil
 				case release2Name:
 					remote := cargo.BOSHReleaseTarballLock{
-						Name: release2Name, Version: release2Version,
+						Name:         release2Name,
+						Version:      release2Version,
 						RemotePath:   newRelease2RemotePath,
 						RemoteSource: unpublishableReleaseSourceID,
 						SHA1:         "not-calculated",
@@ -126,7 +129,8 @@ var _ = Describe("UpdateStemcell", func() {
 					return remote, nil
 				case release3Name:
 					remote := cargo.BOSHReleaseTarballLock{
-						Name: release3Name, Version: release3Version,
+						Name:         release3Name,
+						Version:      release3Version,
 						RemotePath:   newRelease3RemotePath,
 						RemoteSource: publishableReleaseSourceID,
 						SHA1:         newRelease3SHA,
@@ -141,7 +145,8 @@ var _ = Describe("UpdateStemcell", func() {
 				switch requirement.Name {
 				case release1Name:
 					remote := cargo.BOSHReleaseTarballLock{
-						Name: release1Name, Version: release1Version,
+						Name:         release1Name,
+						Version:      release1Version,
 						RemotePath:   newRelease1RemotePath,
 						RemoteSource: publishableReleaseSourceID,
 						SHA1:         "",
@@ -149,7 +154,8 @@ var _ = Describe("UpdateStemcell", func() {
 					return remote, nil
 				case release2Name:
 					remote := cargo.BOSHReleaseTarballLock{
-						Name: release2Name, Version: release2Version,
+						Name:         release2Name,
+						Version:      release2Version,
 						RemotePath:   newRelease2RemotePath,
 						RemoteSource: unpublishableReleaseSourceID,
 						SHA1:         "not-calculated",
@@ -157,7 +163,8 @@ var _ = Describe("UpdateStemcell", func() {
 					return remote, nil
 				case release3Name:
 					remote := cargo.BOSHReleaseTarballLock{
-						Name: release3Name, Version: release3Version,
+						Name:         release3Name,
+						Version:      release3Version,
 						RemotePath:   newRelease3RemotePath,
 						RemoteSource: publishableReleaseSourceID,
 						SHA1:         newRelease3SHA,
@@ -172,13 +179,31 @@ var _ = Describe("UpdateStemcell", func() {
 				switch remote.Name {
 				case release1Name:
 					local := component.Local{
-						Lock:      cargo.BOSHReleaseTarballLock{Name: release1Name, Version: release1Version, SHA1: newRelease1SHA},
+						Lock: cargo.BOSHReleaseTarballLock{
+							Name:    release1Name,
+							Version: release1Version,
+							SHA1:    newRelease1SHA,
+						},
 						LocalPath: "not-used",
 					}
 					return local, nil
 				case release2Name:
 					local := component.Local{
-						Lock:      cargo.BOSHReleaseTarballLock{Name: release2Name, Version: release2Version, SHA1: newRelease2SHA},
+						Lock: cargo.BOSHReleaseTarballLock{
+							Name:    release2Name,
+							Version: release2Version,
+							SHA1:    newRelease2SHA,
+						},
+						LocalPath: "not-used",
+					}
+					return local, nil
+				case release3Name:
+					local := component.Local{
+						Lock: cargo.BOSHReleaseTarballLock{
+							Name:    release3Name,
+							Version: release3Version,
+							SHA1:    newRelease3SHA,
+						},
 						LocalPath: "not-used",
 					}
 					return local, nil
@@ -260,26 +285,33 @@ var _ = Describe("UpdateStemcell", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
+			Expect(releaseSource.FindReleaseVersionCallCount()).To(Equal(0))
 			Expect(releaseSource.GetMatchedReleaseCallCount()).To(Equal(3))
 
 			req1 := releaseSource.GetMatchedReleaseArgsForCall(0)
 			Expect(req1).To(Equal(cargo.BOSHReleaseTarballSpecification{
-				Name: release1Name, Version: release1Version,
-				StemcellOS: newStemcellOS, StemcellVersion: newStemcellVersion,
+				Name:             release1Name,
+				Version:          release1Version,
+				StemcellOS:       newStemcellOS,
+				StemcellVersion:  newStemcellVersion,
 				GitHubRepository: "https://example.com/lemon",
 			}))
 
 			req2 := releaseSource.GetMatchedReleaseArgsForCall(1)
 			Expect(req2).To(Equal(cargo.BOSHReleaseTarballSpecification{
-				Name: release2Name, Version: release2Version,
-				StemcellOS: newStemcellOS, StemcellVersion: newStemcellVersion,
+				Name:             release2Name,
+				Version:          release2Version,
+				StemcellOS:       newStemcellOS,
+				StemcellVersion:  newStemcellVersion,
 				GitHubRepository: "https://example.com/orange",
 			}))
 
 			req3 := releaseSource.GetMatchedReleaseArgsForCall(2)
 			Expect(req3).To(Equal(cargo.BOSHReleaseTarballSpecification{
-				Name: release3Name, Version: release3Version,
-				StemcellOS: newStemcellOS, StemcellVersion: newStemcellVersion,
+				Name:             release3Name,
+				Version:          release3Version,
+				StemcellOS:       newStemcellOS,
+				StemcellVersion:  newStemcellVersion,
 				GitHubRepository: "https://example.com/pomelo",
 			}))
 		})
@@ -290,37 +322,45 @@ var _ = Describe("UpdateStemcell", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(releaseSource.FindReleaseVersionCallCount()).To(Equal(3))
+			Expect(releaseSource.GetMatchedReleaseCallCount()).To(Equal(0))
 
 			req1, noDownload1 := releaseSource.FindReleaseVersionArgsForCall(0)
 			Expect(req1).To(Equal(cargo.BOSHReleaseTarballSpecification{
-				Name: release1Name, Version: "*",
-				StemcellOS: newStemcellOS, StemcellVersion: newStemcellVersion,
+				Name:             release1Name,
+				Version:          "*",
+				StemcellOS:       newStemcellOS,
+				StemcellVersion:  newStemcellVersion,
 				GitHubRepository: "https://example.com/lemon",
 			}))
 			Expect(noDownload1).To(BeTrue())
 
 			req2, noDownload2 := releaseSource.FindReleaseVersionArgsForCall(1)
 			Expect(req2).To(Equal(cargo.BOSHReleaseTarballSpecification{
-				Name: release2Name, Version: "*",
-				StemcellOS: newStemcellOS, StemcellVersion: newStemcellVersion,
+				Name:             release2Name,
+				Version:          "*",
+				StemcellOS:       newStemcellOS,
+				StemcellVersion:  newStemcellVersion,
 				GitHubRepository: "https://example.com/orange",
 			}))
 			Expect(noDownload2).To(BeTrue())
 		})
 
-		It("downloads 2 of the 3 correct releases, ", func() {
+		It("downloads all of the releases", func() {
 			err := update.Execute([]string{
-				"--kilnfile", kilnfilePath, "--version", newStemcellVersion, "--releases-directory", releasesDirPath,
+				"--kilnfile", kilnfilePath,
+				"--version", newStemcellVersion,
+				"--releases-directory", releasesDirPath,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(releaseSource.DownloadReleaseCallCount()).To(Equal(2))
+			Expect(releaseSource.DownloadReleaseCallCount()).To(Equal(3))
 
 			actualDir, remote1 := releaseSource.DownloadReleaseArgsForCall(0)
 			Expect(actualDir).To(Equal(releasesDirPath))
 			Expect(remote1).To(Equal(
 				cargo.BOSHReleaseTarballLock{
-					Name: release1Name, Version: release1Version,
+					Name:         release1Name,
+					Version:      release1Version,
 					RemotePath:   newRelease1RemotePath,
 					RemoteSource: publishableReleaseSourceID,
 					SHA1:         "",
@@ -331,12 +371,114 @@ var _ = Describe("UpdateStemcell", func() {
 			Expect(actualDir).To(Equal(releasesDirPath))
 			Expect(remote2).To(Equal(
 				cargo.BOSHReleaseTarballLock{
-					Name: release2Name, Version: release2Version,
+					Name:         release2Name,
+					Version:      release2Version,
 					RemotePath:   newRelease2RemotePath,
 					RemoteSource: unpublishableReleaseSourceID,
 					SHA1:         "not-calculated",
 				},
 			))
+
+			actualDir, remote3 := releaseSource.DownloadReleaseArgsForCall(2)
+			Expect(actualDir).To(Equal(releasesDirPath))
+			Expect(remote3).To(Equal(
+				cargo.BOSHReleaseTarballLock{
+					Name:         release3Name,
+					Version:      release3Version,
+					RemotePath:   newRelease3RemotePath,
+					RemoteSource: publishableReleaseSourceID,
+					SHA1:         "new-sha1-3",
+				},
+			))
+		})
+
+		When("the remote information for a release doesn't change", func() {
+			BeforeEach(func() {
+				kilnfileLock.Releases[1].RemoteSource = unpublishableReleaseSourceID
+				kilnfileLock.Releases[1].RemotePath = newRelease2RemotePath
+			})
+
+			It("still downloads the release", func() {
+				err := update.Execute([]string{
+					"--kilnfile", kilnfilePath,
+					"--version", newStemcellVersion,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(releaseSource.DownloadReleaseCallCount()).To(Equal(3))
+
+				_, remote := releaseSource.DownloadReleaseArgsForCall(0)
+				Expect(remote.Name).To(Equal(release1Name))
+
+				_, remote = releaseSource.DownloadReleaseArgsForCall(1)
+				Expect(remote.Name).To(Equal(release2Name))
+
+				_, remote = releaseSource.DownloadReleaseArgsForCall(2)
+				Expect(remote.Name).To(Equal(release3Name))
+
+				Expect(string(outputBuffer.Contents())).To(ContainSubstring(fmt.Sprintf("No change for release %q", release2Name)))
+			})
+		})
+
+		When("when the --without-download flag is specified", func() {
+			It("downloads 2 of the 3 correct releases", func() {
+				err := update.Execute([]string{
+					"--kilnfile", kilnfilePath,
+					"--version", newStemcellVersion,
+					"--releases-directory", releasesDirPath,
+					"--without-download",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(releaseSource.DownloadReleaseCallCount()).To(Equal(2))
+
+				actualDir, remote1 := releaseSource.DownloadReleaseArgsForCall(0)
+				Expect(actualDir).To(Equal(releasesDirPath))
+				Expect(remote1).To(Equal(
+					cargo.BOSHReleaseTarballLock{
+						Name:         release1Name,
+						Version:      release1Version,
+						RemotePath:   newRelease1RemotePath,
+						RemoteSource: publishableReleaseSourceID,
+						SHA1:         "",
+					},
+				))
+
+				actualDir, remote2 := releaseSource.DownloadReleaseArgsForCall(1)
+				Expect(actualDir).To(Equal(releasesDirPath))
+				Expect(remote2).To(Equal(
+					cargo.BOSHReleaseTarballLock{
+						Name:         release2Name,
+						Version:      release2Version,
+						RemotePath:   newRelease2RemotePath,
+						RemoteSource: unpublishableReleaseSourceID,
+						SHA1:         "not-calculated",
+					},
+				))
+			})
+
+			When("the remote information for a release doesn't change", func() {
+				BeforeEach(func() {
+					kilnfileLock.Releases[1].RemoteSource = unpublishableReleaseSourceID
+					kilnfileLock.Releases[1].RemotePath = newRelease2RemotePath
+				})
+
+				It("doesn't download the release", func() {
+					err := update.Execute([]string{
+						"--kilnfile", kilnfilePath,
+						"--version", newStemcellVersion,
+						"--without-download",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(releaseSource.DownloadReleaseCallCount()).To(Equal(1))
+
+					_, remote := releaseSource.DownloadReleaseArgsForCall(0)
+					Expect(remote.Name).To(Equal(release1Name))
+
+					Expect(string(outputBuffer.Contents())).To(ContainSubstring(fmt.Sprintf("No change for release %q", release2Name)))
+				})
+			})
 		})
 
 		When("the version input is invalid", func() {
@@ -467,25 +609,6 @@ var _ = Describe("UpdateStemcell", func() {
 						RemotePath:   newRelease3RemotePath,
 					},
 				))
-			})
-		})
-
-		When("the remote information for a release doesn't change", func() {
-			BeforeEach(func() {
-				kilnfileLock.Releases[1].RemoteSource = unpublishableReleaseSourceID
-				kilnfileLock.Releases[1].RemotePath = newRelease2RemotePath
-			})
-
-			It("doesn't download the release", func() {
-				err := update.Execute([]string{"--kilnfile", kilnfilePath, "--version", newStemcellVersion})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(releaseSource.DownloadReleaseCallCount()).To(Equal(1))
-				_, remote := releaseSource.DownloadReleaseArgsForCall(0)
-				Expect(remote.Name).To(Equal(release1Name))
-
-				Expect(string(outputBuffer.Contents())).To(ContainSubstring("No change"))
-				Expect(string(outputBuffer.Contents())).To(ContainSubstring(release2Name))
 			})
 		})
 

--- a/internal/component/artifactory_release_source.go
+++ b/internal/component/artifactory_release_source.go
@@ -177,7 +177,7 @@ func (ars *ArtifactoryReleaseSource) GetMatchedRelease(spec cargo.BOSHReleaseTar
 	default:
 		return cargo.BOSHReleaseTarballLock{}, fmt.Errorf("unexpected http status: %s", http.StatusText(response.StatusCode))
 	}
-	
+
 	matchedRelease := cargo.BOSHReleaseTarballLock{
 		Name:         spec.Name,
 		Version:      spec.Version,

--- a/internal/component/artifactory_release_source.go
+++ b/internal/component/artifactory_release_source.go
@@ -177,13 +177,20 @@ func (ars *ArtifactoryReleaseSource) GetMatchedRelease(spec cargo.BOSHReleaseTar
 	default:
 		return cargo.BOSHReleaseTarballLock{}, fmt.Errorf("unexpected http status: %s", http.StatusText(response.StatusCode))
 	}
-
-	return cargo.BOSHReleaseTarballLock{
+	
+	matchedRelease := cargo.BOSHReleaseTarballLock{
 		Name:         spec.Name,
 		Version:      spec.Version,
 		RemotePath:   remotePath,
 		RemoteSource: ars.ID,
-	}, nil
+	}
+
+	matchedRelease.SHA1, err = ars.getFileSHA1(matchedRelease)
+	if err != nil {
+		return cargo.BOSHReleaseTarballLock{}, err
+	}
+
+	return matchedRelease, nil
 }
 
 // FindReleaseVersion may use any of the fields on Requirement to return the best matching

--- a/internal/component/artifactory_release_source_test.go
+++ b/internal/component/artifactory_release_source_test.go
@@ -106,6 +106,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					// StemcellVersion: "9.9",
 					RemotePath:   "bosh-releases/smoothie/9.9/mango/mango-2.3.4-smoothie-9.9.tgz",
 					RemoteSource: "some-mango-tree",
+					SHA1:         "some-sha",
 				}))
 			})
 

--- a/internal/component/bosh_io_release_source_test.go
+++ b/internal/component/bosh_io_release_source_test.go
@@ -47,7 +47,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `null`))
 
 				path, _ = regexp.Compile(`/api/v1/releases/github.com/\S+/uaa.*`)
-				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"version": "73.3.0"}]`))
+				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"version": "73.3.0", "sha1":"b6e8a9cbc8724edcecb8658fa9459ee6c8fc259e"}]`))
 
 				path, _ = regexp.Compile(`/api/v1/releases/github.com/\S+/metrics.*`)
 				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"version": "2.3.0"}]`))
@@ -74,6 +74,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 					Version:      "73.3.0",
 					RemotePath:   uaaURL,
 					RemoteSource: component.ReleaseSourceTypeBOSHIO,
+					SHA1:         "b6e8a9cbc8724edcecb8658fa9459ee6c8fc259e",
 				}))
 
 				foundRelease, err = releaseSource.GetMatchedRelease(rabbitmqRequirement)
@@ -299,7 +300,7 @@ var _ = Describe("BOSHIOReleaseSource", func() {
 				testServer = ghttp.NewServer()
 
 				path, _ := regexp.Compile(`/api/v1/releases/github.com/\S+/cf-rabbitmq.*`)
-				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"name":"github.com/cloudfoundry/cf-rabbitmq-release","version":"309.0.5","url":"https://bosh.io/d/github.com/cloudfoundry/cf-rabbitmq-release?v=309.0.0","sha1":"5df538657c2cc830bda679420a9b162682018ded"},{"name":"github.com/cloudfoundry/cf-rabbitmq-release","version":"308.0.0","url":"https://bosh.io/d/github.com/cloudfoundry/cf-rabbitmq-release?v=308.0.0","sha1":"56202c9a466a8394683ae432ee2dea21ef6ef865"}]`))
+				testServer.RouteToHandler("GET", path, ghttp.RespondWith(http.StatusOK, `[{"name":"github.com/cloudfoundry/cf-rabbitmq-release","version":"309.0.5","url":"https://bosh.io/d/github.com/cloudfoundry/cf-rabbitmq-release?v=309.0.0","sha1":"5df538657c2cc830bda679420a9b162682018ded","sha256": "49cad4a9758026cbae7a26f77921300595459dfa6bc0ca5332fc6ba52bd336b8"},{"name":"github.com/cloudfoundry/cf-rabbitmq-release","version":"308.0.0","url":"https://bosh.io/d/github.com/cloudfoundry/cf-rabbitmq-release?v=308.0.0","sha1":"56202c9a466a8394683ae432ee2dea21ef6ef865","sha256":"5970d4211d236896d9366b150a66e38cbbd757fed31895962e499bb5458e0937"}]`))
 
 				releaseSource = component.NewBOSHIOReleaseSource(cargo.ReleaseSourceConfig{ID: ID, Publishable: false}, testServer.URL(), logger)
 			})

--- a/internal/component/github_release_source.go
+++ b/internal/component/github_release_source.go
@@ -286,7 +286,7 @@ func downloadRelease(ctx context.Context, releaseDir string, remoteRelease cargo
 
 	rTag, _, err := client.GetReleaseByTag(ctx, org, repo, "v"+remoteRelease.Version)
 	if err != nil {
-		logger.Println("warning: failed to find release tag of ", "v"+remoteRelease.Version)
+		logger.Println("warning: failed to find release tag of", "v"+remoteRelease.Version)
 		rTag, _, err = client.GetReleaseByTag(ctx, org, repo, remoteRelease.Version)
 		if err != nil {
 			return Local{}, fmt.Errorf("cant find release tag: %+v", err.Error())

--- a/pkg/cargo/bosh_release.go
+++ b/pkg/cargo/bosh_release.go
@@ -155,7 +155,7 @@ func ReadBOSHReleaseTarball(tarballPath string, r io.Reader) (BOSHReleaseTarball
 	if err != nil {
 		return BOSHReleaseTarball{}, err
 	}
-	_, err = io.CopyBuffer(io.Discard, r, make([]byte, 1024 * 64))
+	_, err = io.CopyBuffer(io.Discard, r, make([]byte, 1024*64))
 	return BOSHReleaseTarball{
 		Manifest: m,
 		SHA1:     hex.EncodeToString(sum.Sum(nil)),


### PR DESCRIPTION
This PR re-applies the changes from #493 with the addition of a without-download
flag to control the behaviour.
