### PR TITLE
Add support for uses_kubernetes_features metadata

### DIFF
--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -661,6 +661,7 @@ func (b *baker) generateBaseYaml() error {
 	meta.CompatibleKubernetesDistributions = b.metadata.CompatibleKubernetesDistributions
 	meta.SupportsParallelDeploys = b.metadata.SupportsParallelDeploys
 	meta.RequiresProductVersions = b.metadata.RequiresProductVersions
+	meta.UsesKubernetesFeatures = b.metadata.UsesKubernetesFeatures
 	meta.FormTypes = b.metadata.FormTypes
 	meta.PropertyBlueprints = b.metadata.PropertyBlueprints
 	meta.Variables = b.metadata.Variables

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -418,6 +418,11 @@ consumes:
 					Expect(outMeta.RequiresProductVersions[0].Name).To(Equal("some-other-product"))
 					Expect(outMeta.RequiresProductVersions[0].Version).To(Equal(">=1.0.0"))
 					Expect(outMeta.RequiresProductVersions[0].Optional).To(BeTrue())
+					Expect(outMeta.UsesKubernetesFeatures).To(HaveLen(2))
+					Expect(outMeta.UsesKubernetesFeatures[0].Name).To(Equal("gpu-scheduling"))
+					Expect(outMeta.UsesKubernetesFeatures[0].Optional).To(BeFalse())
+					Expect(outMeta.UsesKubernetesFeatures[1].Name).To(Equal("node-local-storage"))
+					Expect(outMeta.UsesKubernetesFeatures[1].Optional).To(BeTrue())
 				})
 				It("creates empty instance_group and jobs directories", func() {
 					Expect(filepath.Join(outputPath, "instance_groups")).To(BeADirectory())
@@ -598,6 +603,51 @@ consumes:
 					Expect(err).NotTo(HaveOccurred())
 					Expect(outMeta.SupportsParallelDeploys).To(BeFalse())
 					Expect(outMeta.RequiresProductVersions).To(BeEmpty())
+				})
+			})
+			When("the tile declares no kubernetes features", func() {
+				// Ops Manager rejects uses_kubernetes_features on a tile that is not a
+				// kubernetes consumer, so an absent block must stay absent rather than
+				// baking out as an empty list.
+				BeforeEach(func() {
+					m := models.Metadata{
+						Name:                     "k8s-tile-test",
+						Label:                    "test tile",
+						IconImage:                "$( icon )",
+						MetadataVersion:          "3.2.0",
+						MinimumVersionForUpgrade: "0.0.0",
+						ProductVersion:           "$( version )",
+						Rank:                     1,
+						Serial:                   false,
+						PropertyBlueprints: []string{
+							`$( property "database_name" )`,
+							`$( property "admin_password" )`,
+						},
+						FormTypes:                         []string{`$( form "db_props" )`},
+						Variables:                         []proofing.Variable{},
+						PackageInstalls:                   []string{`$( package "test-install" )`},
+						CompatibleKubernetesDistributions: []models.ProductVersion{{Name: "k0s", Version: ">0.0.0"}},
+					}
+					yamlData, err := yaml.Marshal(&m)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(yamlData)).NotTo(ContainSubstring("uses_kubernetes_features"))
+					err = os.WriteFile(path.Join(inputPath, "base.yml"), yamlData, 0644)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("omits uses_kubernetes_features from the baked metadata", func() {
+					Expect(err).NotTo(HaveOccurred())
+
+					yamlData, readErr := os.ReadFile(path.Join(outputPath, "base.yml"))
+					Expect(readErr).NotTo(HaveOccurred())
+					Expect(string(yamlData)).NotTo(ContainSubstring("uses_kubernetes_features"))
+
+					outMeta := models.MetadataOut{}
+					Expect(yaml.Unmarshal(yamlData, &outMeta)).To(Succeed())
+					Expect(outMeta.UsesKubernetesFeatures).To(BeEmpty())
+					// the rest of the kubernetes metadata is unaffected
+					Expect(outMeta.RequiresKubernetes).To(BeTrue())
+					Expect(outMeta.CompatibleKubernetesDistributions).To(HaveLen(1))
 				})
 			})
 		})

--- a/internal/carvel/models/metadata.go
+++ b/internal/carvel/models/metadata.go
@@ -18,4 +18,5 @@ type Metadata struct {
 	CompatibleKubernetesDistributions []ProductVersion         `yaml:"compatible_kubernetes_distributions,omitempty"`
 	SupportsParallelDeploys           bool                     `yaml:"supports_parallel_deploys,omitempty"`
 	RequiresProductVersions           []RequiredProductVersion `yaml:"requires_product_versions,omitempty"`
+	UsesKubernetesFeatures            []KubernetesFeature      `yaml:"uses_kubernetes_features,omitempty"`
 }

--- a/internal/carvel/models/metadata_out.go
+++ b/internal/carvel/models/metadata_out.go
@@ -22,6 +22,7 @@ type MetadataOut struct {
 	CompatibleKubernetesDistributions []ProductVersion         `yaml:"compatible_kubernetes_distributions"`
 	SupportsParallelDeploys           bool                     `yaml:"supports_parallel_deploys,omitempty"`
 	RequiresProductVersions           []RequiredProductVersion `yaml:"requires_product_versions,omitempty"`
+	UsesKubernetesFeatures            []KubernetesFeature      `yaml:"uses_kubernetes_features,omitempty"`
 }
 
 type StemcellCriteria struct {
@@ -37,5 +38,10 @@ type ProductVersion struct {
 type RequiredProductVersion struct {
 	Name     string `yaml:"name"`
 	Version  string `yaml:"version"`
+	Optional bool   `yaml:"optional,omitempty"`
+}
+
+type KubernetesFeature struct {
+	Name     string `yaml:"name"`
 	Optional bool   `yaml:"optional,omitempty"`
 }

--- a/internal/carvel/testdata/sample-tile/base.yml
+++ b/internal/carvel/testdata/sample-tile/base.yml
@@ -28,3 +28,7 @@ requires_product_versions:
 - name: some-other-product
   version: '>=1.0.0'
   optional: true
+uses_kubernetes_features:
+- name: gpu-scheduling
+- name: node-local-storage
+  optional: true


### PR DESCRIPTION
uses_kubernetes_features is a new tile attribute that allows K8s consumer tiles to restrict which K8s distribution tiles can be assigned to it by matching those features against the distribution's features. This commit updates `kiln carvel bake` to pass through the new attribute.

ai-assisted=yes
[TNZ-120804] Define available_kubernetes_features / uses_kubernetes_features tile metadata schema