### PR TITLE
Fix update-release swallowing release source errors

### DIFF
--- a/internal/commands/update_release.go
+++ b/internal/commands/update_release.go
@@ -79,10 +79,7 @@ func (u UpdateRelease) Execute(args []string) error {
 			GitHubRepository: releaseSpec.GitHubRepository,
 		}, false)
 		if err != nil {
-			if component.IsErrNotFound(err) {
-				return fmt.Errorf("error finding the release: %w", err)
-			}
-			return fmt.Errorf("couldn't find %q %s in any release source", u.Options.Name, u.Options.Version)
+			return fmt.Errorf("couldn't find %q %s in any release source: %w", u.Options.Name, u.Options.Version, err)
 		}
 
 		newVersion = remoteRelease.Version
@@ -98,10 +95,7 @@ func (u UpdateRelease) Execute(args []string) error {
 			GitHubRepository: releaseSpec.GitHubRepository,
 		})
 		if err != nil {
-			if component.IsErrNotFound(err) {
-				return fmt.Errorf("error finding the release: %w", err)
-			}
-			return fmt.Errorf("couldn't find %q %s in any release source", u.Options.Name, u.Options.Version)
+			return fmt.Errorf("couldn't find %q %s in any release source: %w", u.Options.Name, u.Options.Version, err)
 		}
 
 		localRelease, err = releaseSource.DownloadRelease(u.Options.ReleasesDir, remoteRelease)

--- a/internal/commands/update_release_test.go
+++ b/internal/commands/update_release_test.go
@@ -342,6 +342,39 @@ var _ = Describe("UpdateRelease", func() {
 			})
 		})
 
+		When("a release source returns an unexpected error (e.g. auth failure) during GetMatchedRelease", func() {
+			BeforeEach(func() {
+				releaseSource.GetMatchedReleaseReturns(cargo.BOSHReleaseTarballLock{}, errors.New("401 Unauthorized"))
+			})
+
+			It("includes the underlying error in the returned error", func() {
+				err := updateReleaseCommand.Execute([]string{
+					"--kilnfile", "Kilnfile",
+					"--name", releaseName,
+					"--version", newReleaseVersion,
+					"--releases-directory", releasesDir,
+				})
+				Expect(err).To(MatchError(ContainSubstring("401 Unauthorized")))
+			})
+		})
+
+		When("a release source returns an unexpected error (e.g. auth failure) during FindReleaseVersion", func() {
+			BeforeEach(func() {
+				releaseSource.FindReleaseVersionReturns(cargo.BOSHReleaseTarballLock{}, errors.New("401 Unauthorized"))
+			})
+
+			It("includes the underlying error in the returned error", func() {
+				err := updateReleaseCommand.Execute([]string{
+					"--kilnfile", "Kilnfile",
+					"--name", releaseName,
+					"--version", newReleaseVersion,
+					"--releases-directory", releasesDir,
+					"--without-download",
+				})
+				Expect(err).To(MatchError(ContainSubstring("401 Unauthorized")))
+			})
+		})
+
 		When("downloading the release fails", func() {
 			BeforeEach(func() {
 				releaseSource.DownloadReleaseReturns(component.Local{}, errors.New("bad stuff"))


### PR DESCRIPTION
## Summary

- When a release source returned a non-not-found error (e.g. a 401 auth failure), `update-release` discarded the underlying error and returned a generic `couldn't find "X" VERSION in any release source` message
- Both the `GetMatchedRelease` and `FindReleaseVersion` paths had this bug
- Now wraps the underlying error with `%w` so the actual failure (source ID, HTTP status, etc.) is surfaced to the user

Closes #520

## Test plan

- [x] Added two new test cases covering auth-style errors for both the download and no-download paths — both previously failed and now pass
- [x] All existing `UpdateRelease` tests continue to pass (`go test ./internal/commands/`)

Made with [Cursor](https://cursor.com)