### PR TITLE
feat(carvel): emit cross-deployment consumes on runtime config addon job

### DIFF
--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -310,21 +310,21 @@ func (b *baker) readJobSpecOverlays() ([]boshLinkConsumer, error) {
 
 // boshLinkConsumer declares a BOSH link the registry-data job should consume.
 // Populated from per-packageinstall *.job-spec-overlay.yml sidecar files.
-// When RuntimeConfigFrom or RuntimeConfigDeployment is set, kiln also emits
-// a cross-deployment consumes entry for the link in the runtime config addon job.
+// When From or Deployment is set, kiln also emits a cross-deployment consumes
+// entry for the link in the runtime config addon job.
 type boshLinkConsumer struct {
-	Name                    string `yaml:"name"`
-	Type                    string `yaml:"type"`
-	Optional                bool   `yaml:"optional"`
-	RuntimeConfigFrom       string `yaml:"runtime_config_from,omitempty"`
-	RuntimeConfigDeployment string `yaml:"runtime_config_deployment,omitempty"`
+	Name       string `yaml:"name"`
+	Type       string `yaml:"type"`
+	Optional   bool   `yaml:"optional"`
+	From       string `yaml:"from,omitempty"`
+	Deployment string `yaml:"deployment,omitempty"`
 }
 
 // jobSpecOverlay is the schema for <entry>.job-spec-overlay.yml sidecar files.
 // kiln reads these from packageinstalls/ and merges the consumes entries into
 // the generated registry-data job.MF alongside the hardcoded cluster-info link.
-// Entries that set runtime_config_from or runtime_config_deployment are also
-// emitted as cross-deployment consumes on the runtime config addon job.
+// Entries that set from or deployment are also emitted as cross-deployment
+// consumes on the runtime config addon job.
 type jobSpecOverlay struct {
 	Consumes []boshLinkConsumer `yaml:"consumes"`
 }
@@ -745,10 +745,10 @@ func (b *baker) generateRuntimeConfigs() error {
 
 	consumesMap := make(map[string]models.JobConsumes)
 	for _, c := range deduped {
-		if c.RuntimeConfigFrom != "" || c.RuntimeConfigDeployment != "" {
+		if c.From != "" || c.Deployment != "" {
 			consumesMap[c.Name] = models.JobConsumes{
-				From:       c.RuntimeConfigFrom,
-				Deployment: c.RuntimeConfigDeployment,
+				From:       c.From,
+				Deployment: c.Deployment,
 			}
 		}
 	}

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -299,7 +299,7 @@ func (b *baker) readJobSpecOverlays() ([]boshLinkConsumer, error) {
 			continue
 		}
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("reading %s: %w", overlayPath, err)
 		}
 		var overlay jobSpecOverlay
 		if err := yaml.Unmarshal(data, &overlay); err != nil {
@@ -320,6 +320,15 @@ type boshLinkConsumer struct {
 	Optional   bool   `yaml:"optional"`
 	From       string `yaml:"from,omitempty"`
 	Deployment string `yaml:"deployment,omitempty"`
+}
+
+// jobMFConsumes is the subset of boshLinkConsumer fields that are valid in a
+// BOSH job.MF spec consumes list. From/Deployment are runtime-config-only and
+// must not appear in job.MF.
+type jobMFConsumes struct {
+	Name     string `yaml:"name"`
+	Type     string `yaml:"type"`
+	Optional bool   `yaml:"optional"`
 }
 
 // jobSpecOverlay is the schema for <entry>.job-spec-overlay.yml sidecar files.
@@ -467,7 +476,11 @@ files:
 	}
 	deduped := b.deduplicateConsumes(allConsumes)
 
-	registryDataSpec, err := buildRegistryDataSpec(registryDataTemplates, registryDataProperties, deduped)
+	jobMFLinks := make([]jobMFConsumes, len(deduped))
+	for i, c := range deduped {
+		jobMFLinks[i] = jobMFConsumes{Name: c.Name, Type: c.Type, Optional: c.Optional}
+	}
+	registryDataSpec, err := buildRegistryDataSpec(registryDataTemplates, registryDataProperties, jobMFLinks)
 	if err != nil {
 		return err
 	}
@@ -483,7 +496,7 @@ files:
 // buildRegistryDataSpec constructs the job.MF content for the registry-data BOSH job.
 // It always includes the hardcoded cluster-info link and appends any additional links
 // collected from *.job-spec-overlay.yml sidecars in the packageinstalls/ directory.
-func buildRegistryDataSpec(templates, properties string, additionalLinks []boshLinkConsumer) (string, error) {
+func buildRegistryDataSpec(templates, properties string, additionalLinks []jobMFConsumes) (string, error) {
 	extraLinks := ""
 	if len(additionalLinks) > 0 {
 		data, err := yaml.Marshal(additionalLinks)

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -322,10 +322,9 @@ type boshLinkConsumer struct {
 	Deployment string `yaml:"deployment,omitempty"`
 }
 
-// jobMFConsumes is the subset of boshLinkConsumer fields that are valid in a
-// BOSH job.MF spec consumes list. From/Deployment are runtime-config-only and
-// must not appear in job.MF.
-type jobMFConsumes struct {
+// boshConsumes is the BOSH job spec consumes schema: name, type, and optional only.
+// From/Deployment are runtime-config-only and must not appear in the job spec.
+type boshConsumes struct {
 	Name     string `yaml:"name"`
 	Type     string `yaml:"type"`
 	Optional bool   `yaml:"optional"`
@@ -476,11 +475,11 @@ files:
 	}
 	deduped := b.deduplicateConsumes(allConsumes)
 
-	jobMFLinks := make([]jobMFConsumes, len(deduped))
+	boshLinks := make([]boshConsumes, len(deduped))
 	for i, c := range deduped {
-		jobMFLinks[i] = jobMFConsumes{Name: c.Name, Type: c.Type, Optional: c.Optional}
+		boshLinks[i] = boshConsumes{Name: c.Name, Type: c.Type, Optional: c.Optional}
 	}
-	registryDataSpec, err := buildRegistryDataSpec(registryDataTemplates, registryDataProperties, jobMFLinks)
+	registryDataSpec, err := buildRegistryDataSpec(registryDataTemplates, registryDataProperties, boshLinks)
 	if err != nil {
 		return err
 	}
@@ -496,7 +495,7 @@ files:
 // buildRegistryDataSpec constructs the job.MF content for the registry-data BOSH job.
 // It always includes the hardcoded cluster-info link and appends any additional links
 // collected from *.job-spec-overlay.yml sidecars in the packageinstalls/ directory.
-func buildRegistryDataSpec(templates, properties string, additionalLinks []jobMFConsumes) (string, error) {
+func buildRegistryDataSpec(templates, properties string, additionalLinks []boshConsumes) (string, error) {
 	extraLinks := ""
 	if len(additionalLinks) > 0 {
 		data, err := yaml.Marshal(additionalLinks)

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -282,17 +282,49 @@ func (b *baker) deduplicateConsumes(consumes []boshLinkConsumer) []boshLinkConsu
 	return deduped
 }
 
+// readJobSpecOverlays reads all *.job-spec-overlay.yml sidecars for the tile's
+// package installs and returns the merged slice of boshLinkConsumer entries.
+func (b *baker) readJobSpecOverlays() ([]boshLinkConsumer, error) {
+	var all []boshLinkConsumer
+	for _, entry := range b.metadata.PackageInstalls {
+		entry = strings.Trim(entry, "$() ")
+		entry = strings.TrimPrefix(entry, "package")
+		entry = strings.Trim(entry, `"' `)
+
+		overlayPath := path.Join(b.source, "packageinstalls", entry+".job-spec-overlay.yml")
+		data, err := os.ReadFile(overlayPath)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		var overlay jobSpecOverlay
+		if err := yaml.Unmarshal(data, &overlay); err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", overlayPath, err)
+		}
+		all = append(all, overlay.Consumes...)
+	}
+	return all, nil
+}
+
 // boshLinkConsumer declares a BOSH link the registry-data job should consume.
 // Populated from per-packageinstall *.job-spec-overlay.yml sidecar files.
+// When RuntimeConfigFrom or RuntimeConfigDeployment is set, kiln also emits
+// a cross-deployment consumes entry for the link in the runtime config addon job.
 type boshLinkConsumer struct {
-	Name     string `yaml:"name"`
-	Type     string `yaml:"type"`
-	Optional bool   `yaml:"optional"`
+	Name                    string `yaml:"name"`
+	Type                    string `yaml:"type"`
+	Optional                bool   `yaml:"optional"`
+	RuntimeConfigFrom       string `yaml:"runtime_config_from,omitempty"`
+	RuntimeConfigDeployment string `yaml:"runtime_config_deployment,omitempty"`
 }
 
 // jobSpecOverlay is the schema for <entry>.job-spec-overlay.yml sidecar files.
 // kiln reads these from packageinstalls/ and merges the consumes entries into
 // the generated registry-data job.MF alongside the hardcoded cluster-info link.
+// Entries that set runtime_config_from or runtime_config_deployment are also
+// emitted as cross-deployment consumes on the runtime config addon job.
 type jobSpecOverlay struct {
 	Consumes []boshLinkConsumer `yaml:"consumes"`
 }
@@ -355,7 +387,6 @@ files:
 
 	registryDataTemplates := ""
 	registryDataProperties := ""
-	var allConsumes []boshLinkConsumer
 
 	b.progress("  Configuring package installs")
 	for _, entry := range b.metadata.PackageInstalls {
@@ -416,21 +447,6 @@ files:
 			overlayContent = string(overlayData)
 		}
 
-		// Read optional job-spec-overlay sidecar to discover additional BOSH link consumptions.
-		jobSpecOverlayPath := path.Join(b.source, "packageinstalls", entry+".job-spec-overlay.yml")
-		overlayData, overlayErr = os.ReadFile(jobSpecOverlayPath)
-		if overlayErr != nil {
-			if !errors.Is(overlayErr, os.ErrNotExist) {
-				return overlayErr
-			}
-		} else {
-			var overlay jobSpecOverlay
-			if parseErr := yaml.Unmarshal(overlayData, &overlay); parseErr != nil {
-				return fmt.Errorf("parsing %s: %w", jobSpecOverlayPath, parseErr)
-			}
-			allConsumes = append(allConsumes, overlay.Consumes...)
-		}
-
 		manifestTemplate := generateManifestTemplate(entry, overlayContent)
 
 		err = os.WriteFile(
@@ -443,6 +459,10 @@ files:
 		}
 	}
 
+	allConsumes, err := b.readJobSpecOverlays()
+	if err != nil {
+		return err
+	}
 	deduped := b.deduplicateConsumes(allConsumes)
 
 	registryDataSpec, err := buildRegistryDataSpec(registryDataTemplates, registryDataProperties, deduped)
@@ -717,10 +737,29 @@ func (b *baker) generateRuntimeConfigs() error {
 		}
 	}
 
+	allConsumes, err := b.readJobSpecOverlays()
+	if err != nil {
+		return err
+	}
+	deduped := b.deduplicateConsumes(allConsumes)
+
+	consumesMap := make(map[string]models.JobConsumes)
+	for _, c := range deduped {
+		if c.RuntimeConfigFrom != "" || c.RuntimeConfigDeployment != "" {
+			consumesMap[c.Name] = models.JobConsumes{
+				From:       c.RuntimeConfigFrom,
+				Deployment: c.RuntimeConfigDeployment,
+			}
+		}
+	}
+
 	registryDataJob := models.Job{
 		Name:       "registry-data",
 		Release:    b.metadata.Name,
 		Properties: registryDataProps,
+	}
+	if len(consumesMap) > 0 {
+		registryDataJob.Consumes = consumesMap
 	}
 
 	inner := models.RuntimeConfigInner{

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -257,7 +257,7 @@ func (b *baker) progress(message string) {
 
 // deduplicateConsumes removes duplicate BOSH link consumer entries by name.
 // Identical duplicates are dropped silently. If two entries share a name but
-// differ in type or optional, the first is kept and a WARNING is emitted —
+// differ in any field, the first is kept and a WARNING is emitted —
 // BOSH rejects duplicate link names in job.MF, so the second is always ignored.
 func (b *baker) deduplicateConsumes(consumes []boshLinkConsumer) []boshLinkConsumer {
 	seen := make(map[string]boshLinkConsumer)
@@ -272,10 +272,12 @@ func (b *baker) deduplicateConsumes(consumes []boshLinkConsumer) []boshLinkConsu
 		if existing != c {
 			b.progress(fmt.Sprintf(
 				"WARNING: duplicate BOSH link consumer name %q found across packageinstalls.\n"+
-					"  Keeping:  {type: %s, optional: %v}\n"+
-					"  Ignoring: {type: %s, optional: %v}\n"+
+					"  Keeping:  {type: %s, optional: %v, from: %s, deployment: %s}\n"+
+					"  Ignoring: {type: %s, optional: %v, from: %s, deployment: %s}\n"+
 					"  Ensure all packageinstalls agree on the link definition.",
-				c.Name, existing.Type, existing.Optional, c.Type, c.Optional,
+				c.Name,
+				existing.Type, existing.Optional, existing.From, existing.Deployment,
+				c.Type, c.Optional, c.From, c.Deployment,
 			))
 		}
 	}

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -280,6 +280,25 @@ consumes:
 			err := yaml.Unmarshal([]byte("consumes: [\ninvalid"), &overlay)
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("parses runtime_config_from and runtime_config_deployment fields", func() {
+			content := `
+consumes:
+- name: nats-tls
+  type: nats-tls
+  optional: false
+  runtime_config_from: nats-tls
+  runtime_config_deployment: "(( ..cf.deployment_name ))"
+`
+			var overlay jobSpecOverlay
+			err := yaml.Unmarshal([]byte(content), &overlay)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overlay.Consumes).To(HaveLen(1))
+			c := overlay.Consumes[0]
+			Expect(c.Name).To(Equal("nats-tls"))
+			Expect(c.RuntimeConfigFrom).To(Equal("nats-tls"))
+			Expect(c.RuntimeConfigDeployment).To(Equal("(( ..cf.deployment_name ))"))
+		})
 	})
 
 	Context("Bake", func() {
@@ -455,6 +474,12 @@ consumes:
 					props := addon.Jobs[0].Properties["test-install"]
 					Expect(props.Name).To(Equal("something-test.tanzu.vmware.com"))
 					Expect(props.Version).To(Equal("0.1.5"))
+
+					By("emitting cross-deployment consumes from job-spec-overlay runtime_config_from/deployment fields")
+					Expect(addon.Jobs[0].Consumes).To(HaveKey("binding_cache"))
+					bc := addon.Jobs[0].Consumes["binding_cache"]
+					Expect(bc.From).To(Equal("binding_cache"))
+					Expect(bc.Deployment).To(Equal("(( ..cf.deployment_name ))"))
 				})
 				It("can be kiln baked", func() {
 					if !kilnInstalled() {

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -281,14 +281,14 @@ consumes:
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("parses runtime_config_from and runtime_config_deployment fields", func() {
+		It("parses from and deployment fields for cross-deployment link resolution", func() {
 			content := `
 consumes:
 - name: nats-tls
   type: nats-tls
   optional: false
-  runtime_config_from: nats-tls
-  runtime_config_deployment: "(( ..cf.deployment_name ))"
+  from: nats-tls
+  deployment: "(( ..cf.deployment_name ))"
 `
 			var overlay jobSpecOverlay
 			err := yaml.Unmarshal([]byte(content), &overlay)
@@ -296,8 +296,8 @@ consumes:
 			Expect(overlay.Consumes).To(HaveLen(1))
 			c := overlay.Consumes[0]
 			Expect(c.Name).To(Equal("nats-tls"))
-			Expect(c.RuntimeConfigFrom).To(Equal("nats-tls"))
-			Expect(c.RuntimeConfigDeployment).To(Equal("(( ..cf.deployment_name ))"))
+			Expect(c.From).To(Equal("nats-tls"))
+			Expect(c.Deployment).To(Equal("(( ..cf.deployment_name ))"))
 		})
 	})
 
@@ -475,7 +475,7 @@ consumes:
 					Expect(props.Name).To(Equal("something-test.tanzu.vmware.com"))
 					Expect(props.Version).To(Equal("0.1.5"))
 
-					By("emitting cross-deployment consumes from job-spec-overlay runtime_config_from/deployment fields")
+					By("emitting cross-deployment consumes from job-spec-overlay from/deployment fields")
 					Expect(addon.Jobs[0].Consumes).To(HaveKey("binding_cache"))
 					bc := addon.Jobs[0].Consumes["binding_cache"]
 					Expect(bc.From).To(Equal("binding_cache"))

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -281,6 +281,36 @@ consumes:
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("emits a consumes entry when only from is set (no deployment)", func() {
+			content := `
+consumes:
+- name: nats-tls
+  type: nats-tls
+  optional: false
+  from: nats-tls
+`
+			var overlay jobSpecOverlay
+			err := yaml.Unmarshal([]byte(content), &overlay)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overlay.Consumes[0].From).To(Equal("nats-tls"))
+			Expect(overlay.Consumes[0].Deployment).To(BeEmpty())
+		})
+
+		It("emits a consumes entry when only deployment is set (no from)", func() {
+			content := `
+consumes:
+- name: nats-tls
+  type: nats-tls
+  optional: false
+  deployment: "(( ..cf.deployment_name ))"
+`
+			var overlay jobSpecOverlay
+			err := yaml.Unmarshal([]byte(content), &overlay)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overlay.Consumes[0].From).To(BeEmpty())
+			Expect(overlay.Consumes[0].Deployment).To(Equal("(( ..cf.deployment_name ))"))
+		})
+
 		It("parses from and deployment fields for cross-deployment link resolution", func() {
 			content := `
 consumes:

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Carvel Baker", func() {
 
 	Context("buildRegistryDataSpec", func() {
 		It("includes user-declared additional links after cluster-info", func() {
-			links := []jobMFConsumes{
+			links := []boshConsumes{
 				{Name: "binding_cache", Type: "binding_cache", Optional: false},
 			}
 			spec, err := buildRegistryDataSpec("", "", links)
@@ -136,7 +136,7 @@ var _ = Describe("Carvel Baker", func() {
 		})
 
 		It("marks optional links correctly", func() {
-			links := []jobMFConsumes{
+			links := []boshConsumes{
 				{Name: "optional-link", Type: "some-type", Optional: true},
 			}
 			spec, err := buildRegistryDataSpec("", "", links)
@@ -154,7 +154,7 @@ var _ = Describe("Carvel Baker", func() {
 		It("safely encodes link names containing YAML-special characters", func() {
 			// yaml.Marshal quotes/blocks the value so it cannot inject extra YAML keys.
 			// The real type field ("legit-type") must still appear at the correct level.
-			links := []jobMFConsumes{
+			links := []boshConsumes{
 				{Name: "name: injected\ntype: evil", Type: "legit-type", Optional: false},
 			}
 			spec, err := buildRegistryDataSpec("", "", links)
@@ -163,7 +163,7 @@ var _ = Describe("Carvel Baker", func() {
 		})
 
 		It("emits each unique link name only once given pre-deduplicated input", func() {
-			links := []jobMFConsumes{
+			links := []boshConsumes{
 				{Name: "binding_cache", Type: "binding_cache", Optional: false},
 			}
 			spec, err := buildRegistryDataSpec("", "", links)

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Carvel Baker", func() {
 
 	Context("buildRegistryDataSpec", func() {
 		It("includes user-declared additional links after cluster-info", func() {
-			links := []boshLinkConsumer{
+			links := []jobMFConsumes{
 				{Name: "binding_cache", Type: "binding_cache", Optional: false},
 			}
 			spec, err := buildRegistryDataSpec("", "", links)
@@ -136,7 +136,7 @@ var _ = Describe("Carvel Baker", func() {
 		})
 
 		It("marks optional links correctly", func() {
-			links := []boshLinkConsumer{
+			links := []jobMFConsumes{
 				{Name: "optional-link", Type: "some-type", Optional: true},
 			}
 			spec, err := buildRegistryDataSpec("", "", links)
@@ -154,7 +154,7 @@ var _ = Describe("Carvel Baker", func() {
 		It("safely encodes link names containing YAML-special characters", func() {
 			// yaml.Marshal quotes/blocks the value so it cannot inject extra YAML keys.
 			// The real type field ("legit-type") must still appear at the correct level.
-			links := []boshLinkConsumer{
+			links := []jobMFConsumes{
 				{Name: "name: injected\ntype: evil", Type: "legit-type", Optional: false},
 			}
 			spec, err := buildRegistryDataSpec("", "", links)
@@ -163,7 +163,7 @@ var _ = Describe("Carvel Baker", func() {
 		})
 
 		It("emits each unique link name only once given pre-deduplicated input", func() {
-			links := []boshLinkConsumer{
+			links := []jobMFConsumes{
 				{Name: "binding_cache", Type: "binding_cache", Optional: false},
 			}
 			spec, err := buildRegistryDataSpec("", "", links)
@@ -281,7 +281,7 @@ consumes:
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("emits a consumes entry when only from is set (no deployment)", func() {
+		It("parses an entry with only from set (no deployment)", func() {
 			content := `
 consumes:
 - name: nats-tls
@@ -296,7 +296,7 @@ consumes:
 			Expect(overlay.Consumes[0].Deployment).To(BeEmpty())
 		})
 
-		It("emits a consumes entry when only deployment is set (no from)", func() {
+		It("parses an entry with only deployment set (no from)", func() {
 			content := `
 consumes:
 - name: nats-tls

--- a/internal/carvel/models/job.go
+++ b/internal/carvel/models/job.go
@@ -3,5 +3,14 @@ package models
 type Job struct {
 	Name       string                         `yaml:"name"`
 	Release    string                         `yaml:"release"`
+	Consumes   map[string]JobConsumes         `yaml:"consumes,omitempty"`
 	Properties map[string]PackageInstallProps `yaml:"properties,omitempty"`
+}
+
+// JobConsumes declares cross-deployment link resolution for a runtime config addon job.
+// When a job-spec-overlay declares runtime_config_from or runtime_config_deployment,
+// kiln includes this entry in the addon job's consumes map in the generated metadata.
+type JobConsumes struct {
+	From       string `yaml:"from,omitempty"`
+	Deployment string `yaml:"deployment,omitempty"`
 }

--- a/internal/carvel/models/job.go
+++ b/internal/carvel/models/job.go
@@ -8,8 +8,8 @@ type Job struct {
 }
 
 // JobConsumes declares cross-deployment link resolution for a runtime config addon job.
-// When a job-spec-overlay declares runtime_config_from or runtime_config_deployment,
-// kiln includes this entry in the addon job's consumes map in the generated metadata.
+// When a job-spec-overlay entry sets from or deployment, kiln includes it in the
+// addon job's consumes map in the generated metadata.
 type JobConsumes struct {
 	From       string `yaml:"from,omitempty"`
 	Deployment string `yaml:"deployment,omitempty"`

--- a/internal/carvel/testdata/sample-tile/packageinstalls/test-install.job-spec-overlay.yml
+++ b/internal/carvel/testdata/sample-tile/packageinstalls/test-install.job-spec-overlay.yml
@@ -2,5 +2,5 @@ consumes:
 - name: binding_cache
   type: binding_cache
   optional: false
-  runtime_config_from: binding_cache
-  runtime_config_deployment: "(( ..cf.deployment_name ))"
+  from: binding_cache
+  deployment: "(( ..cf.deployment_name ))"

--- a/internal/carvel/testdata/sample-tile/packageinstalls/test-install.job-spec-overlay.yml
+++ b/internal/carvel/testdata/sample-tile/packageinstalls/test-install.job-spec-overlay.yml
@@ -2,3 +2,5 @@ consumes:
 - name: binding_cache
   type: binding_cache
   optional: false
+  runtime_config_from: binding_cache
+  runtime_config_deployment: "(( ..cf.deployment_name ))"


### PR DESCRIPTION
## Summary

- Extends the \`job-spec-overlay\` sidecar format with two optional fields: \`from\` and \`deployment\`
- When set on a \`boshLinkConsumer\` entry, \`generateRuntimeConfigs()\` now includes the link in the \`registry-data\` addon job's \`consumes:\` map using the BOSH cross-deployment link resolution schema
- Extracts a \`readJobSpecOverlays()\` helper so overlay-reading is shared between \`generateBoshReleaseDir()\` and \`generateRuntimeConfigs()\` rather than duplicated

## Motivation

Tile authors currently have to post-process the built \`.pivotal\` to inject a \`consumes:\` block into the runtime config addon job after \`kiln carvel bake\`. This change makes it possible to declare cross-deployment link resolution natively in the sidecar files, eliminating the need for that patch step.

## Example overlay

```yaml
consumes:
- name: nats-tls
  type: nats-tls
  optional: false
  from: nats-tls
  deployment: "(( ..cf.deployment_name ))"
- name: binding_cache
  type: binding_cache
  optional: true
  from: binding_cache
  deployment: "(( ..cf.deployment_name ))"
```

Generated runtime config addon job will include:

```yaml
consumes:
  nats-tls:
    from: nats-tls
    deployment: (( ..cf.deployment_name ))
  binding_cache:
    from: binding_cache
    deployment: (( ..cf.deployment_name ))
```

## Test plan

- [ ] \`go test ./internal/carvel/...\` passes (unit + integration tests)
- [ ] New unit tests: \`jobSpecOverlay\` parses \`from\`/\`deployment\` fields correctly, including partial presence (only \`from\` set, only \`deployment\` set)
- [ ] Updated integration test: \`addon.Jobs[0].Consumes["binding_cache"]\` has expected \`From\`/\`Deployment\` values in the generated runtime config
- [ ] Entries without \`from\`/\`deployment\` are unaffected (no \`consumes:\` key emitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)