### PR TITLE
feat: [TNZ-32601] Updated hello tile and bosh repo references

### DIFF
--- a/.github/workflows/create-debugging-artifact.yml
+++ b/.github/workflows/create-debugging-artifact.yml
@@ -58,6 +58,6 @@ jobs:
           
           git reset --hard HEAD
           
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./kiln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           go test --covermode=atomic --coverprofile=kiln-${{github.sha}}-unit-test-code-coverage.out ./...
 
       - name: Archive Unit Test Code Coverage Output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Code Coverage Output
           path: kiln-${{github.sha}}-unit-test-code-coverage.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v6.3.0
 
       - name: Ensure Generate Succeeds and Does Not Make Changes
         run: |
@@ -39,7 +39,7 @@ jobs:
         run: go test --covermode=atomic --coverprofile=kiln-${{ github.sha }}-unit-test-code-coverage.out ./...
 
       - name: Archive Unit Test Code Coverage Output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Code Coverage Output
           path: kiln-${{ github.sha }}-unit-test-code-coverage.out

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ an opinionated folder structure and templating capabilities. It is designed to b
 both in CI environments and in command-line to produce a tile.
 
 More information for those just getting started can be found in the [Ops Manager Tile Developer Guide](https://docs.vmware.com/en/Tile-Developer-Guide/3.0/tile-dev-guide/index.html) .
-Looking at an [example kiln tile](https://github.com/crhntr/hello-tile/tree/main) may also be helpful
+Looking at an [example kiln tile](https://github.com/releen/hello-tile/tree/main) may also be helpful
 
 ## Installation
 
@@ -770,10 +770,10 @@ releases:
   remote_source: unique-name # this could be artifactory or s3
   remote_path: bosh-releases/compiled/backup-and-restore-sdk-1.18.84-ubuntu-jammy-1.179.tgz
 - name: hello-release
-  sha1: 06500a2002f6e14f6c258b7ee7044761a28d3d5a
-  version: 0.1.5
+  sha1: d7de88ab98d7d61d0a4e660c8fff76727817c059
+  version: 0.4.0
   remote_source: the-github-org 
-  remote_path: https://github.com/crhntr/hello-release/releases/download/v0.1.5/hello-release-v0.1.5.tgz
+  remote_path: https://github.com/releen/hello-release/releases/download/0.4.0/hello-release-0.4.0.tgz
 stemcell_criteria:
   os: ubuntu-xenial
   version: "621.0"

--- a/TILE_AUTHOR_GUIDE.md
+++ b/TILE_AUTHOR_GUIDE.md
@@ -23,9 +23,9 @@ This guide intends to be more opinionated while the README.me is more general.
 - [TanzuNet Release Publication](#kiln-publish)
 - [Importing Go Source Code](#go-import-kiln)
 #### Helpful external links
-- [Metadata Testing Example](https://github.com/crhntr/hello-tile/blob/main/test/manifest/manifest_test.go)
+- [Metadata Testing Example](https://github.com/releen/hello-tile/blob/main/test/manifest/manifest_test.go)
 
-Again, see [hello-tile](https://github.com/crhntr/hello-tile) (non-VMware employees) or the TAS repo (VMware employees) for tile source code that kiln "just works" with.
+Again, see [hello-tile](https://github.com/releen/hello-tile) (non-VMware employees) or the TAS repo (VMware employees) for tile source code that kiln "just works" with.
 
 ## Bootstrapping a tile repository
 
@@ -37,7 +37,7 @@ mkdir -p bosh_variables forms instance_groups jobs migrations properties release
 touch {bosh_variables,forms,instance_groups,jobs,migrations,properties,releases,runtime_configs}/.gitkeep
 
 # Add a tile image
-curl -L -o icon.png "https://github.com/crhntr/hello-tile/blob/main/icon.png?raw=true"
+curl -L -o icon.png "https://github.com/releen/hello-tile/blob/main/icon.png?raw=true"
 
 # Add a version file (this is the default location Kiln reads from)
 echo '0.1.0' > 'version'
@@ -125,8 +125,8 @@ Other functions:
 - `select`  _TODO function documentation_
 - `regexReplaceAll`  _TODO function documentation_
 
-See the [crhntr/hello-tile/base.yml](https://github.com/pivotal/hello-tile/blob/c6b59dcb1118c9b2f5d4fbf836842ce4033baa80/base.yml#L29C1-L30C1) for some use of the above functions.
-The property definition in [crhntr/hello-tile/properties/hello.yml](https://github.com/pivotal/hello-tile/blob/c6b59dcb1118c9b2f5d4fbf836842ce4033baa80/properties/hello.yml#L2-L5)
+See the [releen/hello-tile/base.yml](https://github.com/releen/hello-tile/blob/main/base.yml) for some use of the above functions.
+The property definition in [releen/hello-tile/properties/hello.yml](https://github.com/releen/hello-tile/blob/main/properties/hello.yml)
 in referenced in `base.yml` using `$( property "port" )`.
 Most other product template part functions behave similarly.
 
@@ -149,8 +149,8 @@ The Kiln way is to
 
 While the following examples start from empty directories and mostly use S3 and BOSH.io.
 There are similar simple scripts for a small test tile illustrating similar usage patterns to the follwoing example.
-See [hello-tile](https://github.com/crhntr/hello-tile).
-Hello Tile consumes a single custom BOSH Release, [hello-release](https://github.com/crhntr/hello-release), from a GitHub release.
+See [hello-tile](https://github.com/releen/hello-tile).
+Hello Tile consumes a single custom BOSH Release, [hello-release](https://github.com/releen/hello-release), from a GitHub release.
 It does not upload the release to TanzuNet but adds the built tile to a GitHub Release.
 
 #### <a id="kiln-fetch-example"></a> **EXAMPLE** Using Kiln to Download BOSH Release Tarballs
@@ -356,8 +356,8 @@ To download BOSH Release Tarballs from GitHub Releases, add the following
 ```yaml
 release_sources:
   - type: "github"
-    id: crhntr # (optional) the default ID in this case is the value of org
-    org: "crhntr"
+    id: releen # (optional) the default ID in this case is the value of org
+    org: "releen"
     github_token: $(variable "github_access_token")
 ```
 

--- a/internal/acceptance/workflows/baking_a_tile.feature
+++ b/internal/acceptance/workflows/baking_a_tile.feature
@@ -11,13 +11,13 @@ Feature: As a developer, I want to bake a tile
       | metadata/metadata.yml             |
       | migrations/v1                     |
       | releases/bpm-1.2.12.tgz           |
-      | releases/hello-release-0.2.3.tgz |
+      | releases/hello-release-0.4.0.tgz |
     And "bake_records/0.2.0-dev.json" contains substring: "version": "0.2.0-dev"
-    And "bake_records/0.2.0-dev.json" contains substring: "source_revision": "896c44a006a24d8601ed09fd871b1a4423636d77"
+    And "bake_records/0.2.0-dev.json" contains substring: "source_revision": "f576bdedff1f014d550a26bf19effd28293c09e1"
     And "bake_records/0.2.0-dev.json" contains substring: "tile_directory": "."
     And "bake_records/0.2.0-dev.json" contains substring: "kiln_version": "0.0.0+acceptance-tests"
-    And "bake_records/0.2.0-dev.json" contains substring: "file_checksum": "6754bb95193e42cd5706f810c3fdb1beead88e2a01601bb222e3e98818f90e8a"
-    And "tile-0.2.0-dev.pivotal" has sha256 sum "6754bb95193e42cd5706f810c3fdb1beead88e2a01601bb222e3e98818f90e8a"
+    And "bake_records/0.2.0-dev.json" contains substring: "file_checksum": "b8d1e2f328b204db813a85a8cd98dd70c1148b7dde4137c12fae69d52e673bfb"
+    And "tile-0.2.0-dev.pivotal" has sha256 sum "b8d1e2f328b204db813a85a8cd98dd70c1148b7dde4137c12fae69d52e673bfb"
 
   Scenario: it reads directory configuration from Kilnfile
     Given I have a tile source directory "testdata/tiles/non-standard-paths"

--- a/internal/acceptance/workflows/generating_release_notes.feature
+++ b/internal/acceptance/workflows/generating_release_notes.feature
@@ -4,11 +4,11 @@ Feature: As a robot, I want to generate release notes
 
     And I execute git tag v0.1.3
 
-    And GitHub repository "crhntr/hello-release" has release with tag "v0.1.5"
+    And GitHub repository "releen/hello-release" has release with tag "0.5.0"
     And I invoke kiln
       | update-release                            |
       | --name=hello-release                      |
-      | --version=v0.1.5                          |
+      | --version=0.5.0                           |
       | --without-download                        |
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
     And I write file "version"
@@ -18,7 +18,7 @@ Feature: As a robot, I want to generate release notes
     And I execute git show
     And I execute git tag v0.1.4
 
-    And I execute git remote add origin git@github.com:crhntr/hello-tile
+    And I execute git remote add origin git@github.com:releen/hello-tile
 
     # it does not contain 0.1.4 release header only 0.1.3
     And "notes/release_notes.md.erb" has regex matches: id='(?P<version>[\d\.]+)'
@@ -46,14 +46,14 @@ Feature: As a robot, I want to generate release notes
     And "notes/release_notes.md.erb" contains substring: **[Bug Fix]** Index page has inconsistent whitespace
 
     # it contains the component release note
-    And "notes/release_notes.md.erb" contains substring: "**[Fix]**\n  The HTML had  inconsistent	 spacing"
+    And "notes/release_notes.md.erb" contains substring: "**[Fix]**: The HTML had inconsistent spacing"
 
     # the table contains the name/versions
     And "notes/release_notes.md.erb" has regex matches: (?mU)<tr><td>(?P<release_name>.*)</td><td>(?P<release_version>.*)</td>
       | release_name           | release_version |
       | ubuntu-xenial stemcell | 621.0           |
       | bpm                    | 1.1.18          |
-      | hello-release          | 0.1.5           |
+      | hello-release          | 0.5.0           |
       | ubuntu-xenial stemcell | 621.0           |
       | bpm                    | 1.1.18          |
-      | hello-release          | v0.1.4          |
+      | hello-release          | 0.4.5           |

--- a/internal/acceptance/workflows/glaze.feature
+++ b/internal/acceptance/workflows/glaze.feature
@@ -3,7 +3,7 @@ Feature: As a maintainer, I want to pin all BOSH Releases
     Given I have a tile source directory "testdata/tiles/v2"
     When I invoke kiln
       | glaze |
-    Then the Kilnfile version for release "hello-release" is "0.2.3"
+    Then the Kilnfile version for release "hello-release" is "0.4.0"
     And  the Kilnfile version for release "bpm" is "1.2.12"
     And  the Kilnfile version for the stemcell is "1.329"
 

--- a/internal/acceptance/workflows/scenario/step_funcs_github_test.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_github_test.go
@@ -11,7 +11,7 @@ import (
 func Test_githubRepoHasReleaseWithTag(t *testing.T) {
 	t.Skip("skipping this test because it requires a github token to run. ")
 	if isRunningInCI() {
-		t.Skip("skip this step in CI. GitHub action credentials do not have access to crhntr/hello-release")
+		t.Skip("skip this step in CI. GitHub action credentials do not have access to releen/hello-release")
 	}
 	setup := func(t *testing.T) (context.Context, Gomega) {
 		ctx := context.Background()
@@ -31,13 +31,13 @@ func Test_githubRepoHasReleaseWithTag(t *testing.T) {
 
 	t.Run("release exists", func(t *testing.T) {
 		ctx, please := setup(t)
-		err := githubRepoHasReleaseWithTag(ctx, "crhntr", "hello-release", "v0.1.5")
+		err := githubRepoHasReleaseWithTag(ctx, "releen", "hello-release", "0.4.5")
 		please.Expect(err).NotTo(HaveOccurred())
 	})
 
 	t.Run("release does not exist", func(t *testing.T) {
 		ctx, please := setup(t)
-		err := githubRepoHasReleaseWithTag(ctx, "crhntr", "hello-release", "v99.99.99-banana")
+		err := githubRepoHasReleaseWithTag(ctx, "releen", "hello-release", "v99.99.99-banana")
 		please.Expect(err).To(HaveOccurred())
 	})
 }

--- a/internal/acceptance/workflows/scenario/step_funcs_tile_test.go
+++ b/internal/acceptance/workflows/scenario/step_funcs_tile_test.go
@@ -23,7 +23,7 @@ func Test_theLockSpecifiesVersionForRelease(t *testing.T) {
 
 	t.Run("it matches the release version", func(t *testing.T) {
 		ctx, please := setup(t)
-		err := theLockSpecifiesVersionForRelease(ctx, "0.2.3", "hello-release")
+		err := theLockSpecifiesVersionForRelease(ctx, "0.4.0", "hello-release")
 		please.Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/internal/acceptance/workflows/testdata/tiles/v1/Kilnfile
+++ b/internal/acceptance/workflows/testdata/tiles/v1/Kilnfile
@@ -1,11 +1,11 @@
 ---
-slug: crhntr-hello
+slug: releen-hello
 release_sources:
   - type: github
-    org: crhntr
+    org: releen
     github_token: $(variable "github_access_token")
   - type: bosh.io
 releases:
   - name: bpm
   - name: hello-release
-    github_repository: https://github.com/crhntr/hello-release
+    github_repository: https://github.com/releen/hello-release

--- a/internal/acceptance/workflows/testdata/tiles/v1/Kilnfile.lock
+++ b/internal/acceptance/workflows/testdata/tiles/v1/Kilnfile.lock
@@ -5,10 +5,10 @@ releases:
   remote_source: bosh.io
   remote_path: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18
 - name: hello-release
-  sha1: e893386c9fbd34f3e136941eb1841e044a0bed28
-  version: v0.1.4
-  remote_source: crhntr
-  remote_path: https://github.com/crhntr/hello-release/releases/download/v0.1.4/hello-release-v0.1.4.tgz
+  sha1: 695e3721bc9459ce197909dd3e99680e9d57d8f0
+  version: 0.4.5
+  remote_source: releen
+  remote_path: https://github.com/releen/hello-release/releases/download/0.4.5/hello-release-0.4.5.tgz
 stemcell_criteria:
   os: ubuntu-xenial
   version: "621.0"

--- a/internal/acceptance/workflows/testdata/tiles/v1/README.md
+++ b/internal/acceptance/workflows/testdata/tiles/v1/README.md
@@ -1,4 +1,4 @@
-# A [Ops Manager Tile](https://docs.pivotal.io/tiledev/2-10/index.html) wrapping [Hello Release](https://github.com/crhntr/hello-release)
+# A [Ops Manager Tile](https://docs.pivotal.io/tiledev/2-10/index.html) wrapping [Hello Release](https://github.com/releen/hello-release)
 
 This is an example for [Kiln](https://github.com/pivotal-cf/kiln).
 

--- a/internal/acceptance/workflows/testdata/tiles/v1/notes/release_notes.md.erb
+++ b/internal/acceptance/workflows/testdata/tiles/v1/notes/release_notes.md.erb
@@ -3,7 +3,7 @@ title: Hello Tile Example v0.1 Release Notes
 owner: Christopher Hunter
 ---
 
-This topic contains release notes [Hello Tile](https://github.com/crhntr/hello-tile).
+This topic contains release notes [Hello Tile](https://github.com/releen/hello-tile).
 
 ## <a id='releases'></a> Releases
 
@@ -11,7 +11,7 @@ This topic contains release notes [Hello Tile](https://github.com/crhntr/hello-t
 
 **Release Date:** 06/26/2022
 
-* Bump hello-release to version `v0.1.4`
+* Bump hello-release to version `0.4.5`
 
 <table border="1" class="nice">
   <thead>
@@ -24,7 +24,7 @@ This topic contains release notes [Hello Tile](https://github.com/crhntr/hello-t
   <tbody>
     <tr><td>ubuntu-xenial stemcell</td><td>621.0</td><td></td></tr>
     <tr><td>bpm</td><td>1.1.18</td><td></td></tr>
-    <tr><td>hello-release</td><td>v0.1.4</td><td></td></tr>
+    <tr><td>hello-release</td><td>0.4.5</td><td></td></tr>
   </tbody>
 </table>
 

--- a/internal/acceptance/workflows/testdata/tiles/v2/Kilnfile
+++ b/internal/acceptance/workflows/testdata/tiles/v2/Kilnfile
@@ -1,14 +1,14 @@
 ---
-slug: crhntr-hello
+slug: releen-hello
 release_sources:
   - type: github
-    org: crhntr
+    org: releen
     github_token: $(variable "github_access_token")
   - type: bosh.io
 releases:
   - name: bpm
   - name: hello-release
-    github_repository: https://github.com/crhntr/hello-release
+    github_repository: https://github.com/releen/hello-release
 stemcell_criteria:
     os: ubuntu-jammy
     version: "*"

--- a/internal/acceptance/workflows/testdata/tiles/v2/Kilnfile.lock
+++ b/internal/acceptance/workflows/testdata/tiles/v2/Kilnfile.lock
@@ -5,10 +5,10 @@ releases:
       remote_source: bosh.io
       remote_path: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.12
     - name: hello-release
-      sha1: a0f2747fd22796d5fbbe036d0d8786e76a2ac651
-      version: 0.2.3
-      remote_source: crhntr
-      remote_path: https://github.com/crhntr/hello-release/releases/download/v0.2.3/hello-release-v0.2.3.tgz
+      sha1: d7de88ab98d7d61d0a4e660c8fff76727817c059
+      version: 0.4.0
+      remote_source: releen
+      remote_path: https://github.com/releen/hello-release/releases/download/0.4.0/hello-release-0.4.0.tgz
 stemcell_criteria:
     os: ubuntu-jammy
     version: "1.329"

--- a/internal/acceptance/workflows/testdata/tiles/v2/README.md
+++ b/internal/acceptance/workflows/testdata/tiles/v2/README.md
@@ -1,4 +1,4 @@
-# A [Ops Manager Tile](https://docs.pivotal.io/tiledev/2-10/index.html) wrapping [Hello Release](https://github.com/crhntr/hello-release) [![Release](https://github.com/crhntr/hello-tile/actions/workflows/release.yml/badge.svg)](https://github.com/crhntr/hello-tile/actions/workflows/release.yml)
+# A [Ops Manager Tile](https://docs.pivotal.io/tiledev/2-10/index.html) wrapping [Hello Release](https://github.com/releen/hello-release) [![Release](https://github.com/releen/hello-tile/actions/workflows/release.yml/badge.svg)](https://github.com/releen/hello-tile/actions/workflows/release.yml)
 
 This is an example for [Kiln](https://github.com/pivotal-cf/kiln).
 

--- a/internal/acceptance/workflows/testdata/tiles/v2/go.mod
+++ b/internal/acceptance/workflows/testdata/tiles/v2/go.mod
@@ -1,4 +1,4 @@
-module github.com/crhntr/hello-tile
+module github.com/releen/hello-tile
 
 go 1.22.6
 

--- a/internal/acceptance/workflows/updating_releases.feature
+++ b/internal/acceptance/workflows/updating_releases.feature
@@ -1,13 +1,13 @@
 Feature: As a dependabot, I want to update a BOSH Release
   Scenario: Find a version on GitHub
     Given I have a tile source directory "testdata/tiles/v2"
-    And GitHub repository "crhntr/hello-release" has release with tag "v0.2.3"
-    And I set the version constraint to "0.2.3" for release "hello-release"
+    And GitHub repository "releen/hello-release" has release with tag "0.4.0"
+    And I set the version constraint to "0.4.0" for release "hello-release"
     When I invoke kiln
       | find-release-version                      |
       | --release=hello-release                   |
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
-    Then stdout contains substring: "0.2.3"
+    Then stdout contains substring: "0.4.0"
 
   Scenario: Find a version on bosh.io
     Given I have a tile source directory "testdata/tiles/v2"
@@ -22,16 +22,16 @@ Feature: As a dependabot, I want to update a BOSH Release
   Scenario: Update a component to a new release with download
     Given I have a tile source directory "testdata/tiles/v2"
     And the repository has no fetched releases
-    And the Kilnfile.lock specifies version "0.2.3" for release "hello-release"
-    And GitHub repository "crhntr/hello-release" has release with tag "0.3.0"
+    And the Kilnfile.lock specifies version "0.4.0" for release "hello-release"
+    And GitHub repository "releen/hello-release" has release with tag "0.5.0"
     When I invoke kiln
       | update-release                            |
       | --name=hello-release                      |
-      | --version=0.3.0                           |
+      | --version=0.5.0                           |
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
-    Then the Kilnfile.lock specifies version "0.3.0" for release "hello-release"
+    Then the Kilnfile.lock specifies version "0.5.0" for release "hello-release"
     And kiln validate succeeds
-    And the "hello-release-0.3.0.tgz" release tarball exists
+    And the "hello-release-0.5.0.tgz" release tarball exists
 
   Scenario: Update a component to a new release without download
     Given I have a tile source directory "testdata/tiles/v2"

--- a/internal/acceptance/workflows/updating_stemcell.feature
+++ b/internal/acceptance/workflows/updating_stemcell.feature
@@ -23,9 +23,9 @@ Feature: As a dependabot, I want to update a stemcell
       | --version=1.340                           |
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
     Then "Kilnfile.lock" contains substring: version: "1.340"
-    And the Kilnfile.lock specifies version "0.2.3" for release "hello-release"
+    And the Kilnfile.lock specifies version "0.4.0" for release "hello-release"
     And the "bpm-1.2.12.tgz" release tarball exists
-    And the "hello-release-0.2.3.tgz" release tarball exists
+    And the "hello-release-0.4.0.tgz" release tarball exists
 
   Scenario: Update the stemcell without download
     Given I have a tile source directory "testdata/tiles/v2"
@@ -38,9 +38,9 @@ Feature: As a dependabot, I want to update a stemcell
       | --without-download                        |
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
     Then "Kilnfile.lock" contains substring: version: "1.340"
-    And the Kilnfile.lock specifies version "0.2.3" for release "hello-release"
+    And the Kilnfile.lock specifies version "0.4.0" for release "hello-release"
     And the "bpm-1.2.12.tgz" release tarball does not exist
-    And the "hello-release-0.2.3.tgz" release tarball does not exist
+    And the "hello-release-0.4.0.tgz" release tarball does not exist
 
   Scenario: Update the stemcell with release updates
     Given I have a tile source directory "testdata/tiles/v2"
@@ -53,5 +53,5 @@ Feature: As a dependabot, I want to update a stemcell
       | --update-releases                         |
       | --variable=github_access_token="${GITHUB_ACCESS_TOKEN}" |
     Then "Kilnfile.lock" contains substring: version: "1.340"
-    And the Kilnfile.lock specifies version "0.3.0" for release "hello-release"
-    And the "hello-release-0.3.0.tgz" release tarball exists
+    And the Kilnfile.lock specifies version "0.5.0" for release "hello-release"
+    And the "hello-release-0.5.0.tgz" release tarball exists

--- a/internal/commands/release_notes_test.go
+++ b/internal/commands/release_notes_test.go
@@ -268,7 +268,7 @@ func Test_getGithubRemoteRepoOwnerAndName(t *testing.T) {
 		_, _ = repo.CreateRemote(&config.RemoteConfig{
 			Name: "fork",
 			URLs: []string{
-				"git@github.com:crhntr/kiln.git",
+				"git@github.com:releen/kiln.git",
 			},
 		})
 		_, _ = repo.CreateRemote(&config.RemoteConfig{

--- a/internal/gh/uri_test.go
+++ b/internal/gh/uri_test.go
@@ -18,13 +18,13 @@ func Test_RepositoryOwnerAndNameFromPath(t *testing.T) {
 	}{
 		{
 			Name:            "valid url",
-			URI:             "https://github.com/crhntr/hello-release",
-			RepositoryOwner: "crhntr", RepositoryName: "hello-release", RepositoryHost: "github.com",
+			URI:             "https://github.com/releen/hello-release",
+			RepositoryOwner: "releen", RepositoryName: "hello-release", RepositoryHost: "github.com",
 		},
 		{
 			Name:            "ssh url",
-			URI:             "git@github.com:crhntr/hello-release.git",
-			RepositoryOwner: "crhntr", RepositoryName: "hello-release", RepositoryHost: "github.com",
+			URI:             "git@github.com:releen/hello-release.git",
+			RepositoryOwner: "releen", RepositoryName: "hello-release", RepositoryHost: "github.com",
 		},
 		{
 			Name:           "empty ssh path",
@@ -43,12 +43,12 @@ func Test_RepositoryOwnerAndNameFromPath(t *testing.T) {
 		},
 		{
 			Name:           "missing repo name",
-			URI:            "https://github.com/crhntr",
+			URI:            "https://github.com/releen",
 			ErrorSubstring: "path missing expected parts",
 		},
 		{
 			Name:           "missing repo owner",
-			URI:            "https://github.com//crhntr",
+			URI:            "https://github.com//releen",
 			ErrorSubstring: "path missing expected parts",
 		},
 		{

--- a/pkg/cargo/validate_test.go
+++ b/pkg/cargo/validate_test.go
@@ -221,14 +221,14 @@ func TestValidate_release_sources(t *testing.T) {
 		please := NewWithT(t)
 		results := Validate(Kilnfile{
 			ReleaseSources: []ReleaseSourceConfig{
-				{Org: "crhntr", Type: BOSHReleaseTarballSourceTypeGithub},
+				{Org: "releen", Type: BOSHReleaseTarballSourceTypeGithub},
 			},
 			Releases: []BOSHReleaseTarballSpecification{
-				{Name: "hello-tile", GitHubRepository: "https://github.com/crhntr/hello-tile"},
+				{Name: "hello-tile", GitHubRepository: "https://github.com/releen/hello-tile"},
 			},
 		}, KilnfileLock{
 			Releases: []BOSHReleaseTarballLock{
-				{Name: "hello-tile", Version: "1.2.3", RemoteSource: "crhntr"},
+				{Name: "hello-tile", Version: "1.2.3", RemoteSource: "releen"},
 			},
 		})
 		please.Expect(results).To(HaveLen(0))


### PR DESCRIPTION
- Updated Chris test hello tile and hello release repo references to point to releen
- Updated upload-artifact github action to v4
- Pinned golangci-lint-action to v6.3.0 because of an error in the latest version

JIRA Link: https://vmw-jira.broadcom.net/browse/TNZ-32601
[TNZ-32601] - [Kiln]: Stop using Chris's hello release and tile repos for testing
Date: 27-Feb-2025

Authored-by: Ramkumar Vengadakrishnan <ramkumar.vengadakrishnan@broadcom.com>