### PR TITLE
feat: Added depdendabot to autobump dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more details:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  # Enable version updates for go
+  - package-ecosystem: "gomod"
+    # Look for go.mod file in the `root` directory
+    directory: "/"
+    # Check for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
[TNZ-33526] - [Kiln]: Enable Dependabot for Kiln repo
JIRA Link: https://vmw-jira.broadcom.net/browse/TNZ-33526
Date: 07-Mar-2025

Authored-by: Ramkumar Vengadakrishnan <ramkumar.vengadakrishnan@broadcom.com>