### PR TITLE
feat: resolve stemcell slug for Noble

### DIFF
--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -215,6 +215,8 @@ func (stemcell Stemcell) ProductSlug() (string, error) {
 		return "stemcells-ubuntu-xenial", nil
 	case "ubuntu-jammy":
 		return "stemcells-ubuntu-jammy", nil
+	case "ubuntu-noble":
+		return "stemcells-ubuntu-noble", nil
 	case "windows2019":
 		return "stemcells-windows-server", nil
 	default:

--- a/pkg/cargo/kilnfile_test.go
+++ b/pkg/cargo/kilnfile_test.go
@@ -90,6 +90,11 @@ func TestStemcell_ProductSlug(t *testing.T) {
 			ExpSlug:  "stemcells-ubuntu-jammy",
 		},
 		{
+			Name:     "when using known os ubuntu-noble",
+			Stemcell: Stemcell{OS: "ubuntu-noble"},
+			ExpSlug:  "stemcells-ubuntu-noble",
+		},
+		{
 			Name:     "when using known os windows2019",
 			Stemcell: Stemcell{OS: "windows2019"},
 			ExpSlug:  "stemcells-windows-server",


### PR DESCRIPTION
Addresses the following issue when the `stemcell_criteria.slug` is not specified in the Kilnfile but `stemcell_criteria.os` is `ubuntu-noble`:
```
$ kiln find-stemcell-version
2025/09/24 11:09:00 could not execute "find-stemcell-version": stemcell
slug not set for os ubuntu-noble
```