### PR TITLE
Fix ReadRecords erroring on non-bake files in records directory

### DIFF
--- a/pkg/bake/record.go
+++ b/pkg/bake/record.go
@@ -105,6 +105,9 @@ func ReadRecords(dir fs.FS) ([]Record, error) {
 	}
 	builds := make([]Record, 0, len(infos))
 	for _, info := range infos {
+		if path.Ext(info.Name()) != ".json" {
+			continue
+		}
 		buf, err := fs.ReadFile(dir, path.Join(RecordsDirectory, info.Name()))
 		if err != nil {
 			return nil, err

--- a/pkg/bake/record_test.go
+++ b/pkg/bake/record_test.go
@@ -119,6 +119,24 @@ product_version: some-product-version
 		require.ErrorContains(t, b.WriteFile(dir), "tile bake record already exists for some-tile/some-version")
 	})
 
+	t.Run("when non-bake files like .gitkeep are present in the records directory", func(t *testing.T) {
+		dir := t.TempDir()
+
+		record := bake.Record{
+			TileName:       "p-each",
+			SourceRevision: "some-revision",
+			Version:        "1.2.3",
+		}
+		require.NoError(t, record.WriteFile(dir))
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, bake.RecordsDirectory, ".gitkeep"), []byte{}, 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, bake.RecordsDirectory, ".gitignore"), []byte("*.tmp\n"), 0o644))
+
+		result, err := bake.ReadRecords(os.DirFS(dir))
+		require.NoError(t, err)
+		require.Equal(t, []bake.Record{record}, result)
+	})
+
 	t.Run("when read builds", func(t *testing.T) {
 		dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- `bake.ReadRecords` tried to JSON-unmarshal every file in `bake_records/`, including non-bake files like `.gitkeep` and `.gitignore`
- This caused a JSON parse error and the function returned early with no records
- Now skips any file whose name does not end in `.json`

Closes #521

## Test plan

- [ ] Added a test case with both `.gitkeep` and `.gitignore` present alongside a valid record — previously failed, now passes
- [ ] All existing `bake` package tests continue to pass (`go test ./pkg/bake/`)

Made with [Cursor](https://cursor.com)