### PR TITLE
[Draft] Enhance Kiln to be able to run pre-install and post-install hooks for carvel tiles

### DIFF
--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -592,6 +592,14 @@ func (b *baker) generateOutputTile() error {
 		return err
 	}
 
+	if len(b.metadata.AdditionalReleases) > 0 {
+		b.progress("  Copying additional BOSH releases")
+		err = b.copyAdditionalReleases()
+		if err != nil {
+			return err
+		}
+	}
+
 	b.progress("  Creating BOSH release tarball (this may take a while)...")
 	err = b.createBoshRelease()
 	if err != nil {
@@ -675,7 +683,7 @@ func (b *baker) generateRuntimeConfigs() error {
 		return err
 	}
 
-	registryDataProps := map[string]models.PackageInstallProps{}
+	registryDataProps := map[string]interface{}{}
 
 	// we need one PackageInstall for each entry in the metadata.
 	for _, entry := range b.metadata.PackageInstalls {
@@ -723,10 +731,24 @@ func (b *baker) generateRuntimeConfigs() error {
 		Properties: registryDataProps,
 	}
 
+	// Base release list and addon jobs — always includes the tile's own release
+	// and registry-data job.
+	releases := []string{`$( release "` + b.metadata.Name + `" )`}
+	addonJobs := []models.Job{registryDataJob}
+
+	// Append any additional releases and their jobs declared in base.yml.
+	for _, ar := range b.metadata.AdditionalReleases {
+		releases = append(releases, `$( release "`+ar.Name+`" )`)
+		for _, jobName := range ar.Jobs {
+			addonJobs = append(addonJobs, models.Job{
+				Name:    jobName,
+				Release: ar.Name,
+			})
+		}
+	}
+
 	inner := models.RuntimeConfigInner{
-		Releases: []string{
-			`$( release "` + b.metadata.Name + `" )`,
-		},
+		Releases: releases,
 		Addons: []models.Addon{
 			{
 				Name: b.metadata.Name + "-pkgr",
@@ -739,9 +761,7 @@ func (b *baker) generateRuntimeConfigs() error {
 						{Name: "install-packages", Release: "tanzu-content"},
 					},
 				},
-				Jobs: []models.Job{
-					registryDataJob,
-				},
+				Jobs: addonJobs,
 			},
 		},
 	}
@@ -783,6 +803,26 @@ func (b *baker) generateJobFiles() error {
 		return err
 	}
 
+	return nil
+}
+
+// copyAdditionalReleases copies each locally-built BOSH release tarball
+// declared in base.yml's additional_releases: into .carvel-tile/releases/.
+// The tile's own build.sh must produce the tarballs before kiln carvel bake
+// is invoked — kiln does not build or fetch them.
+func (b *baker) copyAdditionalReleases() error {
+	releasesDir := path.Join(b.destination, "releases")
+	if err := os.MkdirAll(releasesDir, 0755); err != nil {
+		return err
+	}
+	for _, ar := range b.metadata.AdditionalReleases {
+		src := path.Join(b.source, ar.TarballPath)
+		dst := path.Join(releasesDir, ar.Name+"-"+ar.Version+".tgz")
+		b.progress(fmt.Sprintf("    %s-%s.tgz ← %s", ar.Name, ar.Version, ar.TarballPath))
+		if err := copyFileContents(src, dst); err != nil {
+			return fmt.Errorf("copying additional release %q from %q: %w", ar.Name, src, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -747,10 +747,11 @@ func (b *baker) generateRuntimeConfigs() error {
 	// Append any additional releases and their jobs declared in base.yml.
 	for _, ar := range b.metadata.AdditionalReleases {
 		releases = append(releases, `$( release "`+ar.Name+`" )`)
-		for _, jobName := range ar.Jobs {
+		for _, job := range ar.Jobs {
 			addonJobs = append(addonJobs, models.Job{
-				Name:    jobName,
-				Release: ar.Name,
+				Name:       job.Name,
+				Release:    ar.Name,
+				Properties: job.Properties,
 			})
 		}
 	}

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -455,6 +455,68 @@ files:
 		return err
 	}
 
+	// Synthesize one adapter job per declared pre/post-install hook, into the
+	// same .boshrelease directory as registry-data. createBoshRelease (called
+	// later) auto-discovers every job directory under .boshrelease/jobs/ via
+	// `bosh create-release`, so no further wiring is needed there.
+	type hookModeGroup struct {
+		mode  string
+		hooks []models.HookDeclaration
+	}
+	prefix := b.metadata.Name + "-"
+	for _, group := range []hookModeGroup{
+		{mode: "pre-install", hooks: b.metadata.PreInstallHooks},
+		{mode: "post-install", hooks: b.metadata.PostInstallHooks},
+	} {
+		for _, hook := range group.hooks {
+			if hook.Name == "" || hook.Command == "" {
+				return fmt.Errorf("%s hook declaration missing name or command", group.mode)
+			}
+
+			jobName := hook.Name
+			if !strings.HasPrefix(jobName, prefix) {
+				jobName = prefix + jobName
+			}
+
+			genCmd := exec.Command("bosh", "generate-job", "--dir="+dirName, jobName)
+			b.log("executing " + genCmd.String())
+			out, err := genCmd.CombinedOutput()
+			b.log("output: " + string(out))
+			if err != nil {
+				return err
+			}
+
+			templateName := "hooks-" + group.mode + ".erb"
+			jobSpec := fmt.Sprintf(`---
+name: %s
+templates:
+  %s: bin/hooks/%s
+packages: []
+properties: {}
+`, jobName, templateName, group.mode)
+			if err = os.WriteFile(path.Join(dirName, "jobs", jobName, "spec"), []byte(jobSpec), 0644); err != nil {
+				return err
+			}
+
+			if err = os.MkdirAll(path.Join(dirName, "jobs", jobName, "templates"), 0755); err != nil {
+				return err
+			}
+			templateContent := fmt.Sprintf("#!/bin/bash\nset -euo pipefail\nexec %s\n", hook.Command)
+			err = os.WriteFile(
+				path.Join(dirName, "jobs", jobName, "templates", templateName),
+				[]byte(templateContent),
+				0644,
+			)
+			if err != nil {
+				return err
+			}
+			// monit: deliberately left as bosh generate-job's own default
+			// output — registry-data's own generation doesn't overwrite it
+			// either, so this follows the same established precedent rather
+			// than introducing a special case.
+		}
+	}
+
 	return nil
 }
 
@@ -743,6 +805,20 @@ func (b *baker) generateRuntimeConfigs() error {
 	// and registry-data job.
 	releases := []string{`$( release "` + b.metadata.Name + `" )`}
 	addonJobs := []models.Job{registryDataJob}
+
+	// Append synthesized pre/post-install hook adapter jobs — same release as
+	// registry-data, same auto-prefixed naming as generateBoshReleaseDir uses.
+	prefix := b.metadata.Name + "-"
+	for _, hook := range append(
+		append([]models.HookDeclaration{}, b.metadata.PreInstallHooks...),
+		b.metadata.PostInstallHooks...,
+	) {
+		jobName := hook.Name
+		if !strings.HasPrefix(jobName, prefix) {
+			jobName = prefix + jobName
+		}
+		addonJobs = append(addonJobs, models.Job{Name: jobName, Release: b.metadata.Name})
+	}
 
 	// Append any additional releases and their jobs declared in base.yml.
 	for _, ar := range b.metadata.AdditionalReleases {

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -633,9 +633,17 @@ func (b *baker) generateBaseYaml() error {
 		`$( runtime_config "` + b.metadata.Name + `-pkgr" )`,
 	}
 
-	// we will use the tile name and version as the bosh release name and version.
+	// The tile's own BOSH release plus any additional releases declared in
+	// additional_releases must all appear in the top-level releases: list so
+	// that OpsManager uploads them all to BOSH during "Upload runtime config
+	// releases" (OM calls release_file_path on each release referenced in the
+	// runtime config and returns nil for any release not in this list, causing
+	// "undefined method 'file' for nil").
 	meta.Releases = []string{
 		`$( release "` + b.metadata.Name + `" )`,
+	}
+	for _, ar := range b.metadata.AdditionalReleases {
+		meta.Releases = append(meta.Releases, `$( release "`+ar.Name+`" )`)
 	}
 
 	yamlData, err := yaml.Marshal(&meta)

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -490,14 +490,14 @@ consumes:
 					Expect(err).NotTo(HaveOccurred())
 					var m models.Metadata
 					Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
-					m.AdditionalReleases = []models.AdditionalRelease{
-						{
-							Name:        extraReleaseName,
-							Version:     extraReleaseVersion,
-							TarballPath: "scripts-release/scripts-release-dev.tgz",
-							Jobs:        []string{extraJobName},
-						},
-					}
+				m.AdditionalReleases = []models.AdditionalRelease{
+					{
+						Name:        extraReleaseName,
+						Version:     extraReleaseVersion,
+						TarballPath: "scripts-release/scripts-release-dev.tgz",
+						Jobs:        []models.AdditionalJob{{Name: extraJobName}},
+					},
+				}
 					updated, err := yaml.Marshal(&m)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
@@ -537,13 +537,86 @@ consumes:
 					addon := inner.Addons[0]
 					Expect(addon.Jobs).To(HaveLen(2))
 					extraJob := addon.Jobs[1]
-					Expect(extraJob.Name).To(Equal(extraJobName))
-					Expect(extraJob.Release).To(Equal(extraReleaseName))
-					Expect(extraJob.Properties).To(BeEmpty())
-				})
+				Expect(extraJob.Name).To(Equal(extraJobName))
+				Expect(extraJob.Release).To(Equal(extraReleaseName))
+				Expect(extraJob.Properties).To(BeEmpty())
 			})
 		})
