### PR TITLE
Feat/artifactory source full semver support

### DIFF
--- a/internal/component/artifactory_release_source.go
+++ b/internal/component/artifactory_release_source.go
@@ -238,7 +238,13 @@ func (ars *ArtifactoryReleaseSource) FindReleaseVersion(spec cargo.BOSHReleaseTa
 
 	regexSpec := spec
 	regexSpec.Version = fmt.Sprintf(`(?P<bosh_version>(%s))`, semverRegex)
-	regexSpec.StemcellVersion = fmt.Sprintf(`(?P<bosh_stemcell_version>(%s))`, semverRegex)
+	if spec.StemcellOS != "" {
+		if spec.StemcellVersion == "" {
+			panic("TODO: test this: this shouldn't happen.")
+		}
+		regexSpec.StemcellVersion = fmt.Sprintf(`(?P<bosh_stemcell_version>(%s))`, semverRegex)
+	}
+
 	semverFilepathRegex, err := ars.RemotePath(regexSpec)
 	if err != nil {
 		return cargo.BOSHReleaseTarballLock{}, err
@@ -293,6 +299,7 @@ func (ars *ArtifactoryReleaseSource) FindReleaseVersion(spec cargo.BOSHReleaseTa
 		if version != "" {
 			newVersion, _ := semver.NewVersion(version)
 			check := constraint.Check(newVersion)
+			fmt.Println("comparing", constraint.String(), "to", newVersion)
 			if !check {
 				continue
 			}

--- a/internal/component/artifactory_release_source_test.go
+++ b/internal/component/artifactory_release_source_test.go
@@ -120,7 +120,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					_, _ = io.WriteString(res, string(apiStorageListingBytes))
 				}), requireAuth))
 			})
