### PR TITLE
feat: Removed code to push kiln image to GCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to GCR
-        uses: docker/login-action@v2
-        with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.TAS_PPE_GCR_SERVICE_JSON_KEY }}
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,8 +44,6 @@ dockers:
   - image_templates:
       - "pivotalcfreleng/kiln:latest"
       - "pivotalcfreleng/kiln:{{ .Tag }}"
-      - "gcr.io/tas-ppe/pivotalcfreleng/kiln:latest"
-      - "gcr.io/tas-ppe/pivotalcfreleng/kiln:{{ .Tag }}"
 
     skip_push: false
 


### PR DESCRIPTION
[TNZ-36076] - [GCP Migration]: Migrate TAS Releng GCP projects to internal BSG GCP JIRA Link - https://vmw-jira.broadcom.net/browse/TNZ-36076 Updated on: 07-Apr-2025

Authored-by: Ramkumar Vengadakrishnan <ramkumar.vengadakrishnan@broadcom.com>