-		When("the tile metadata version is too old", func() {
+
+		When("an additional_release job carries a properties block", func() {
+			const (
+				extraReleaseName    = "smoke-tests"
+				extraReleaseVersion = "dev"
+			)
+
+			BeforeEach(func() {
+				tarballDir := filepath.Join(inputPath, "smoke-tests-release")
+				Expect(os.MkdirAll(tarballDir, 0755)).To(Succeed())
+				stubTarball := filepath.Join(tarballDir, "smoke-tests-release-dev.tgz")
+				Expect(os.WriteFile(stubTarball, []byte("stub smoke-tests tarball"), 0644)).To(Succeed())
+
+				baseYMLPath := filepath.Join(inputPath, "base.yml")
+				raw, err := os.ReadFile(baseYMLPath)
+				Expect(err).NotTo(HaveOccurred())
+				var m models.Metadata
+				Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+				m.AdditionalReleases = []models.AdditionalRelease{
+					{
+						Name:        extraReleaseName,
+						Version:     extraReleaseVersion,
+						TarballPath: "smoke-tests-release/smoke-tests-release-dev.tgz",
+						Jobs: []models.AdditionalJob{
+							{Name: "dummy-smoke-tests"},
+							{
+								Name: "smoke_tests",
+								Properties: map[string]interface{}{
+									"bpm": map[string]interface{}{"enabled": false},
+									"smoke_tests": map[string]interface{}{
+										"api": "(( .properties.smoke_tests_api.value ))",
+									},
+								},
+							},
+						},
+					},
+				}
+				updated, err := yaml.Marshal(&m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+			})
+
+			It("marshals per-job properties through to the generated runtime-config", func() {
+				rcPath := filepath.Join(outputPath, "runtime_configs", "k8s-tile-test-pkgr.yml")
+				rcData, err := os.ReadFile(rcPath)
+				Expect(err).NotTo(HaveOccurred())
+				var rc models.RuntimeConfigOuter
+				Expect(yaml.Unmarshal(rcData, &rc)).To(Succeed())
+				var inner models.RuntimeConfigInner
+				Expect(yaml.Unmarshal([]byte(rc.RuntimeConfig), &inner)).To(Succeed())
+
+				addon := inner.Addons[0]
+				// addon.Jobs[0] = registry-data (always first), [1] = dummy-smoke-tests, [2] = smoke_tests
+				Expect(addon.Jobs).To(HaveLen(3))
+
+				By("keeping the no-properties job empty")
+				dummyJob := addon.Jobs[1]
+				Expect(dummyJob.Name).To(Equal("dummy-smoke-tests"))
+				Expect(dummyJob.Release).To(Equal(extraReleaseName))
+				Expect(dummyJob.Properties).To(BeEmpty())
+
+				By("round-tripping the nested properties block intact")
+				smokeJob := addon.Jobs[2]
+				Expect(smokeJob.Name).To(Equal("smoke_tests"))
+				Expect(smokeJob.Release).To(Equal(extraReleaseName))
+				smokeProps, ok := smokeJob.Properties["smoke_tests"].(map[string]interface{})
+				Expect(ok).To(BeTrue(), "smoke_tests key should be a nested map")
+				Expect(smokeProps["api"]).To(Equal("(( .properties.smoke_tests_api.value ))"))
+				bpmProps, ok := smokeJob.Properties["bpm"].(map[string]interface{})
+				Expect(ok).To(BeTrue(), "bpm key should be a nested map")
+				Expect(bpmProps["enabled"]).To(BeFalse())
+			})
+		})
+	})
+	When("the tile metadata version is too old", func() {
 				BeforeEach(func() {
 					m := models.Metadata{
 						Name:                     "k8s-tile-test",

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -615,7 +615,87 @@ consumes:
 				Expect(bpmProps["enabled"]).To(BeFalse())
 			})
 		})
+
+		When("the tile base.yml declares post_install_hooks", func() {
+			BeforeEach(func() {
+				baseYMLPath := filepath.Join(inputPath, "base.yml")
+				raw, err := os.ReadFile(baseYMLPath)
+				Expect(err).NotTo(HaveOccurred())
+				var m models.Metadata
+				Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+				m.PostInstallHooks = []models.HookDeclaration{
+					{
+						Name:    "smoke-tests-post-install-hook",
+						Command: "/var/vcap/jobs/smoke_tests/bin/run",
+					},
+				}
+				updated, err := yaml.Marshal(&m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+			})
+
+			It("synthesizes the hook adapter job into the auto-generated release", func() {
+				// The release tarball should contain the synthesized job.
+				releaseVersion := subject.GetReleaseVersion()
+				tarballPath := filepath.Join(outputPath, "releases", "k8s-tile-test-"+releaseVersion+".tgz")
+				Expect(tarballPath).To(BeAnExistingFile())
+
+				// We can check the generated .boshrelease directory.
+				jobDir := filepath.Join(boshReleasePath, "jobs", "k8s-tile-test-smoke-tests-post-install-hook")
+				Expect(jobDir).To(BeADirectory())
+
+				specPath := filepath.Join(jobDir, "spec")
+				Expect(specPath).To(BeAnExistingFile())
+				specData, err := os.ReadFile(specPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(specData)).To(ContainSubstring("name: k8s-tile-test-smoke-tests-post-install-hook"))
+				Expect(string(specData)).To(ContainSubstring("hooks-post-install.erb: bin/hooks/post-install"))
+
+				templatePath := filepath.Join(jobDir, "templates", "hooks-post-install.erb")
+				Expect(templatePath).To(BeAnExistingFile())
+				templateData, err := os.ReadFile(templatePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(templateData)).To(ContainSubstring("exec /var/vcap/jobs/smoke_tests/bin/run"))
+			})
+
+			It("extends the runtime-config addon with the synthesized job", func() {
+				rcPath := filepath.Join(outputPath, "runtime_configs", "k8s-tile-test-pkgr.yml")
+				rcData, err := os.ReadFile(rcPath)
+				Expect(err).NotTo(HaveOccurred())
+				var rc models.RuntimeConfigOuter
+				Expect(yaml.Unmarshal(rcData, &rc)).To(Succeed())
+				var inner models.RuntimeConfigInner
+				Expect(yaml.Unmarshal([]byte(rc.RuntimeConfig), &inner)).To(Succeed())
+
+				addon := inner.Addons[0]
+				Expect(addon.Jobs).To(HaveLen(2))
+				hookJob := addon.Jobs[1]
+				Expect(hookJob.Name).To(Equal("k8s-tile-test-smoke-tests-post-install-hook"))
+				Expect(hookJob.Release).To(Equal("k8s-tile-test"))
+			})
+		})
 	})
+
+	When("a hook declaration is missing name or command", func() {
+		BeforeEach(func() {
+			baseYMLPath := filepath.Join(inputPath, "base.yml")
+			raw, err := os.ReadFile(baseYMLPath)
+			Expect(err).NotTo(HaveOccurred())
+			var m models.Metadata
+			Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+			m.PostInstallHooks = []models.HookDeclaration{
+				{Name: "missing-command"},
+			}
+			updated, err := yaml.Marshal(&m)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+		})
+
+		It("returns a clear error", func() {
+			Expect(err).To(MatchError(ContainSubstring("post-install hook declaration missing name or command")))
+		})
+	})
+
 	When("the tile metadata version is too old", func() {
 				BeforeEach(func() {
 					m := models.Metadata{

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -450,22 +450,90 @@ consumes:
 					Expect(addon.Jobs[0].Name).To(Equal("registry-data"))
 					Expect(addon.Jobs[0].Release).To(Equal("k8s-tile-test"))
 
-					By("carrying package install properties on the registry-data job")
-					Expect(addon.Jobs[0].Properties).To(HaveKey("test-install"))
-					props := addon.Jobs[0].Properties["test-install"]
-					Expect(props.Name).To(Equal("something-test.tanzu.vmware.com"))
-					Expect(props.Version).To(Equal("0.1.5"))
+				By("carrying package install properties on the registry-data job")
+				Expect(addon.Jobs[0].Properties).To(HaveKey("test-install"))
+				// Properties is map[string]interface{} — YAML unmarshal produces a
+				// nested map[string]interface{} for the PackageInstallProps value.
+				propsRaw := addon.Jobs[0].Properties["test-install"]
+				propsMap, ok := propsRaw.(map[string]interface{})
+				Expect(ok).To(BeTrue(), "expected PackageInstallProps to unmarshal as map[string]interface{}")
+				Expect(propsMap).To(HaveKeyWithValue("name", "something-test.tanzu.vmware.com"))
+				Expect(propsMap).To(HaveKeyWithValue("version", "0.1.5"))
 				})
-				It("can be kiln baked", func() {
-					if !kilnInstalled() {
-						Skip("kiln CLI not installed - skipping integration test")
-					}
-					err := subject.KilnBake(filepath.Join(outputPath, "my-tile.pivotal"))
+			It("can be kiln baked", func() {
+				if !kilnInstalled() {
+					Skip("kiln CLI not installed - skipping integration test")
+				}
+				err := subject.KilnBake(filepath.Join(outputPath, "my-tile.pivotal"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(filepath.Join(outputPath, "my-tile.pivotal")).To(BeAnExistingFile())
+			})
+
+			When("the tile base.yml declares additional_releases", func() {
+				const (
+					extraReleaseName    = "smoke-test-scripts"
+					extraReleaseVersion = "dev"
+					extraJobName        = "smoke-test-scripts"
+				)
+
+				BeforeEach(func() {
+					// Place a stub tarball — copyAdditionalReleases copies bytes
+					// verbatim, so a valid BOSH tgz is not required here.
+					tarballDir := filepath.Join(inputPath, "scripts-release")
+					Expect(os.MkdirAll(tarballDir, 0755)).To(Succeed())
+					stubTarball := filepath.Join(tarballDir, "scripts-release-dev.tgz")
+					Expect(os.WriteFile(stubTarball, []byte("stub bosh release tarball"), 0644)).To(Succeed())
+
+					// Reload the sample-tile base.yml and append additional_releases.
+					baseYMLPath := filepath.Join(inputPath, "base.yml")
+					raw, err := os.ReadFile(baseYMLPath)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(filepath.Join(outputPath, "my-tile.pivotal")).To(BeAnExistingFile())
+					var m models.Metadata
+					Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+					m.AdditionalReleases = []models.AdditionalRelease{
+						{
+							Name:        extraReleaseName,
+							Version:     extraReleaseVersion,
+							TarballPath: "scripts-release/scripts-release-dev.tgz",
+							Jobs:        []string{extraJobName},
+						},
+					}
+					updated, err := yaml.Marshal(&m)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+				})
+
+				It("copies the tarball verbatim into .carvel-tile/releases/", func() {
+					dst := filepath.Join(outputPath, "releases", extraReleaseName+"-"+extraReleaseVersion+".tgz")
+					Expect(dst).To(BeAnExistingFile())
+					data, err := os.ReadFile(dst)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(Equal("stub bosh release tarball"))
+				})
+
+				It("extends the runtime-config addon with the extra release and job", func() {
+					rcPath := filepath.Join(outputPath, "runtime_configs", "k8s-tile-test-pkgr.yml")
+					rcData, err := os.ReadFile(rcPath)
+					Expect(err).NotTo(HaveOccurred())
+					var rc models.RuntimeConfigOuter
+					Expect(yaml.Unmarshal(rcData, &rc)).To(Succeed())
+					var inner models.RuntimeConfigInner
+					Expect(yaml.Unmarshal([]byte(rc.RuntimeConfig), &inner)).To(Succeed())
+
+					By("adding the release to the releases: list")
+					Expect(inner.Releases).To(ContainElement(`$( release "` + extraReleaseName + `" )`))
+
+					By("appending the job to the addon's jobs: list")
+					addon := inner.Addons[0]
+					Expect(addon.Jobs).To(HaveLen(2))
+					extraJob := addon.Jobs[1]
+					Expect(extraJob.Name).To(Equal(extraJobName))
+					Expect(extraJob.Release).To(Equal(extraReleaseName))
+					Expect(extraJob.Properties).To(BeEmpty())
 				})
 			})
-			When("the tile metadata version is too old", func() {
+		})
+		When("the tile metadata version is too old", func() {
 				BeforeEach(func() {
 					m := models.Metadata{
 						Name:                     "k8s-tile-test",

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -511,17 +511,27 @@ consumes:
 					Expect(string(data)).To(Equal("stub bosh release tarball"))
 				})
 
-				It("extends the runtime-config addon with the extra release and job", func() {
-					rcPath := filepath.Join(outputPath, "runtime_configs", "k8s-tile-test-pkgr.yml")
-					rcData, err := os.ReadFile(rcPath)
-					Expect(err).NotTo(HaveOccurred())
-					var rc models.RuntimeConfigOuter
-					Expect(yaml.Unmarshal(rcData, &rc)).To(Succeed())
-					var inner models.RuntimeConfigInner
-					Expect(yaml.Unmarshal([]byte(rc.RuntimeConfig), &inner)).To(Succeed())
+			It("adds the additional release to the top-level tile releases list", func() {
+				baseYMLPath := filepath.Join(outputPath, "base.yml")
+				raw, err := os.ReadFile(baseYMLPath)
+				Expect(err).NotTo(HaveOccurred())
+				var outMeta models.MetadataOut
+				Expect(yaml.Unmarshal(raw, &outMeta)).To(Succeed())
+				Expect(outMeta.Releases).To(HaveLen(2))
+				Expect(outMeta.Releases).To(ContainElement(ContainSubstring(extraReleaseName)))
+			})
 
-					By("adding the release to the releases: list")
-					Expect(inner.Releases).To(ContainElement(`$( release "` + extraReleaseName + `" )`))
+			It("extends the runtime-config addon with the extra release and job", func() {
+				rcPath := filepath.Join(outputPath, "runtime_configs", "k8s-tile-test-pkgr.yml")
+				rcData, err := os.ReadFile(rcPath)
+				Expect(err).NotTo(HaveOccurred())
+				var rc models.RuntimeConfigOuter
+				Expect(yaml.Unmarshal(rcData, &rc)).To(Succeed())
+				var inner models.RuntimeConfigInner
+				Expect(yaml.Unmarshal([]byte(rc.RuntimeConfig), &inner)).To(Succeed())
+
+				By("adding the release to the releases: list")
+				Expect(inner.Releases).To(ContainElement(`$( release "` + extraReleaseName + `" )`))
 
 					By("appending the job to the addon's jobs: list")
 					addon := inner.Addons[0]

--- a/internal/carvel/models/job.go
+++ b/internal/carvel/models/job.go
@@ -1,7 +1,11 @@
 package models
 
 type Job struct {
-	Name       string                         `yaml:"name"`
-	Release    string                         `yaml:"release"`
-	Properties map[string]PackageInstallProps `yaml:"properties,omitempty"`
+	Name    string `yaml:"name"`
+	Release string `yaml:"release"`
+	// Properties is intentionally map[string]interface{} so both the
+	// PackageInstall-shaped registry-data job and simpler additional jobs
+	// (e.g. script-deposit jobs with no PackageInstall-shaped payload) can
+	// coexist without being forced into the {name, version, values} schema.
+	Properties map[string]interface{} `yaml:"properties,omitempty"`
 }

--- a/internal/carvel/models/metadata.go
+++ b/internal/carvel/models/metadata.go
@@ -3,17 +3,39 @@ package models
 import "github.com/pivotal-cf/kiln/pkg/proofing"
 
 type Metadata struct {
-	Name                              string              `yaml:"name"`
-	ProductVersion                    string              `yaml:"product_version"`
-	IconImage                         string              `yaml:"icon_image"`
-	Label                             string              `yaml:"label"`
-	MetadataVersion                   string              `yaml:"metadata_version"`
-	MinimumVersionForUpgrade          string              `yaml:"minimum_version_for_upgrade"`
-	Rank                              int                 `yaml:"rank"`
-	Serial                            bool                `yaml:"serial"`
-	PropertyBlueprints                []string            `yaml:"property_blueprints"`
-	FormTypes                         []string            `yaml:"form_types"`
-	Variables                         []proofing.Variable `yaml:"variables"`
-	PackageInstalls                   []string            `yaml:"package_installs"`
-	CompatibleKubernetesDistributions []ProductVersion    `yaml:"compatible_kubernetes_distributions,omitempty"`
+	Name                              string               `yaml:"name"`
+	ProductVersion                    string               `yaml:"product_version"`
+	IconImage                         string               `yaml:"icon_image"`
+	Label                             string               `yaml:"label"`
+	MetadataVersion                   string               `yaml:"metadata_version"`
+	MinimumVersionForUpgrade          string               `yaml:"minimum_version_for_upgrade"`
+	Rank                              int                  `yaml:"rank"`
+	Serial                            bool                 `yaml:"serial"`
+	PropertyBlueprints                []string             `yaml:"property_blueprints"`
+	FormTypes                         []string             `yaml:"form_types"`
+	Variables                         []proofing.Variable  `yaml:"variables"`
+	PackageInstalls                   []string             `yaml:"package_installs"`
+	CompatibleKubernetesDistributions []ProductVersion     `yaml:"compatible_kubernetes_distributions,omitempty"`
+	// AdditionalReleases declares locally-built BOSH releases that kiln should
+	// splice into the runtime-config addon alongside the auto-generated tile
+	// release. Each entry's TarballPath is resolved relative to the tile source
+	// directory; kiln copies it verbatim into .carvel-tile/releases/ and adds
+	// the release + declared jobs to the runtime-config addon's releases:/jobs:
+	// lists. The tile's own build.sh is responsible for producing the tarball
+	// before invoking kiln carvel bake.
+	AdditionalReleases []AdditionalRelease `yaml:"additional_releases,omitempty"`
+}
+
+// AdditionalRelease declares a locally-built BOSH release to include alongside
+// the auto-generated tile release in the carvel runtime-config addon.
+type AdditionalRelease struct {
+	// Name is the BOSH release name (must match the name used in bosh create-release).
+	Name string `yaml:"name"`
+	// Version is the BOSH release version (e.g. "dev" for POC builds).
+	Version string `yaml:"version"`
+	// TarballPath is the path to the pre-built release tarball, relative to
+	// the tile source directory.
+	TarballPath string `yaml:"tarball_path"`
+	// Jobs lists the job names from this release to add to the addon's jobs: list.
+	Jobs []string `yaml:"jobs"`
 }

--- a/internal/carvel/models/metadata.go
+++ b/internal/carvel/models/metadata.go
@@ -24,6 +24,28 @@ type Metadata struct {
 	// lists. The tile's own build.sh is responsible for producing the tarball
 	// before invoking kiln carvel bake.
 	AdditionalReleases []AdditionalRelease `yaml:"additional_releases,omitempty"`
+	// PreInstallHooks/PostInstallHooks declare adapter jobs kiln should
+	// synthesize directly into the tile's own auto-generated release, each
+	// depositing a single delegating script at the conventional hook path
+	// consumed by a provider tile's generic hook-runner (see
+	// tanzu-vks-provider/docs/2026-07-16-generic-consumer-hook-contract.md).
+	// Job names are auto-prefixed with the tile's own name to avoid collisions
+	// with other consumer tiles' hook jobs on the same shared VM.
+	PreInstallHooks  []HookDeclaration `yaml:"pre_install_hooks,omitempty"`
+	PostInstallHooks []HookDeclaration `yaml:"post_install_hooks,omitempty"`
+}
+
+// HookDeclaration declares one hook adapter job for kiln to synthesize.
+type HookDeclaration struct {
+	// Name becomes the synthesized job name, auto-prefixed with the tile's
+	// own name unless already prefixed — e.g. "smoke-tests-post-install-hook"
+	// on tile "ear-k8s-runtime" becomes job
+	// "ear-k8s-runtime-smoke-tests-post-install-hook".
+	Name string `yaml:"name"`
+	// Command is the single command the synthesized script execs —
+	// typically another already-colocated job's own entrypoint, e.g.
+	// /var/vcap/jobs/smoke_tests/bin/run.
+	Command string `yaml:"command"`
 }
 
 // AdditionalRelease declares a locally-built BOSH release to include alongside

--- a/internal/carvel/models/metadata.go
+++ b/internal/carvel/models/metadata.go
@@ -36,6 +36,16 @@ type AdditionalRelease struct {
 	// TarballPath is the path to the pre-built release tarball, relative to
 	// the tile source directory.
 	TarballPath string `yaml:"tarball_path"`
-	// Jobs lists the job names from this release to add to the addon's jobs: list.
-	Jobs []string `yaml:"jobs"`
+	// Jobs lists jobs from this release to add to the addon's jobs: list.
+	// Each entry can carry an optional properties block that is marshaled
+	// verbatim into the generated runtime-config.
+	Jobs []AdditionalJob `yaml:"jobs"`
+}
+
+// AdditionalJob names a job within an AdditionalRelease and carries an
+// optional properties block. It is the input shape (parsed from base.yml);
+// models.Job is the output shape (written into the generated runtime-config).
+type AdditionalJob struct {
+	Name       string                 `yaml:"name"`
+	Properties map[string]interface{} `yaml:"properties,omitempty"`
 }


### PR DESCRIPTION
### Summary
This PR enhances `kiln carvel bake` to support colocating external BOSH releases on a shared VM and introduces native support for synthesizing pre-install and post-install hook adapter jobs. These changes allow Carvel-based tiles to easily run external jobs (like `smoke-tests`) as part of the deployment lifecycle without needing to hand-author separate BOSH releases.

### Key Features

1. **Support for `additional_releases`**
   * Added the `additional_releases` field to the Carvel `base.yml` metadata schema.
   * Allows tiles to declare extra locally-built BOSH releases (e.g., `cf-cli`, `smoke-tests`).
   * Kiln now copies these pre-built tarballs verbatim into `.carvel-tile/releases/` and automatically splices the releases and their declared jobs into the runtime-config addon.
   * Supports passing per-job `properties` blocks directly through to the generated runtime-config.

2. **Auto-Synthesis of Pre/Post-Install Hooks**
   * Added `pre_install_hooks` and `post_install_hooks` fields to the `base.yml` metadata schema.
   * Kiln now automatically synthesizes adapter jobs for these hooks directly into the tile's own auto-generated release (alongside `registry-data`).
   * For each hook, Kiln generates a BOSH job (auto-prefixed with the tile's name to prevent collisions) that deposits a single delegating script at the conventional path (`bin/hooks/pre-install` or `bin/hooks/post-install`).
   * This script simply `exec`s the command specified in `base.yml` (typically another colocated job's entrypoint, like `/var/vcap/jobs/smoke_tests/bin/run`).
   * Eliminates the need for tile authors to maintain separate "hook adapter" BOSH release repositories.

### Technical Details
* **`internal/carvel/models/metadata.go`**: Added `AdditionalReleases`, `PreInstallHooks`, and `PostInstallHooks` structs to the metadata schema.
* **`internal/carvel/baker.go`**: 
  * Updated `generateBoshReleaseDir()` to scaffold the new hook adapter jobs using `bosh generate-job`.
  * Updated `generateRuntimeConfigs()` to append the `additional_releases` and synthesized hook jobs to the runtime-config addon's job list.
* **`internal/carvel/baker_test.go`**: Added comprehensive unit tests to verify the tarball copying, runtime-config generation, property marshaling, and hook job synthesis behaviors.
