### PR TITLE
Consume ops-manifest as a pre-built gem

### DIFF
--- a/.github/workflows/create-debugging-artifact.yml
+++ b/.github/workflows/create-debugging-artifact.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: true
         type: boolean
-        
+
 permissions:
   contents: write
 
@@ -35,7 +35,7 @@ jobs:
         run: |
           go build ./...
           ls -alth
-          
+
       - name: Unit Test
         env:
           RELEEN_GITHUB_TOKEN: ${{ secrets.RELEEN_GITHUB_TOKEN }}
@@ -50,14 +50,13 @@ jobs:
         run: |
           set -euo pipefail
           export GITHUB_ACCESS_TOKEN="${RELEEN_GITHUB_TOKEN}"
-              
-          set -x
+
           go test --run '(using_kiln|baking_a_tile|generating_release_notes|updating_)' \
             -v --timeout 24h --tags acceptance \
             github.com/pivotal-cf/kiln/internal/acceptance/workflows
-          
+
           git reset --hard HEAD
-          
+
       - uses: actions/upload-artifact@v4
         with:
           path: ./kiln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
           go-version-file: go.mod
 
       - name: Build
-        run: go build ./...
+        run: |
+          go build ./...
 
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.7.0
@@ -37,7 +38,7 @@ jobs:
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.RELEEN_GITHUB_TOKEN }}
         run: |
-          go test --covermode=atomic --coverprofile=kiln-${{github.sha}}-unit-test-code-coverage.out ./...
+          go test --covermode=atomic --coverprofile=kiln-${{ github.sha }}-unit-test-code-coverage.out -skip 'TestDockerIntegration' ./...
 
       - name: Archive Unit Test Code Coverage Output
         uses: actions/upload-artifact@v4
@@ -52,7 +53,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          set -x
           go test -v --timeout 24h --tags acceptance github.com/pivotal-cf/kiln/internal/acceptance/workflows
 
           git reset --hard HEAD

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: test
+
 on:
   push:
     branches: ["main"]
   pull_request:
+
 jobs:
   test:
     name: test
@@ -28,7 +30,8 @@ jobs:
           git status --porcelain # When this fails, things have changed.
 
       - name: Build
-        run: go build -v ./...
+        run: |
+          go build -v ./...
 
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.7.0
@@ -36,7 +39,8 @@ jobs:
           ssh-private-key: ${{ secrets.RELENG_CI_BOT_KEY }}
 
       - name: Unit Tests
-        run: go test --covermode=atomic --coverprofile=kiln-${{ github.sha }}-unit-test-code-coverage.out ./...
+        run: |
+          go test --covermode=atomic --coverprofile=kiln-${{ github.sha }}-unit-test-code-coverage.out -skip 'TestDockerIntegration' ./...
 
       - name: Archive Unit Test Code Coverage Output
         uses: actions/upload-artifact@v4
@@ -52,5 +56,4 @@ jobs:
           set -euo pipefail
           export GITHUB_ACCESS_TOKEN="${RELEEN_GITHUB_TOKEN}"
 
-          set -x
           go test -v --timeout 15m --tags acceptance github.com/pivotal-cf/kiln/internal/acceptance/workflows

--- a/internal/test/Dockerfile
+++ b/internal/test/Dockerfile
@@ -5,7 +5,6 @@ FROM pivotalcfreleng/kiln:v0.77.0 as kiln
 
 FROM ruby:3.2.0 as builder
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-ADD git@github.com:pivotal-cf/ops-manager.git#v2.10.66 /tmp/ops-manager
 
 FROM ruby:3.2.0
 
@@ -32,17 +31,14 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin:${PATH}"
 
-# Install ops-manifest
-#   assumes ops-manifest repo was cloned into ./vendor/ops-manager/gems/ops-manifest
-COPY --from=builder /tmp/ops-manager /tmp/ops-manager
-WORKDIR /tmp/ops-manager/gems/ops-manifest
+# Install OpsManifest from Artifactory
+ARG ARTIFACTORY_USERNAME
+ARG ARTIFACTORY_PASSWORD
 
-RUN bundle install && \
-  rm -rf *.gem && \
-  bundle exec gem build ops-manifest.gemspec && \
-  gem install ops-manifest-*.gem --no-document && \
-  gem uninstall json && \
-  gem install json --version 2.7.1 && \
-  gem uninstall concurrent-ruby --force && \
-  gem install concurrent-ruby --version 1.3.4 
+ENV ARTIFACTORY_USERNAME=${ARTIFACTORY_USERNAME}
+ENV ARTIFACTORY_PASSWORD=${ARTIFACTORY_PASSWORD}
+
+RUN gem source -a https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@usw1.packages.broadcom.com/artifactory/api/gems/tas-rel-eng-gem-dev-local/
+RUN gem install --verbose ops-manifest -v 0.0.3.pre
+
 RUN which ops-manifest

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -28,6 +28,16 @@ func TestDockerIntegration(t *testing.T) {
 
 	checkDaemonVersion(t)
 
+	artifactoryUsername, usernameFound := os.LookupEnv("ARTIFACTORY_USERNAME")
+	if !usernameFound {
+		t.Fatal("Missing ARTIFACTORY_USERNAME environment variable")
+	}
+
+	artifactoryPassword, passwordFound := os.LookupEnv("ARTIFACTORY_PASSWORD")
+	if !passwordFound {
+		t.Fatal("Missing ARTIFACTORY_PASSWORD environment variable")
+	}
+
 	t.Run("the test succeeds", func(t *testing.T) {
 		wd, err := os.Getwd()
 		require.NoError(t, err)
@@ -36,6 +46,7 @@ func TestDockerIntegration(t *testing.T) {
 		configuration := test.Configuration{
 			AbsoluteTileDirectory: filepath.Join(wd, "testdata", "happy-tile"),
 			RunAll:                true,
+			Environment:           []string{"ARTIFACTORY_USERNAME=" + artifactoryUsername, "ARTIFACTORY_PASSWORD=" + artifactoryPassword},
 		}
 		out := io.Discard
 		if testing.Verbose() {
@@ -54,7 +65,7 @@ func TestDockerIntegration(t *testing.T) {
 		configuration := test.Configuration{
 			AbsoluteTileDirectory: filepath.Join(wd, "testdata", "happy-tile"),
 			RunManifest:           true,
-			Environment:           []string{"FAIL_TEST=true"},
+			Environment:           []string{"FAIL_TEST=true", "ARTIFACTORY_USERNAME=" + artifactoryUsername, "ARTIFACTORY_PASSWORD=" + artifactoryPassword},
 		}
 
 		outBuffer := new(bytes.Buffer)


### PR DESCRIPTION
Skip the integration test for the internal/test package as it requires
access to Artifactory.
