### PR TITLE
feat(carvel): generate unique bosh release names

### DIFF
--- a/internal/acceptance/carvel/carvel_workflow_test.go
+++ b/internal/acceptance/carvel/carvel_workflow_test.go
@@ -288,10 +288,11 @@ var _ = Describe("carvel full workflow", Ordered, func() {
 		Expect(lock.Releases).To(HaveLen(1))
 		rel := lock.Releases[0]
 		Expect(rel.Name).To(Equal("k8s-tile-test"))
-		Expect(rel.Version).To(Equal("0.1.1"))
+		Expect(rel.Version).To(HavePrefix("0.1.1+"))
+		Expect(rel.Version).To(MatchRegexp(`^0\.1\.1\+[0-9a-f]{12}$`))
 		Expect(rel.SHA1).NotTo(BeEmpty(), "lock must contain SHA1 of uploaded tarball")
 		Expect(rel.RemoteSource).To(Equal("artifactory"))
-		Expect(rel.RemotePath).To(Equal("bosh-releases/k8s-tile-test/k8s-tile-test-0.1.1.tgz"))
+		Expect(rel.RemotePath).To(Equal("bosh-releases/k8s-tile-test/k8s-tile-test-" + rel.Version + ".tgz"))
 
 		gitInTile("add", "Kilnfile.lock")
 		gitInTile("commit", "-m", "add Kilnfile.lock from upload")

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -1,14 +1,18 @@
 package carvel
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/pivotal-cf/kiln/internal/carvel/models"
@@ -25,7 +29,12 @@ type Baker interface {
 	BakeFromLockfile(source string, releaseLock cargo.BOSHReleaseTarballLock, localTarball string) error
 	KilnBake(destination string) error
 	GetName() string
+	// GetVersion returns the product version from base.yml or the version file.
 	GetVersion() (string, error)
+	// GetReleaseVersion returns the BOSH release version, which includes a
+	// content fingerprint suffix (e.g., "10.4.0+a1b2c3d4e5f6"). Only valid
+	// after Bake() or BakeFromLockfile() has been called.
+	GetReleaseVersion() string
 	GetReleaseTarball() (string, error)
 	SetWriter(w io.Writer)
 	SetProgressWriter(w io.Writer)
@@ -42,6 +51,7 @@ func NewBaker() Baker {
 type baker struct {
 	metadata            models.Metadata
 	source, destination string
+	releaseVersion      string
 	writer              io.Writer
 	progressWriter      io.Writer
 }
@@ -138,6 +148,8 @@ func (b *baker) BakeFromLockfile(source string, releaseLock cargo.BOSHReleaseTar
 		return fmt.Errorf("lockfile release name %q does not match tile name %q", releaseLock.Name, b.metadata.Name)
 	}
 
+	b.releaseVersion = releaseLock.Version
+
 	err = os.RemoveAll(b.destination)
 	if err != nil {
 		return err
@@ -175,7 +187,7 @@ func (b *baker) BakeFromLockfile(source string, releaseLock cargo.BOSHReleaseTar
 		return err
 	}
 
-	destTarball := path.Join(releasesDir, b.metadata.Name+"-"+ver+".tgz")
+	destTarball := path.Join(releasesDir, b.metadata.Name+"-"+releaseLock.Version+".tgz")
 
 	b.progress("Copying cached BOSH release from " + localTarball)
 	b.log("copying cached BOSH release from " + localTarball)
@@ -188,11 +200,10 @@ func (b *baker) BakeFromLockfile(source string, releaseLock cargo.BOSHReleaseTar
 }
 
 func (b *baker) GetReleaseTarball() (string, error) {
-	ver, err := b.GetVersion()
-	if err != nil {
-		return "", err
+	if b.releaseVersion == "" {
+		return "", fmt.Errorf("release version not set -- call Bake() or BakeFromLockfile() first")
 	}
-	tarball := path.Join(b.destination, "releases", b.metadata.Name+"-"+ver+".tgz")
+	tarball := path.Join(b.destination, "releases", b.metadata.Name+"-"+b.releaseVersion+".tgz")
 	if _, err := os.Stat(tarball); err != nil {
 		return "", fmt.Errorf("release tarball not found at %s: %w", tarball, err)
 	}
@@ -201,6 +212,10 @@ func (b *baker) GetReleaseTarball() (string, error) {
 
 func (b *baker) GetName() string {
 	return b.metadata.Name
+}
+
+func (b *baker) GetReleaseVersion() string {
+	return b.releaseVersion
 }
 
 func (b *baker) GetVersion() (string, error) {
@@ -666,19 +681,29 @@ func (b *baker) createBoshRelease() error {
 		return err
 	}
 
-	version, err := b.GetVersion()
+	productVersion, err := b.GetVersion()
 	if err != nil {
 		return err
 	}
 
 	dirName := path.Join(b.source, ".boshrelease")
+
+	fingerprint, err := hashBoshReleaseInputs(dirName)
+	if err != nil {
+		return err
+	}
+
+	releaseVersion := buildReleaseVersion(productVersion, fingerprint)
+	b.releaseVersion = releaseVersion
+
+	finalTarball := path.Join(b.destination, "releases", b.metadata.Name+"-"+releaseVersion+".tgz")
 	cmd := exec.Command("bosh",
 		"create-release",
 		"--dir="+dirName,
 		"--force",
 		"--name", b.metadata.Name,
-		"--version", version,
-		"--tarball", path.Join(b.destination, "releases", b.metadata.Name+"-"+version+".tgz"))
+		"--version", releaseVersion,
+		"--tarball", finalTarball)
 	b.log("executing " + cmd.String())
 	out, err := cmd.CombinedOutput()
 	b.log("output: " + string(out))
@@ -686,7 +711,59 @@ func (b *baker) createBoshRelease() error {
 		return err
 	}
 
+	b.progress(fmt.Sprintf("  BOSH release version: %s", releaseVersion))
 	return nil
+}
+
+func hashBoshReleaseInputs(boshReleaseDir string) (string, error) {
+	h := sha256.New()
+
+	var paths []string
+	err := filepath.WalkDir(boshReleaseDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(boshReleaseDir, p)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, rel)
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to walk .boshrelease directory: %w", err)
+	}
+
+	sort.Strings(paths)
+
+	for _, rel := range paths {
+		_, _ = fmt.Fprintf(h, "path:%s\n", rel)
+
+		f, err := os.Open(filepath.Join(boshReleaseDir, rel))
+		if err != nil {
+			return "", err
+		}
+		if _, err := io.Copy(h, f); err != nil {
+			_ = f.Close()
+			return "", err
+		}
+		_ = f.Close()
+	}
+
+	return hex.EncodeToString(h.Sum(nil))[:12], nil
+}
+
+func buildReleaseVersion(productVersion, fingerprint string) string {
+	if strings.Contains(productVersion, "+") {
+		return productVersion + "." + fingerprint
+	}
+	return productVersion + "+" + fingerprint
 }
 
 func copyFileContents(src, dst string) (err error) {

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -194,8 +194,15 @@ var _ = Describe("Carvel Baker", func() {
 					Expect(filepath.Join(outputPath, "icon.png")).To(BeAnExistingFile())
 					Expect(filepath.Join(outputPath, "version")).To(BeAnExistingFile())
 				})
-				It("Generates a bosh release tarball", func() {
-					Expect(filepath.Join(outputPath, "releases", "k8s-tile-test-0.1.1.tgz")).To(BeAnExistingFile())
+				It("generates a bosh release tarball with fingerprinted version", func() {
+					releaseVersion := subject.GetReleaseVersion()
+					Expect(releaseVersion).To(HavePrefix("0.1.1+"))
+					Expect(releaseVersion).To(MatchRegexp(`^0\.1\.1\+[0-9a-f]{12}$`))
+					Expect(filepath.Join(outputPath, "releases", "k8s-tile-test-"+releaseVersion+".tgz")).To(BeAnExistingFile())
+
+					tarball, err := subject.GetReleaseTarball()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(tarball).To(ContainSubstring(releaseVersion))
 				})
 				It("does not generate a separate package-install job", func() {
 					Expect(filepath.Join(boshReleasePath, "jobs", "package-install")).NotTo(BeADirectory())
@@ -347,9 +354,11 @@ var _ = Describe("Carvel Baker", func() {
 				err = copyTestFile(tarball, cachedTarball)
 				Expect(err).NotTo(HaveOccurred())
 
+				uploadReleaseVersion := subject.GetReleaseVersion()
+
 				releaseLock := cargo.BOSHReleaseTarballLock{
 					Name:    "k8s-tile-test",
-					Version: "0.1.1",
+					Version: uploadReleaseVersion,
 				}
 
 				subject2 := NewBaker()
@@ -359,8 +368,9 @@ var _ = Describe("Carvel Baker", func() {
 
 				outputPath := path.Join(inputPath, ".carvel-tile")
 				Expect(filepath.Join(outputPath, "base.yml")).To(BeAnExistingFile())
-				Expect(filepath.Join(outputPath, "releases", "k8s-tile-test-0.1.1.tgz")).To(BeAnExistingFile())
+				Expect(filepath.Join(outputPath, "releases", "k8s-tile-test-"+uploadReleaseVersion+".tgz")).To(BeAnExistingFile())
 				Expect(filepath.Join(outputPath, "runtime_configs")).To(BeADirectory())
+				Expect(subject2.GetReleaseVersion()).To(Equal(uploadReleaseVersion))
 			})
 		})
 
@@ -436,7 +446,7 @@ var _ = Describe("Carvel Baker", func() {
 
 			releaseLock := cargo.BOSHReleaseTarballLock{
 				Name:    "k8s-tile-test",
-				Version: "0.1.1",
+				Version: uploadBaker.GetReleaseVersion(),
 			}
 
 			publishBaker := NewBaker()
@@ -463,6 +473,99 @@ var _ = Describe("Carvel Baker", func() {
 
 			Expect(rebakeChecksum).To(Equal(publishChecksum),
 				"publish and rebake should produce identical tiles when using the same cached BOSH release tarball")
+		})
+	})
+
+	Context("hashBoshReleaseInputs", func() {
+		It("is deterministic", func() {
+			dir, err := os.MkdirTemp("", "hash-test-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = os.RemoveAll(dir) }()
+
+			Expect(os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0644)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(dir, "sub"), 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "sub", "b.txt"), []byte("world"), 0644)).To(Succeed())
+
+			h1, err := hashBoshReleaseInputs(dir)
+			Expect(err).NotTo(HaveOccurred())
+			h2, err := hashBoshReleaseInputs(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(h1).To(Equal(h2))
+			Expect(h1).To(HaveLen(12))
+		})
+
+		It("changes when file contents change", func() {
+			dir, err := os.MkdirTemp("", "hash-test-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = os.RemoveAll(dir) }()
+
+			Expect(os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0644)).To(Succeed())
+
+			h1, err := hashBoshReleaseInputs(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(os.WriteFile(filepath.Join(dir, "a.txt"), []byte("changed"), 0644)).To(Succeed())
+
+			h2, err := hashBoshReleaseInputs(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(h1).NotTo(Equal(h2))
+		})
+
+		It("changes when a file is renamed", func() {
+			dir, err := os.MkdirTemp("", "hash-test-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = os.RemoveAll(dir) }()
+
+			Expect(os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0644)).To(Succeed())
+
+			h1, err := hashBoshReleaseInputs(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(os.Rename(filepath.Join(dir, "a.txt"), filepath.Join(dir, "b.txt"))).To(Succeed())
+
+			h2, err := hashBoshReleaseInputs(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(h1).NotTo(Equal(h2))
+		})
+
+		It("excludes .git directory", func() {
+			dir, err := os.MkdirTemp("", "hash-test-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = os.RemoveAll(dir) }()
+
+			Expect(os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0644)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(dir, ".git", "objects"), 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte("ref: refs/heads/main"), 0644)).To(Succeed())
+
+			h1, err := hashBoshReleaseInputs(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte("ref: refs/heads/other"), 0644)).To(Succeed())
+
+			h2, err := hashBoshReleaseInputs(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(h1).To(Equal(h2))
+		})
+	})
+
+	Context("buildReleaseVersion", func() {
+		It("appends fingerprint with + separator", func() {
+			Expect(buildReleaseVersion("10.4.0", "a1b2c3d4e5f6")).To(Equal("10.4.0+a1b2c3d4e5f6"))
+		})
+
+		It("appends fingerprint with . separator when version already contains +", func() {
+			Expect(buildReleaseVersion("10.4.0+beta.1", "a1b2c3d4e5f6")).To(Equal("10.4.0+beta.1.a1b2c3d4e5f6"))
+		})
+	})
+
+	Context("GetReleaseVersion", func() {
+		It("returns empty string before Bake is called", func() {
+			subject := NewBaker()
+			Expect(subject.GetReleaseVersion()).To(BeEmpty())
 		})
 	})
 

--- a/internal/commands/carvel_publish_test.go
+++ b/internal/commands/carvel_publish_test.go
@@ -113,6 +113,7 @@ var _ = Describe("CarvelPublish", func() {
 				Expect(err).NotTo(HaveOccurred())
 				tarballData, err := os.ReadFile(tarball)
 				Expect(err).NotTo(HaveOccurred())
+				releaseVersion := b.GetReleaseVersion()
 
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					key := strings.TrimPrefix(r.URL.Path, "/artifactory")
@@ -138,7 +139,7 @@ var _ = Describe("CarvelPublish", func() {
 				}))
 
 				// Pre-load mock with the tarball (simulating a prior upload)
-				remotePath := "/test-repo/bosh-releases/k8s-tile-test/k8s-tile-test-0.1.1.tgz"
+				remotePath := "/test-repo/bosh-releases/k8s-tile-test/k8s-tile-test-" + releaseVersion + ".tgz"
 				blobs[remotePath] = tarballData
 
 				kf := cargo.Kilnfile{
@@ -158,8 +159,8 @@ var _ = Describe("CarvelPublish", func() {
 				lock := cargo.KilnfileLock{
 					Releases: []cargo.BOSHReleaseTarballLock{{
 						Name:         "k8s-tile-test",
-						Version:      "0.1.1",
-						RemotePath:   "bosh-releases/k8s-tile-test/k8s-tile-test-0.1.1.tgz",
+						Version:      releaseVersion,
+						RemotePath:   "bosh-releases/k8s-tile-test/k8s-tile-test-" + releaseVersion + ".tgz",
 						RemoteSource: "artifactory",
 					}},
 					Stemcell: cargo.Stemcell{OS: "ubuntu-jammy", Version: "1.446"},

--- a/internal/commands/carvel_rebake_test.go
+++ b/internal/commands/carvel_rebake_test.go
@@ -165,6 +165,7 @@ var _ = Describe("CarvelReBake", func() {
 				Expect(err).NotTo(HaveOccurred())
 				tarballData, err := os.ReadFile(tarball)
 				Expect(err).NotTo(HaveOccurred())
+				releaseVersion := b.GetReleaseVersion()
 
 				var (
 					mu    sync.Mutex
@@ -193,7 +194,7 @@ var _ = Describe("CarvelReBake", func() {
 				}))
 
 				// Pre-load the mock with the tarball at the expected path
-				remotePath := "/test-repo/bosh-releases/k8s-tile-test/k8s-tile-test-0.1.1.tgz"
+				remotePath := "/test-repo/bosh-releases/k8s-tile-test/k8s-tile-test-" + releaseVersion + ".tgz"
 				blobs[remotePath] = tarballData
 
 				kf := cargo.Kilnfile{
@@ -213,8 +214,8 @@ var _ = Describe("CarvelReBake", func() {
 				lock := cargo.KilnfileLock{
 					Releases: []cargo.BOSHReleaseTarballLock{{
 						Name:         "k8s-tile-test",
-						Version:      "0.1.1",
-						RemotePath:   "bosh-releases/k8s-tile-test/k8s-tile-test-0.1.1.tgz",
+						Version:      releaseVersion,
+						RemotePath:   "bosh-releases/k8s-tile-test/k8s-tile-test-" + releaseVersion + ".tgz",
 						RemoteSource: "artifactory",
 					}},
 					Stemcell: cargo.Stemcell{OS: "ubuntu-jammy", Version: "1.446"},

--- a/internal/commands/carvel_upload.go
+++ b/internal/commands/carvel_upload.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/pivotal-cf/jhanda"
@@ -174,7 +175,7 @@ func uploadToArtifactory(localPath, host, repo, remotePath, username, password s
 	}
 	defer func() { _ = f.Close() }()
 
-	uploadURL := host + "/" + repo + "/" + remotePath
+	uploadURL := host + "/" + repo + "/" + strings.ReplaceAll(remotePath, "+", "%2B")
 
 	req, err := http.NewRequest(http.MethodPut, uploadURL, f)
 	if err != nil {

--- a/internal/commands/carvel_upload.go
+++ b/internal/commands/carvel_upload.go
@@ -83,7 +83,9 @@ func (c CarvelUpload) Execute(args []string) error {
 		return fmt.Errorf("failed to locate release tarball: %w", err)
 	}
 
-	ver, err := baker.GetVersion()
+	releaseVersion := baker.GetReleaseVersion()
+
+	productVersion, err := baker.GetVersion()
 	if err != nil {
 		return fmt.Errorf("failed to get tile version: %w", err)
 	}
@@ -92,7 +94,7 @@ func (c CarvelUpload) Execute(args []string) error {
 	if artConfig.PathTemplate != "" {
 		pathTmpl = artConfig.PathTemplate
 	}
-	remotePath, err := evaluatePathTemplate(pathTmpl, baker.GetName(), ver)
+	remotePath, err := evaluatePathTemplate(pathTmpl, baker.GetName(), releaseVersion)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate path template: %w", err)
 	}
@@ -110,7 +112,7 @@ func (c CarvelUpload) Execute(args []string) error {
 
 	sourceID := cargo.BOSHReleaseTarballSourceID(artConfig)
 	lockfilePath := kilnfilePath + ".lock"
-	err = writeStandardKilnfileLock(lockfilePath, baker.GetName(), ver, remotePath, sourceID, sha1sum)
+	err = writeStandardKilnfileLock(lockfilePath, baker.GetName(), releaseVersion, remotePath, sourceID, sha1sum)
 	if err != nil {
 		return fmt.Errorf("failed to write Kilnfile.lock: %w", err)
 	}
@@ -125,7 +127,7 @@ func (c CarvelUpload) Execute(args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to bake tile: %w", err)
 		}
-		c.outLogger.Printf("Baked %s version %s to %s", baker.GetName(), ver, targetPath)
+		c.outLogger.Printf("Baked %s version %s to %s", baker.GetName(), productVersion, targetPath)
 	}
 
 	return nil

--- a/internal/commands/carvel_upload_test.go
+++ b/internal/commands/carvel_upload_test.go
@@ -158,9 +158,11 @@ var _ = Describe("CarvelUpload", func() {
 				Expect(yaml.Unmarshal(lockData, &lock)).To(Succeed())
 				Expect(lock.Releases).To(HaveLen(1))
 				Expect(lock.Releases[0].Name).To(Equal("k8s-tile-test"))
-				Expect(lock.Releases[0].Version).To(Equal("0.1.1"))
+				Expect(lock.Releases[0].Version).To(HavePrefix("0.1.1+"))
+				Expect(lock.Releases[0].Version).To(MatchRegexp(`^0\.1\.1\+[0-9a-f]{12}$`))
 				Expect(lock.Releases[0].SHA1).NotTo(BeEmpty())
 				Expect(lock.Releases[0].RemotePath).To(ContainSubstring("k8s-tile-test"))
+				Expect(lock.Releases[0].RemotePath).To(ContainSubstring(lock.Releases[0].Version))
 				Expect(lock.Releases[0].RemoteSource).To(Equal("artifactory"))
 
 				By("verifying mock Artifactory received the PUT with Basic Auth")

--- a/internal/commands/carvel_upload_test.go
+++ b/internal/commands/carvel_upload_test.go
@@ -56,11 +56,12 @@ var _ = Describe("CarvelUpload", func() {
 
 		When("valid Kilnfile is provided with a round-trip mock Artifactory", func() {
 			var (
-				inputPath string
-				server    *httptest.Server
-				mu        sync.Mutex
-				blobs     map[string][]byte
-				authOK    bool
+				inputPath      string
+				server         *httptest.Server
+				mu             sync.Mutex
+				blobs          map[string][]byte
+				authOK         bool
+				putRequestURIs []string
 			)
 
 			BeforeEach(func() {
@@ -70,6 +71,7 @@ var _ = Describe("CarvelUpload", func() {
 
 				blobs = make(map[string][]byte)
 				authOK = false
+				putRequestURIs = nil
 
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					u, p, ok := r.BasicAuth()
@@ -84,6 +86,7 @@ var _ = Describe("CarvelUpload", func() {
 						mu.Lock()
 						blobs[key] = body
 						authOK = true
+						putRequestURIs = append(putRequestURIs, r.RequestURI)
 						mu.Unlock()
 						w.WriteHeader(http.StatusCreated)
 					case http.MethodGet:
@@ -172,6 +175,11 @@ var _ = Describe("CarvelUpload", func() {
 				for _, data := range blobs {
 					Expect(len(data)).To(BeNumerically(">", 0), "uploaded tarball must not be empty")
 				}
+				Expect(putRequestURIs).To(HaveLen(1))
+				Expect(putRequestURIs[0]).To(ContainSubstring("%2B"),
+					"PUT request URI must contain %2B for + characters")
+				Expect(putRequestURIs[0]).NotTo(ContainSubstring("+"),
+					"PUT request URI must not contain + characters")
 				mu.Unlock()
 			})
 		})

--- a/internal/component/artifactory_release_source.go
+++ b/internal/component/artifactory_release_source.go
@@ -95,7 +95,7 @@ func (ars *ArtifactoryReleaseSource) DownloadRelease(releaseDir string, remoteRe
 	if path.Base(u.Path) != "artifactory" {
 		downloadURL += "/artifactory"
 	}
-	downloadURL += "/" + ars.Repo + "/" + remoteRelease.RemotePath
+	downloadURL += "/" + ars.Repo + "/" + strings.ReplaceAll(remoteRelease.RemotePath, "+", "%2B")
 
 	ars.logger.Printf(logLineDownload, remoteRelease.Name, remoteRelease.Version, ReleaseSourceTypeArtifactory, ars.ID)
 	resp, err := ars.getWithAuth(downloadURL)


### PR DESCRIPTION
Appends a SHA-256 content hash of .boshrelease inputs to the release version (e.g., 10.4.0+a1b2c3d4e5f6) so that different builds produce distinct versions preventing Artifactory collisions and BOSH Director upload errors

feat(carvel bake): uses the release version for the destination tarball path