-			FIt("finds the latest bosh pre release", func() { // testing FindReleaseVersion
+			It("finds the latest bosh pre release", func() { // testing FindReleaseVersion
 				//s := cargo.BOSHReleaseTarballSpecification{
 				//	Name:             "test",
 				//	Version:          "~2.0",

--- a/internal/component/artifactory_release_source_test.go
+++ b/internal/component/artifactory_release_source_test.go
@@ -67,7 +67,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 	})
 
 	Describe("read operations", func() {
-		When("there are pre-releases", func() {
+		When("there are pre-releases and full releases", func() {
 			BeforeEach(func() {
 				requireAuth := requireBasicAuthMiddleware(correctUsername, correctPassword)
 
@@ -128,7 +128,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 				//}
 				resultLock, resultErr := source.FindReleaseVersion(cargo.BOSHReleaseTarballSpecification{
 					Name:            "mango",
-					Version:         "2.3.4-build.2",
+					Version:         ">=0.0.0-build.0",
 					StemcellOS:      "smoothie",
 					StemcellVersion: "9.9",
 				}, false)
@@ -136,11 +136,11 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 				Expect(resultErr).NotTo(HaveOccurred())
 				Expect(resultLock).To(Equal(cargo.BOSHReleaseTarballLock{
 					Name:    "mango",
-					Version: "2.3.4-build.2",
+					Version: "2.3.4",
 					// StemcellOS:      "smoothie",
 					// StemcellVersion: "9.9",
 					SHA1:         "some-sha",
-					RemotePath:   "bosh-releases/smoothie/9.9/mango/mango-2.3.4-build.2-smoothie-9.9.tgz",
+					RemotePath:   "bosh-releases/smoothie/9.9/mango/mango-2.3.4-smoothie-9.9.tgz",
 					RemoteSource: "some-mango-tree",
 				}))
 			})

--- a/internal/component/artifactory_release_source_test.go
+++ b/internal/component/artifactory_release_source_test.go
@@ -81,12 +81,11 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					}
 
 					apiStorageListing := ApiStorageListing{}
-					for _, version := range []string{
-						"2.3.4-build.1",
-						"2.3.4",
-						"2.3.4-build.2",
+					for _, filename := range []string{
+						"mango-2.3.4-build.1-smoothie-9.9.tgz",
+						"mango-2.3.4-smoothie-9.9.tgz",
+						"mango-2.3.4-build.2-smoothie-9.9.tgz",
 					} {
-						filename := fmt.Sprintf("mango-%s-smoothie-9.9.tgz", version)
 						apiStoragePath := fmt.Sprintf("/api/storage/basket/bosh-releases/smoothie/9.9/mango/%s", filename)
 						artifactoryRouter.Handler(http.MethodGet, apiStoragePath, applyMiddleware(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 							res.WriteHeader(http.StatusOK)
@@ -188,12 +187,11 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					}
 
 					apiStorageListing := ApiStorageListing{}
-					for _, version := range []string{
-						"2.3.4-build.1",
-						"2.3.4-build.3",
-						"2.3.4-build.2",
+					for _, filename := range []string{
+						"mango-2.3.4-build.1-smoothie-9.9.tgz",
+						"mango-2.3.4-build.3-smoothie-9.9.tgz",
+						"mango-2.3.4-build.2-smoothie-9.9.tgz",
 					} {
-						filename := fmt.Sprintf("mango-%s-smoothie-9.9.tgz", version)
 						apiStoragePath := fmt.Sprintf("/api/storage/basket/bosh-releases/smoothie/9.9/mango/%s", filename)
 						artifactoryRouter.Handler(http.MethodGet, apiStoragePath, applyMiddleware(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 							res.WriteHeader(http.StatusOK)
@@ -274,11 +272,10 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					}
 
 					apiStorageListing := ApiStorageListing{}
-					for _, version := range []string{
+					for _, filename := range []string{
 						"",
 						"invalid",
 					} {
-						filename := fmt.Sprintf("mango-%s-smoothie-9.9.tgz", version)
 						apiStoragePath := fmt.Sprintf("/api/storage/basket/bosh-releases/smoothie/9.9/mango/%s", filename)
 						artifactoryRouter.Handler(http.MethodGet, apiStoragePath, applyMiddleware(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 							res.WriteHeader(http.StatusOK)
@@ -359,15 +356,17 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					}
 
 					apiStorageListing := ApiStorageListing{}
-					for _, version := range []string{
+					for _, filename := range []string{
 						"",
 						"invalid",
-						"2.3.3",
-						"2.3.4-build.1",
-						"2.3.4",
-						"2.3.4-build.2",
+						"mango-2.3.3-smoothie-9.9.tgz",
+						"mango-2.3.4-build.1-smoothie-9.9.tgz",
+						"mango-2.3.4-smoothie-9.9.tgz",
+						"mango-2.3.4-build.2-smoothie-9.9.tgz",
+						"mango-2.3.5-notices.zip",
+						"notices-mango-2.3.5.zip",
+						"orange-10.0.0-smoothie-9.9.tgz",
 					} {
-						filename := fmt.Sprintf("mango-%s-smoothie-9.9.tgz", version)
 						apiStoragePath := fmt.Sprintf("/api/storage/basket/bosh-releases/smoothie/9.9/mango/%s", filename)
 						artifactoryRouter.Handler(http.MethodGet, apiStoragePath, applyMiddleware(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 							res.WriteHeader(http.StatusOK)
@@ -392,20 +391,8 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 						})
 					}
 
-					apiStorageListing.Children = append(apiStorageListing.Children, ApiStorageChildren{
-						Uri:    "/mango-2.3.4-notices.zip",
-						Folder: false,
-					})
-					apiStoragePath := "/api/storage/basket/bosh-releases/smoothie/9.9/mango/mango-2.3.4-notices.zip"
-					artifactoryRouter.Handler(http.MethodGet, apiStoragePath, applyMiddleware(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
-						res.WriteHeader(http.StatusOK)
-						// language=json
-						_, _ = io.WriteString(res, `{"checksums": {"sha1":  "some-sha"}}`)
-					}), requireAuth))
-
 					apiStorageListingBytes, err := json.Marshal(apiStorageListing)
 					Expect(err).NotTo(HaveOccurred())
-					fmt.Printf("%+v\n", string(apiStorageListingBytes))
 
 					artifactoryRouter.Handler(http.MethodGet, "/api/storage/basket/bosh-releases/smoothie/9.9/mango", applyMiddleware(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
 						res.WriteHeader(http.StatusOK)

--- a/internal/component/artifactory_release_source_test.go
+++ b/internal/component/artifactory_release_source_test.go
@@ -67,7 +67,7 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 	})
 
 	Describe("read operations", func() {
-		When("there is pre-release", func() {
+		When("there are pre-releases", func() {
 			BeforeEach(func() {
 				requireAuth := requireBasicAuthMiddleware(correctUsername, correctPassword)
 
@@ -120,7 +120,12 @@ var _ = Describe("interacting with BOSH releases on Artifactory", func() {
 					_, _ = io.WriteString(res, string(apiStorageListingBytes))
 				}), requireAuth))
 			})
-			It("finds the latest bosh pre release", func() { // testing FindReleaseVersion
+			FIt("finds the latest bosh pre release", func() { // testing FindReleaseVersion
+				//s := cargo.BOSHReleaseTarballSpecification{
+				//	Name:             "test",
+				//	Version:          "~2.0",
+				//	GitHubRepository: "git@github.com:test-org/test.git",
+				//}
 				resultLock, resultErr := source.FindReleaseVersion(cargo.BOSHReleaseTarballSpecification{
 					Name:            "mango",
 					Version:         "2.3.4-build.2",


### PR DESCRIPTION
## Issue

`kiln` is extracting versions matching the following the pattern `([-v])\d+(.\d+)*` and assuming the first is the bosh release version while if a second version is present it represents the stemcell version. While this works for a wide variety of cases there are some edge cases where it's brittle. For example `some-release-1.2.3-notices.zip` is matched erroneously. Also, in the case a pre-release segment is wanted then the version extracted won't contain it, meaning the ordering of pre-releases isn't well defined. This can be seen by how the version is extracted:

```golang
		versions := semverPattern.FindAllString(filepath.Base(releases.URI), -1)
		version := versions[0]
```

and then sorted

```golang
newVersion, _ := semver.NewVersion(version)
...
foundVersion, _ := semver.NewVersion(foundRelease.Version)
if newVersion.GreaterThan(foundVersion) {
```

## Proposal

I'd like to propose that the artifactory source in particular is brought fully in line with the semver semantics used by mastermind's v3. So that `*` does not match pre-releases allowing tiles to avoid accidental ingestion of them, while still permitting matches when desired using the convention `>0.0.0-0`. See https://github.com/Masterminds/semver?tab=readme-ov-file#working-with-prerelease-versions