### PR TITLE
Implement remote fetch, carvel publish, and hook synthesis for carvel…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ env.yml
 vendor
 
 internal/acceptance/bake/fixtures/bake_records/*.json
+
+# Locally-built kiln binaries — accidentally committed in 8a183a0f, must
+# never be tracked (compiled artifacts, not source).
+/kiln
+/.bin/

--- a/internal/acceptance/carvel/carvel_bake_test.go
+++ b/internal/acceptance/carvel/carvel_bake_test.go
@@ -78,6 +78,10 @@ var _ = Describe("carvel bake command", func() {
 			"carvel", "bake",
 			"--source-directory", inputPath,
 			"--output-file", outputFile,
+			"--variable", "artifactory_host=fake-host",
+			"--variable", "artifactory_repo=fake-repo",
+			"--variable", "artifactory_username=fake-user",
+			"--variable", "artifactory_password=fake-pass",
 		}
 	})
 
@@ -193,7 +197,7 @@ var _ = Describe("carvel bake command", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(session).Should(gexec.Exit(1))
-				Eventually(session.Err).Should(gbytes.Say("base.yml"))
+				Eventually(session.Err).Should(gbytes.Say("Kilnfile"))
 			})
 		})
 	})

--- a/internal/acceptance/carvel/carvel_workflow_test.go
+++ b/internal/acceptance/carvel/carvel_workflow_test.go
@@ -24,11 +24,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// mockArtifactory is a test HTTP server that faithfully simulates Artifactory's
-// upload (PUT) and download (GET) behaviour, including Basic Auth verification.
-// Upload stores the tarball bytes keyed by request path; download serves them
-// back.  The /artifactory prefix that the real download client prepends is
-// handled transparently.
 type mockArtifactory struct {
 	mu       sync.Mutex
 	blobs    map[string][]byte
@@ -57,7 +52,6 @@ func (m *mockArtifactory) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Normalize path: strip the /artifactory prefix the download client adds
 	key := r.URL.Path
 	key = strings.TrimPrefix(key, "/artifactory")
 
@@ -114,23 +108,6 @@ func (m *mockArtifactory) GetCount() int {
 	return m.getCount
 }
 
-// ---------------------------------------------------------------------------
-// End-to-end acceptance test for the full Carvel tile developer workflow.
-//
-// This test exercises every `kiln carvel` subcommand in sequence, chaining
-// their outputs exactly like a real developer and CI pipeline would:
-//
-//   Step 1  kiln carvel bake          (local bake, no Kilnfile.lock)
-//   Step 2  kiln carvel upload        (creates BOSH release, uploads, writes lock)
-//           git add + commit          (Kilnfile.lock)
-//   Step 3  kiln carvel bake          (CI-style: downloads from lock)
-//   Step 4  kiln carvel publish --final (downloads, bakes, writes bake record)
-//           git add + commit          (bake_records/)
-//   Step 5  kiln carvel rebake        (re-bakes from record, verifies checksum)
-//
-// A mock Artifactory server stores the actual uploaded tarball and serves it
-// back on download, proving the full round-trip.
-// ---------------------------------------------------------------------------
 var _ = Describe("carvel full workflow", Ordered, func() {
 	const (
 		sampleTileFixture = "fixtures/sample-tile"
@@ -232,9 +209,6 @@ var _ = Describe("carvel full workflow", Ordered, func() {
 		_ = os.RemoveAll(tmpDir)
 	})
 
-	// -----------------------------------------------------------------------
-	// Step 1: Local bake (no Kilnfile.lock, no Artifactory interaction)
-	// -----------------------------------------------------------------------
 	It("Step 1: bakes a tile locally without Kilnfile.lock", func() {
 		outputFile := filepath.Join(tmpDir, "step1.pivotal")
 
@@ -259,9 +233,6 @@ var _ = Describe("carvel full workflow", Ordered, func() {
 		Expect(os.IsNotExist(err)).To(BeTrue(), "local bake must not create Kilnfile.lock")
 	})
 
-	// -----------------------------------------------------------------------
-	// Step 2: Upload (creates BOSH release, uploads to Artifactory, writes lock)
-	// -----------------------------------------------------------------------
 	It("Step 2: uploads the BOSH release to Artifactory and writes Kilnfile.lock", func() {
 		cmd := exec.Command(pathToMain,
 			append([]string{
@@ -298,9 +269,6 @@ var _ = Describe("carvel full workflow", Ordered, func() {
 		gitInTile("commit", "-m", "add Kilnfile.lock from upload")
 	})
 
-	// -----------------------------------------------------------------------
-	// Step 3: CI-style bake (downloads cached BOSH release via Kilnfile.lock)
-	// -----------------------------------------------------------------------
 	It("Step 3: bakes a tile using Kilnfile.lock (CI path with Artifactory download)", func() {
 		outputFile := filepath.Join(tmpDir, "step3-ci.pivotal")
 
@@ -311,6 +279,7 @@ var _ = Describe("carvel full workflow", Ordered, func() {
 				"carvel", "bake",
 				"--source-directory", inputPath,
 				"--output-file", outputFile,
+				"--from-lockfile",
 				"--verbose",
 			}, variableFlags()...)...,
 		)
@@ -324,9 +293,6 @@ var _ = Describe("carvel full workflow", Ordered, func() {
 			"CI bake must download the cached BOSH release from Artifactory")
 	})
 
-	// -----------------------------------------------------------------------
-	// Step 4: Publish --final (downloads, bakes, creates bake record)
-	// -----------------------------------------------------------------------
 	var publishChecksum string
 
 	It("Step 4: publishes a final tile and writes a bake record", func() {
@@ -372,9 +338,6 @@ var _ = Describe("carvel full workflow", Ordered, func() {
 		// Concourse resource checks out the commit from the record.
 	})
 
-	// -----------------------------------------------------------------------
-	// Step 5: Rebake from bake record (reproducibility verification)
-	// -----------------------------------------------------------------------
 	It("Step 5: re-bakes from the bake record with an identical checksum", func() {
 		outputFile := filepath.Join(tmpDir, "step5-rebake.pivotal")
 		recordPath := filepath.Join(inputPath, "bake_records", "0.1.1.json")

--- a/internal/carvel/baker.go
+++ b/internal/carvel/baker.go
@@ -1,6 +1,7 @@
 package carvel
 
 import (
+	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -16,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/pivotal-cf/kiln/internal/carvel/models"
+	"github.com/pivotal-cf/kiln/internal/component"
 	"github.com/pivotal-cf/kiln/pkg/cargo"
 	"github.com/pivotal-cf/kiln/pkg/proofing"
 
@@ -23,12 +25,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type BakeOptions struct {
+	SkipFetch         bool
+	ReleasesDirectory string
+}
+
 // Baker transforms an imgpkg bundle and tile metadata into a BOSH release
 // and kiln-compatible tile structure that can be baked into a .pivotal file.
 type Baker interface {
-	Bake(source string) error
-	BakeFromLockfile(source string, releaseLock cargo.BOSHReleaseTarballLock, localTarball string) error
+	Bake(source string, kilnfile cargo.Kilnfile, kilnfileLock cargo.KilnfileLock, opts BakeOptions) error
+	BakeFromLockfile(source string, kilnfile cargo.Kilnfile, kilnfileLock cargo.KilnfileLock, releaseLock cargo.BOSHReleaseTarballLock, localTarball string, opts BakeOptions) error
 	KilnBake(destination string) error
+	ParseMetadata(source string) error
 	GetName() string
 	GetBoshReleaseName() string
 	// GetVersion returns the product version from base.yml or the version file.
@@ -76,7 +84,7 @@ func (b *baker) KilnBake(destination string) error {
 	return nil
 }
 
-func (b *baker) Bake(source string) error {
+func (b *baker) Bake(source string, kilnfile cargo.Kilnfile, kilnfileLock cargo.KilnfileLock, opts BakeOptions) error {
 	b.source = source
 	b.destination = path.Join(source, ".carvel-tile")
 
@@ -121,7 +129,7 @@ func (b *baker) Bake(source string) error {
 	}
 
 	b.progress("Generating tile layout in " + b.destination)
-	err = b.generateOutputTile()
+	err = b.generateOutputTile(kilnfile, kilnfileLock, opts)
 	if err != nil {
 		b.log(err.Error())
 		return err
@@ -130,7 +138,7 @@ func (b *baker) Bake(source string) error {
 	return nil
 }
 
-func (b *baker) BakeFromLockfile(source string, releaseLock cargo.BOSHReleaseTarballLock, localTarball string) error {
+func (b *baker) BakeFromLockfile(source string, kilnfile cargo.Kilnfile, kilnfileLock cargo.KilnfileLock, releaseLock cargo.BOSHReleaseTarballLock, localTarball string, opts BakeOptions) error {
 	b.source = source
 	b.destination = path.Join(source, ".carvel-tile")
 
@@ -210,6 +218,16 @@ func (b *baker) BakeFromLockfile(source string, releaseLock cargo.BOSHReleaseTar
 		return fmt.Errorf("failed to copy cached release tarball: %w", err)
 	}
 
+	// We also need to fetch any additional releases when baking from lockfile,
+	// otherwise the final .pivotal assembly will fail because it looks for them.
+	if len(b.metadata.AdditionalReleases) > 0 {
+		b.progress("  Fetching additional BOSH releases")
+		err = b.fetchAdditionalReleases(kilnfile, kilnfileLock, opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -224,8 +242,69 @@ func (b *baker) GetReleaseTarball() (string, error) {
 	return tarball, nil
 }
 
+func (b *baker) ParseMetadata(source string) error {
+	b.source = source
+	baseYMLPath := path.Join(source, "base.yml")
+	raw, err := os.ReadFile(baseYMLPath)
+	if err != nil {
+		return fmt.Errorf("failed to read base.yml: %w", err)
+	}
+	if err := yaml.Unmarshal(raw, &b.metadata); err != nil {
+		return fmt.Errorf("failed to parse base.yml: %w", err)
+	}
+	return nil
+}
+
 func (b *baker) GetName() string {
 	return b.metadata.Name
+}
+
+func (b *baker) hookJobName(hookName string) string {
+	prefix := b.metadata.Name + "-"
+	if strings.HasPrefix(hookName, prefix) {
+		return hookName
+	}
+	return prefix + hookName
+}
+
+// shellQuoteCommand splits a hook's declared command on whitespace and
+// individually single-quotes each word before rejoining them, so the
+// generated hook script's `exec <command>` line safely execs the intended
+// binary/args even if a word contains shell metacharacters (;, $(), `, etc.)
+// — accidental or otherwise. base.yml authors still write one plain string
+// (e.g. "/var/vcap/jobs/smoke_tests/bin/run --foo bar"); the shell just never
+// gets a chance to interpret any of it.
+func shellQuoteCommand(command string) string {
+	words := strings.Fields(command)
+	quoted := make([]string, len(words))
+	for i, w := range words {
+		quoted[i] = shellQuoteWord(w)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// shellQuoteWord wraps a single word in POSIX single quotes, escaping any
+// embedded single quote as '"'"' (end quoting, a literal single quote via a
+// double-quoted segment, then resume quoting).
+func shellQuoteWord(word string) string {
+	return "'" + strings.ReplaceAll(word, "'", `'"'"'`) + "'"
+}
+
+// hookModeGroup pairs a hook mode with its declared hooks. Shared by
+// generateBoshReleaseDir (job synthesis) and generateRuntimeConfigs
+// (validation + addon job references) so both report the same
+// mode-specific error for a malformed hook, regardless of which bake path
+// (Bake vs. BakeFromLockfile) is in use.
+type hookModeGroup struct {
+	mode  string
+	hooks []models.HookDeclaration
+}
+
+func (b *baker) hookModeGroups() []hookModeGroup {
+	return []hookModeGroup{
+		{mode: "pre-install", hooks: b.metadata.PreInstallHooks},
+		{mode: "post-install", hooks: b.metadata.PostInstallHooks},
+	}
 }
 
 func (b *baker) GetBoshReleaseName() string {
@@ -503,6 +582,49 @@ files:
 		return err
 	}
 
+	for _, group := range b.hookModeGroups() {
+		for _, hook := range group.hooks {
+			if hook.Name == "" || hook.Command == "" {
+				return fmt.Errorf("%s hook declaration missing name or command", group.mode)
+			}
+
+			jobName := b.hookJobName(hook.Name)
+
+			genCmd := exec.Command("bosh", "generate-job", "--dir="+dirName, jobName)
+			b.log("executing " + genCmd.String())
+			out, err := genCmd.CombinedOutput()
+			b.log("output: " + string(out))
+			if err != nil {
+				return err
+			}
+
+			templateName := "hooks-" + group.mode + ".erb"
+			jobSpec := fmt.Sprintf(`---
+name: %s
+templates:
+  %s: bin/hooks/%s
+packages: []
+properties: {}
+`, jobName, templateName, group.mode)
+			if err = os.WriteFile(path.Join(dirName, "jobs", jobName, "spec"), []byte(jobSpec), 0644); err != nil {
+				return err
+			}
+
+			if err = os.MkdirAll(path.Join(dirName, "jobs", jobName, "templates"), 0755); err != nil {
+				return err
+			}
+			templateContent := fmt.Sprintf("#!/bin/bash\nset -euo pipefail\nexec %s\n", shellQuoteCommand(hook.Command))
+			err = os.WriteFile(
+				path.Join(dirName, "jobs", jobName, "templates", templateName),
+				[]byte(templateContent),
+				0644,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -601,7 +723,7 @@ spec:
 `
 }
 
-func (b *baker) generateOutputTile() error {
+func (b *baker) generateOutputTile(kilnfile cargo.Kilnfile, kilnfileLock cargo.KilnfileLock, opts BakeOptions) error {
 	err := os.RemoveAll(b.destination)
 	if err != nil {
 		return err
@@ -640,6 +762,14 @@ func (b *baker) generateOutputTile() error {
 		return err
 	}
 
+	if len(b.metadata.AdditionalReleases) > 0 {
+		b.progress("  Fetching additional BOSH releases")
+		err = b.fetchAdditionalReleases(kilnfile, kilnfileLock, opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	b.progress("  Creating BOSH release tarball (this may take a while)...")
 	err = b.createBoshRelease()
 	if err != nil {
@@ -676,9 +806,11 @@ func (b *baker) generateBaseYaml() error {
 		`$( runtime_config "` + b.metadata.Name + `-pkgr" )`,
 	}
 
-	// we will use the tile name and version as the bosh release name and version.
 	meta.Releases = []string{
 		`$( release "` + b.GetBoshReleaseName() + `" )`,
+	}
+	for _, ar := range b.metadata.AdditionalReleases {
+		meta.Releases = append(meta.Releases, `$( release "`+ar.Name+`" )`)
 	}
 
 	yamlData, err := yaml.Marshal(&meta)
@@ -726,7 +858,7 @@ func (b *baker) generateRuntimeConfigs() error {
 		return err
 	}
 
-	registryDataProps := map[string]models.PackageInstallProps{}
+	registryDataProps := map[string]interface{}{}
 
 	// we need one PackageInstall for each entry in the metadata.
 	for _, entry := range b.metadata.PackageInstalls {
@@ -793,10 +925,31 @@ func (b *baker) generateRuntimeConfigs() error {
 		registryDataJob.Consumes = consumesMap
 	}
 
+	releases := []string{`$( release "` + b.GetBoshReleaseName() + `" )`}
+	addonJobs := []models.Job{registryDataJob}
+
+	for _, group := range b.hookModeGroups() {
+		for _, hook := range group.hooks {
+			if hook.Name == "" || hook.Command == "" {
+				return fmt.Errorf("%s hook declaration missing name or command", group.mode)
+			}
+			addonJobs = append(addonJobs, models.Job{Name: b.hookJobName(hook.Name), Release: b.GetBoshReleaseName()})
+		}
+	}
+
+	for _, ar := range b.metadata.AdditionalReleases {
+		releases = append(releases, `$( release "`+ar.Name+`" )`)
+		for _, job := range ar.Jobs {
+			addonJobs = append(addonJobs, models.Job{
+				Name:       job.Name,
+				Release:    ar.Name,
+				Properties: job.Properties,
+			})
+		}
+	}
+
 	inner := models.RuntimeConfigInner{
-		Releases: []string{
-			`$( release "` + b.GetBoshReleaseName() + `" )`,
-		},
+		Releases: releases,
 		Addons: []models.Addon{
 			{
 				Name: b.metadata.Name + "-pkgr",
@@ -809,9 +962,7 @@ func (b *baker) generateRuntimeConfigs() error {
 						{Name: "install-packages", Release: "tanzu-content"},
 					},
 				},
-				Jobs: []models.Job{
-					registryDataJob,
-				},
+				Jobs: addonJobs,
 			},
 		},
 	}
@@ -854,6 +1005,89 @@ func (b *baker) generateJobFiles() error {
 	}
 
 	return nil
+}
+
+func (b *baker) fetchAdditionalReleases(kilnfile cargo.Kilnfile, kilnfileLock cargo.KilnfileLock, opts BakeOptions) error {
+	releasesDir := path.Join(b.destination, "releases")
+	if err := os.MkdirAll(releasesDir, 0755); err != nil {
+		return err
+	}
+	sources := component.NewReleaseSourceRepo(kilnfile)
+
+	for _, ar := range b.metadata.AdditionalReleases {
+		lockEntry, err := kilnfileLock.FindBOSHReleaseWithName(ar.Name)
+		if err != nil {
+			return fmt.Errorf("additional_releases entry %q not found in Kilnfile.lock — run `kiln fetch` or add it to Kilnfile", ar.Name)
+		}
+
+		dst := path.Join(releasesDir, ar.Name+"-"+lockEntry.Version+".tgz")
+		src := path.Join(opts.ReleasesDirectory, additionalReleaseLocalFilename(sources, ar.Name, lockEntry))
+
+		if opts.SkipFetch {
+			if _, err := os.Stat(src); err != nil {
+				return fmt.Errorf("release %q not found in %s and --skip-fetch was set: %w", ar.Name, opts.ReleasesDirectory, err)
+			}
+			if src != dst {
+				if err := copyFileContents(src, dst); err != nil {
+					return fmt.Errorf("failed to copy additional release %q: %w", ar.Name, err)
+				}
+			}
+			continue
+		}
+
+		if _, err := os.Stat(src); err == nil {
+			f, err := os.Open(src)
+			if err == nil {
+				h := sha1.New()
+				if _, err := io.Copy(h, f); err == nil {
+					actualSHA1 := hex.EncodeToString(h.Sum(nil))
+					if lockEntry.SHA1 == "" || actualSHA1 == lockEntry.SHA1 {
+						b.progress(fmt.Sprintf("  Release %s %s already exists locally with correct SHA1 — skipping fetch", lockEntry.Name, lockEntry.Version))
+						f.Close()
+						if src != dst {
+							if err := copyFileContents(src, dst); err != nil {
+								return fmt.Errorf("failed to copy additional release %q: %w", ar.Name, err)
+							}
+						}
+						continue
+					}
+				}
+				f.Close()
+			}
+		}
+
+		b.progress(fmt.Sprintf("  Fetching %s %s from %s", lockEntry.Name, lockEntry.Version, lockEntry.RemoteSource))
+		local, err := sources.DownloadRelease(opts.ReleasesDirectory, lockEntry)
+		if err != nil {
+			return fmt.Errorf("failed to download additional release %q: %w", ar.Name, err)
+		}
+		if lockEntry.SHA1 != "" && local.Lock.SHA1 != lockEntry.SHA1 {
+			return fmt.Errorf("downloaded release %q had incorrect SHA1 - expected %q, got %q", ar.Name, lockEntry.SHA1, local.Lock.SHA1)
+		}
+		if local.LocalPath != dst {
+			if err := copyFileContents(local.LocalPath, dst); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func additionalReleaseLocalFilename(sources component.ReleaseSourceList, name string, lockEntry cargo.BOSHReleaseTarballLock) string {
+	defaultName := name + "-" + lockEntry.Version + ".tgz"
+	if lockEntry.RemotePath == "" || lockEntry.RemoteSource == "" {
+		return defaultName
+	}
+	source, err := sources.FindByID(lockEntry.RemoteSource)
+	if err != nil {
+		return defaultName
+	}
+	switch source.Configuration().Type {
+	case cargo.BOSHReleaseTarballSourceTypeS3, cargo.BOSHReleaseTarballSourceTypeArtifactory:
+		return filepath.Base(lockEntry.RemotePath)
+	default:
+		return defaultName
+	}
 }
 
 func (b *baker) createBoshRelease() error {

--- a/internal/carvel/baker_test.go
+++ b/internal/carvel/baker_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -374,8 +375,20 @@ consumes:
 					_ = os.RemoveAll(filepath.Dir(inputPath))
 				}
 			})
+			var (
+				kilnfile     cargo.Kilnfile
+				kilnfileLock cargo.KilnfileLock
+				opts         BakeOptions
+			)
+
+			BeforeEach(func() {
+				kilnfile = cargo.Kilnfile{}
+				kilnfileLock = cargo.KilnfileLock{}
+				opts = BakeOptions{}
+			})
+
 			JustBeforeEach(func() {
-				err = subject.Bake(inputPath)
+				err = subject.Bake(inputPath, kilnfile, kilnfileLock, opts)
 			})
 			When("the tile data is valid", func() {
 				JustBeforeEach(func() {
@@ -512,28 +525,381 @@ consumes:
 					Expect(addon.Jobs[0].Name).To(Equal("registry-data"))
 					Expect(addon.Jobs[0].Release).To(Equal("k8s-tile-test-pkg"))
 
-					By("carrying package install properties on the registry-data job")
-					Expect(addon.Jobs[0].Properties).To(HaveKey("test-install"))
-					props := addon.Jobs[0].Properties["test-install"]
-					Expect(props.Name).To(Equal("something-test.tanzu.vmware.com"))
-					Expect(props.Version).To(Equal("0.1.5"))
+				By("carrying package install properties on the registry-data job")
+				Expect(addon.Jobs[0].Properties).To(HaveKey("test-install"))
+				propsRaw := addon.Jobs[0].Properties["test-install"]
+				propsMap, ok := propsRaw.(map[string]interface{})
+				Expect(ok).To(BeTrue(), "expected PackageInstallProps to unmarshal as map[string]interface{}")
+				Expect(propsMap).To(HaveKeyWithValue("name", "something-test.tanzu.vmware.com"))
+				Expect(propsMap).To(HaveKeyWithValue("version", "0.1.5"))
 
-					By("emitting cross-deployment consumes from job-spec-overlay from/deployment fields")
-					Expect(addon.Jobs[0].Consumes).To(HaveKey("binding_cache"))
-					bc := addon.Jobs[0].Consumes["binding_cache"]
-					Expect(bc.From).To(Equal("binding_cache"))
-					Expect(bc.Deployment).To(Equal("(( ..cf.deployment_name ))"))
+				By("emitting cross-deployment consumes from job-spec-overlay from/deployment fields")
+				Expect(addon.Jobs[0].Consumes).To(HaveKey("binding_cache"))
+				bc := addon.Jobs[0].Consumes["binding_cache"]
+				Expect(bc.From).To(Equal("binding_cache"))
+				Expect(bc.Deployment).To(Equal("(( ..cf.deployment_name ))"))
 				})
-				It("can be kiln baked", func() {
-					if !kilnInstalled() {
-						Skip("kiln CLI not installed - skipping integration test")
-					}
-					err := subject.KilnBake(filepath.Join(outputPath, "my-tile.pivotal"))
+			It("can be kiln baked", func() {
+				if !kilnInstalled() {
+					Skip("kiln CLI not installed - skipping integration test")
+				}
+				err := subject.KilnBake(filepath.Join(outputPath, "my-tile.pivotal"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(filepath.Join(outputPath, "my-tile.pivotal")).To(BeAnExistingFile())
+			})
+
+			When("the tile base.yml declares additional_releases", func() {
+				const (
+					extraReleaseName    = "smoke-test-scripts"
+					extraReleaseVersion = "dev"
+					extraJobName        = "smoke-test-scripts"
+				)
+
+				BeforeEach(func() {
+					baseYMLPath := filepath.Join(inputPath, "base.yml")
+					raw, err := os.ReadFile(baseYMLPath)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(filepath.Join(outputPath, "my-tile.pivotal")).To(BeAnExistingFile())
+					var m models.Metadata
+					Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+					m.AdditionalReleases = []models.AdditionalRelease{
+						{
+							Name: extraReleaseName,
+							Jobs: []models.AdditionalJob{{Name: extraJobName}},
+						},
+					}
+					updated, err := yaml.Marshal(&m)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+
+				kilnfile = cargo.Kilnfile{
+					ReleaseSources: []cargo.ReleaseSourceConfig{
+						{Type: "s3", Bucket: "fake-bucket", Region: "us-west-1", PathTemplate: "fake-path-template"},
+					},
+				}
+					kilnfileLock = cargo.KilnfileLock{
+						Releases: []cargo.BOSHReleaseTarballLock{
+							{Name: extraReleaseName, Version: extraReleaseVersion, RemoteSource: "fake-bucket"},
+						},
+					}
+					opts = BakeOptions{
+						SkipFetch:         true,
+						ReleasesDirectory: filepath.Join(inputPath, "releases"),
+					}
+
+					Expect(os.MkdirAll(opts.ReleasesDirectory, 0755)).To(Succeed())
+					stubTarball := filepath.Join(opts.ReleasesDirectory, extraReleaseName+"-"+extraReleaseVersion+".tgz")
+					Expect(os.WriteFile(stubTarball, []byte("stub bosh release tarball"), 0644)).To(Succeed())
+				})
+
+				It("copies the tarball verbatim into .carvel-tile/releases/ when skip-fetch is true", func() {
+					dst := filepath.Join(outputPath, "releases", extraReleaseName+"-"+extraReleaseVersion+".tgz")
+					Expect(dst).To(BeAnExistingFile())
+					data, err := os.ReadFile(dst)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(Equal("stub bosh release tarball"))
+				})
+
+				It("fails when skip-fetch is false and tarball is not in cache", func() {
+					opts.SkipFetch = false
+					os.Remove(filepath.Join(opts.ReleasesDirectory, extraReleaseName+"-"+extraReleaseVersion+".tgz"))
+					err := subject.Bake(inputPath, kilnfile, kilnfileLock, opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("failed to download additional release"))
+				})
+
+				It("adds the additional release to the top-level tile releases list", func() {
+					baseYMLPath := filepath.Join(outputPath, "base.yml")
+					raw, err := os.ReadFile(baseYMLPath)
+					Expect(err).NotTo(HaveOccurred())
+					var outMeta models.MetadataOut
+					Expect(yaml.Unmarshal(raw, &outMeta)).To(Succeed())
+					Expect(outMeta.Releases).To(HaveLen(2))
+					Expect(outMeta.Releases).To(ContainElement(ContainSubstring(extraReleaseName)))
+				})
+
+				It("extends the runtime-config addon with the extra release and job", func() {
+					rcPath := filepath.Join(outputPath, "runtime_configs", "k8s-tile-test-pkgr.yml")
+					rcData, err := os.ReadFile(rcPath)
+					Expect(err).NotTo(HaveOccurred())
+					var rc models.RuntimeConfigOuter
+					Expect(yaml.Unmarshal(rcData, &rc)).To(Succeed())
+					var inner models.RuntimeConfigInner
+					Expect(yaml.Unmarshal([]byte(rc.RuntimeConfig), &inner)).To(Succeed())
+
+					By("adding the release to the releases: list")
+					Expect(inner.Releases).To(ContainElement(`$( release "` + extraReleaseName + `" )`))
+
+					By("appending the job to the addon's jobs: list")
+					addon := inner.Addons[0]
+					Expect(addon.Jobs).To(HaveLen(2))
+					extraJob := addon.Jobs[1]
+					Expect(extraJob.Name).To(Equal(extraJobName))
+					Expect(extraJob.Release).To(Equal(extraReleaseName))
+					Expect(extraJob.Properties).To(BeEmpty())
 				})
 			})
-			When("the tile metadata version is too old", func() {
+
+			When("an additional release's RemotePath basename differs from <name>-<version>.tgz", func() {
+				const (
+					extraReleaseName    = "smoke-test-scripts"
+					extraReleaseVersion = "4.12.14"
+					extraJobName        = "smoke-test-scripts"
+				)
+				realFilename := extraReleaseName + "-" + extraReleaseVersion + "-ubuntu-jammy-1.1298.tgz"
+
+				BeforeEach(func() {
+					baseYMLPath := filepath.Join(inputPath, "base.yml")
+					raw, err := os.ReadFile(baseYMLPath)
+					Expect(err).NotTo(HaveOccurred())
+					var m models.Metadata
+					Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+					m.AdditionalReleases = []models.AdditionalRelease{
+						{
+							Name: extraReleaseName,
+							Jobs: []models.AdditionalJob{{Name: extraJobName}},
+						},
+					}
+					updated, err := yaml.Marshal(&m)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+
+					kilnfile = cargo.Kilnfile{
+						ReleaseSources: []cargo.ReleaseSourceConfig{
+							{Type: "s3", Bucket: "fake-bucket", Region: "us-west-1", PathTemplate: "fake-path-template"},
+						},
+					}
+					kilnfileLock = cargo.KilnfileLock{
+						Releases: []cargo.BOSHReleaseTarballLock{
+							{
+								Name:         extraReleaseName,
+								Version:      extraReleaseVersion,
+								RemoteSource: "fake-bucket",
+								RemotePath:   extraReleaseName + "/" + realFilename,
+							},
+						},
+					}
+					opts = BakeOptions{
+						SkipFetch:         true,
+						ReleasesDirectory: filepath.Join(inputPath, "releases"),
+					}
+
+					Expect(os.MkdirAll(opts.ReleasesDirectory, 0755)).To(Succeed())
+					stubTarball := filepath.Join(opts.ReleasesDirectory, realFilename)
+					Expect(os.WriteFile(stubTarball, []byte("stub smoke-tests tarball"), 0644)).To(Succeed())
+				})
+
+				It("finds the tarball under its real filename with --skip-fetch", func() {
+					Expect(err).NotTo(HaveOccurred())
+					dst := filepath.Join(outputPath, "releases", extraReleaseName+"-"+extraReleaseVersion+".tgz")
+					Expect(dst).To(BeAnExistingFile())
+					data, readErr := os.ReadFile(dst)
+					Expect(readErr).NotTo(HaveOccurred())
+					Expect(string(data)).To(Equal("stub smoke-tests tarball"))
+				})
+			})
+
+		When("an additional_release job carries a properties block", func() {
+			const (
+				extraReleaseName    = "smoke-tests"
+				extraReleaseVersion = "dev"
+			)
+
+			BeforeEach(func() {
+				baseYMLPath := filepath.Join(inputPath, "base.yml")
+				raw, err := os.ReadFile(baseYMLPath)
+				Expect(err).NotTo(HaveOccurred())
+				var m models.Metadata
+				Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+				m.AdditionalReleases = []models.AdditionalRelease{
+					{
+						Name: extraReleaseName,
+						Jobs: []models.AdditionalJob{
+							{Name: "dummy-smoke-tests"},
+							{
+								Name: "smoke_tests",
+								Properties: map[string]interface{}{
+									"bpm": map[string]interface{}{"enabled": false},
+									"smoke_tests": map[string]interface{}{
+										"api": "(( .properties.smoke_tests_api.value ))",
+									},
+								},
+							},
+						},
+					},
+				}
+				updated, err := yaml.Marshal(&m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+
+				kilnfile = cargo.Kilnfile{
+					ReleaseSources: []cargo.ReleaseSourceConfig{
+						{Type: "s3", Bucket: "fake-bucket", Region: "us-west-1", PathTemplate: "fake-path-template"},
+					},
+				}
+				kilnfileLock = cargo.KilnfileLock{
+					Releases: []cargo.BOSHReleaseTarballLock{
+						{Name: extraReleaseName, Version: extraReleaseVersion, RemoteSource: "fake-bucket"},
+					},
+				}
+				opts = BakeOptions{
+					SkipFetch:         true,
+					ReleasesDirectory: filepath.Join(inputPath, "releases"),
+				}
+
+				Expect(os.MkdirAll(opts.ReleasesDirectory, 0755)).To(Succeed())
+				stubTarball := filepath.Join(opts.ReleasesDirectory, extraReleaseName+"-"+extraReleaseVersion+".tgz")
+				Expect(os.WriteFile(stubTarball, []byte("stub smoke-tests tarball"), 0644)).To(Succeed())
+			})
+
+			It("marshals per-job properties through to the generated runtime-config", func() {
+				rcPath := filepath.Join(outputPath, "runtime_configs", "k8s-tile-test-pkgr.yml")
+				rcData, err := os.ReadFile(rcPath)
+				Expect(err).NotTo(HaveOccurred())
+				var rc models.RuntimeConfigOuter
+				Expect(yaml.Unmarshal(rcData, &rc)).To(Succeed())
+				var inner models.RuntimeConfigInner
+				Expect(yaml.Unmarshal([]byte(rc.RuntimeConfig), &inner)).To(Succeed())
+
+				addon := inner.Addons[0]
+				Expect(addon.Jobs).To(HaveLen(3))
+
+				By("keeping the no-properties job empty")
+				dummyJob := addon.Jobs[1]
+				Expect(dummyJob.Name).To(Equal("dummy-smoke-tests"))
+				Expect(dummyJob.Release).To(Equal(extraReleaseName))
+				Expect(dummyJob.Properties).To(BeEmpty())
+
+				By("round-tripping the nested properties block intact")
+				smokeJob := addon.Jobs[2]
+				Expect(smokeJob.Name).To(Equal("smoke_tests"))
+				Expect(smokeJob.Release).To(Equal(extraReleaseName))
+				smokeProps, ok := smokeJob.Properties["smoke_tests"].(map[string]interface{})
+				Expect(ok).To(BeTrue(), "smoke_tests key should be a nested map")
+				Expect(smokeProps["api"]).To(Equal("(( .properties.smoke_tests_api.value ))"))
+				bpmProps, ok := smokeJob.Properties["bpm"].(map[string]interface{})
+				Expect(ok).To(BeTrue(), "bpm key should be a nested map")
+				Expect(bpmProps["enabled"]).To(BeFalse())
+			})
+		})
+
+		When("the tile base.yml declares post_install_hooks", func() {
+			BeforeEach(func() {
+				baseYMLPath := filepath.Join(inputPath, "base.yml")
+				raw, err := os.ReadFile(baseYMLPath)
+				Expect(err).NotTo(HaveOccurred())
+				var m models.Metadata
+				Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+				m.PostInstallHooks = []models.HookDeclaration{
+					{
+						Name:    "smoke-tests-post-install-hook",
+						Command: "/var/vcap/jobs/smoke_tests/bin/run",
+					},
+				}
+				updated, err := yaml.Marshal(&m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+			})
+
+			It("synthesizes the hook adapter job into the auto-generated release", func() {
+				releaseVersion := subject.GetReleaseVersion()
+				tarballPath := filepath.Join(outputPath, "releases", "k8s-tile-test-pkg-"+releaseVersion+".tgz")
+				Expect(tarballPath).To(BeAnExistingFile())
+
+				jobDir := filepath.Join(boshReleasePath, "jobs", "k8s-tile-test-smoke-tests-post-install-hook")
+				Expect(jobDir).To(BeADirectory())
+
+				specPath := filepath.Join(jobDir, "spec")
+				Expect(specPath).To(BeAnExistingFile())
+				specData, err := os.ReadFile(specPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(specData)).To(ContainSubstring("name: k8s-tile-test-smoke-tests-post-install-hook"))
+				Expect(string(specData)).To(ContainSubstring("hooks-post-install.erb: bin/hooks/post-install"))
+
+				templatePath := filepath.Join(jobDir, "templates", "hooks-post-install.erb")
+				Expect(templatePath).To(BeAnExistingFile())
+				templateData, err := os.ReadFile(templatePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(templateData)).To(ContainSubstring("exec '/var/vcap/jobs/smoke_tests/bin/run'"))
+			})
+
+			It("extends the runtime-config addon with the synthesized job", func() {
+				rcPath := filepath.Join(outputPath, "runtime_configs", "k8s-tile-test-pkgr.yml")
+				rcData, err := os.ReadFile(rcPath)
+				Expect(err).NotTo(HaveOccurred())
+				var rc models.RuntimeConfigOuter
+				Expect(yaml.Unmarshal(rcData, &rc)).To(Succeed())
+				var inner models.RuntimeConfigInner
+				Expect(yaml.Unmarshal([]byte(rc.RuntimeConfig), &inner)).To(Succeed())
+
+				addon := inner.Addons[0]
+				Expect(addon.Jobs).To(HaveLen(2))
+				hookJob := addon.Jobs[1]
+				Expect(hookJob.Name).To(Equal("k8s-tile-test-smoke-tests-post-install-hook"))
+				Expect(hookJob.Release).To(Equal("k8s-tile-test-pkg"))
+			})
+		})
+
+		Context("when Kilnfile.lock is present alongside hook declarations", func() {
+			BeforeEach(func() {
+				baseYMLPath := filepath.Join(inputPath, "base.yml")
+				raw, err := os.ReadFile(baseYMLPath)
+				Expect(err).NotTo(HaveOccurred())
+				var m models.Metadata
+				Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+				m.PostInstallHooks = []models.HookDeclaration{
+					{
+						Name:    "smoke-tests-post-install-hook",
+						Command: "/var/vcap/jobs/smoke_tests/bin/run",
+					},
+				}
+				updated, err := yaml.Marshal(&m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+
+				lockData := `---
+releases:
+- name: some-release
+  version: "1.2.3"
+  sha1: some-sha
+`
+				err = os.WriteFile(filepath.Join(inputPath, "Kilnfile.lock"), []byte(lockData), 0644)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("still synthesizes the registry-data and hook adapter jobs into the auto-generated release", func() {
+				jobDir := filepath.Join(boshReleasePath, "jobs", "k8s-tile-test-smoke-tests-post-install-hook")
+				Expect(jobDir).To(BeADirectory())
+
+				specPath := filepath.Join(jobDir, "spec")
+				Expect(specPath).To(BeAnExistingFile())
+				
+				registryDataDir := filepath.Join(boshReleasePath, "jobs", "registry-data")
+				Expect(registryDataDir).To(BeADirectory())
+			})
+		})
+	})
+
+	When("a hook declaration is missing name or command", func() {
+		BeforeEach(func() {
+			baseYMLPath := filepath.Join(inputPath, "base.yml")
+			raw, err := os.ReadFile(baseYMLPath)
+			Expect(err).NotTo(HaveOccurred())
+			var m models.Metadata
+			Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+			m.PostInstallHooks = []models.HookDeclaration{
+				{Name: "missing-command"},
+			}
+			updated, err := yaml.Marshal(&m)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+		})
+
+		It("returns a clear error", func() {
+			Expect(err).To(MatchError(ContainSubstring("post-install hook declaration missing name or command")))
+		})
+	})
+
+	When("the tile metadata version is too old", func() {
 				BeforeEach(func() {
 					m := models.Metadata{
 						Name:                     "k8s-tile-test",
@@ -554,7 +920,7 @@ consumes:
 					}
 					yamlData, err := yaml.Marshal(&m)
 					Expect(err).NotTo(HaveOccurred())
-					err = os.WriteFile(path.Join(inputPath, "base.yml"), yamlData, 0644) // 0644 sets file permissions
+					err = os.WriteFile(path.Join(inputPath, "base.yml"), yamlData, 0644)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -585,7 +951,7 @@ consumes:
 					}
 					yamlData, err := yaml.Marshal(&m)
 					Expect(err).NotTo(HaveOccurred())
-					err = os.WriteFile(path.Join(inputPath, "base.yml"), yamlData, 0644) // 0644 sets file permissions
+					err = os.WriteFile(path.Join(inputPath, "base.yml"), yamlData, 0644)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -684,7 +1050,7 @@ consumes:
 
 				subject := NewBaker()
 				subject.SetWriter(GinkgoWriter)
-				err = subject.Bake(inputPath)
+				err = subject.Bake(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, BakeOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				tarball, err := subject.GetReleaseTarball()
@@ -703,7 +1069,7 @@ consumes:
 
 				subject2 := NewBaker()
 				subject2.SetWriter(GinkgoWriter)
-				err = subject2.BakeFromLockfile(inputPath, releaseLock, cachedTarball)
+				err = subject2.BakeFromLockfile(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, releaseLock, cachedTarball, BakeOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				outputPath := path.Join(inputPath, ".carvel-tile")
@@ -730,7 +1096,7 @@ consumes:
 				}
 
 				subject := NewBaker()
-				err = subject.BakeFromLockfile(inputPath, releaseLock, "/nonexistent/tarball.tgz")
+				err = subject.BakeFromLockfile(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, releaseLock, "/nonexistent/tarball.tgz", BakeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("does not match tile-derived name"))
 			})
@@ -746,13 +1112,46 @@ consumes:
 				Expect(err).NotTo(HaveOccurred())
 
 				subject := NewBaker()
-				err = subject.Bake(inputPath)
+				err = subject.Bake(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, BakeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("missing required field 'name'"))
 
-				err = subject.BakeFromLockfile(inputPath, cargo.BOSHReleaseTarballLock{}, "/nonexistent/tarball.tgz")
+				err = subject.BakeFromLockfile(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, cargo.BOSHReleaseTarballLock{}, "/nonexistent/tarball.tgz", BakeOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("missing required field 'name'"))
+			})
+		})
+
+		When("a hook declaration is missing name or command", func() {
+			It("returns a clear error instead of generating a broken runtime-config addon job", func() {
+				inputPath, err := os.MkdirTemp("", "lockfile-bad-hook-*")
+				Expect(err).NotTo(HaveOccurred())
+				inputPath += "/tile"
+				defer func() { _ = os.RemoveAll(filepath.Dir(inputPath)) }()
+
+				err = os.CopyFS(inputPath, os.DirFS("testdata/sample-tile"))
+				Expect(err).NotTo(HaveOccurred())
+
+				baseYMLPath := filepath.Join(inputPath, "base.yml")
+				raw, err := os.ReadFile(baseYMLPath)
+				Expect(err).NotTo(HaveOccurred())
+				var m models.Metadata
+				Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+				m.PostInstallHooks = []models.HookDeclaration{
+					{Name: "missing-command"},
+				}
+				updated, err := yaml.Marshal(&m)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(baseYMLPath, updated, 0644)).To(Succeed())
+
+				releaseLock := cargo.BOSHReleaseTarballLock{
+					Name:    "k8s-tile-test-pkg",
+					Version: "0.1.1",
+				}
+
+				subject := NewBaker()
+				err = subject.BakeFromLockfile(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, releaseLock, "/nonexistent/tarball.tgz", BakeOptions{})
+				Expect(err).To(MatchError(ContainSubstring("post-install hook declaration missing name or command")))
 			})
 		})
 	})
@@ -796,7 +1195,7 @@ consumes:
 
 			uploadBaker := NewBaker()
 			uploadBaker.SetWriter(GinkgoWriter)
-			err = uploadBaker.Bake(inputPath)
+			err = uploadBaker.Bake(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, BakeOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			uploadTarball, err := uploadBaker.GetReleaseTarball()
@@ -811,7 +1210,7 @@ consumes:
 
 			publishBaker := NewBaker()
 			publishBaker.SetWriter(GinkgoWriter)
-			err = publishBaker.BakeFromLockfile(inputPath, releaseLock, cachedTarball)
+			err = publishBaker.BakeFromLockfile(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, releaseLock, cachedTarball, BakeOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			publishTile := filepath.Join(tmpRoot, "publish.pivotal")
@@ -822,7 +1221,7 @@ consumes:
 
 			rebakeBaker := NewBaker()
 			rebakeBaker.SetWriter(GinkgoWriter)
-			err = rebakeBaker.BakeFromLockfile(inputPath, releaseLock, cachedTarball)
+			err = rebakeBaker.BakeFromLockfile(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, releaseLock, cachedTarball, BakeOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			rebakeTile := filepath.Join(tmpRoot, "rebake.pivotal")
@@ -997,3 +1396,44 @@ consumes:
 		})
 	})
 })
+
+func TestShellQuoteCommand(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{
+			name:    "single word",
+			command: "/var/vcap/jobs/smoke_tests/bin/run",
+			want:    `'/var/vcap/jobs/smoke_tests/bin/run'`,
+		},
+		{
+			name:    "command with args",
+			command: "/var/vcap/jobs/smoke_tests/bin/run --foo bar",
+			want:    `'/var/vcap/jobs/smoke_tests/bin/run' '--foo' 'bar'`,
+		},
+		{
+			name:    "a hostile command is neutralized, not interpreted",
+			command: "/bin/true; rm -rf /",
+			want: `'/bin/true;' 'rm' '-rf' '/'`,
+		},
+		{
+			name:    "command substitution is neutralized",
+			command: "/bin/true $(whoami) `whoami`",
+			want:    "'/bin/true' '$(whoami)' '`whoami`'",
+		},
+		{
+			name:    "embedded single quote is escaped, not closed early",
+			command: `/bin/echo it's`,
+			want:    `'/bin/echo' 'it'"'"'s'`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shellQuoteCommand(tt.command)
+			if got != tt.want {
+				t.Errorf("shellQuoteCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/carvel/models/job.go
+++ b/internal/carvel/models/job.go
@@ -1,15 +1,12 @@
 package models
 
 type Job struct {
-	Name       string                         `yaml:"name"`
-	Release    string                         `yaml:"release"`
-	Consumes   map[string]JobConsumes         `yaml:"consumes,omitempty"`
-	Properties map[string]PackageInstallProps `yaml:"properties,omitempty"`
+	Name       string                 `yaml:"name"`
+	Release    string                 `yaml:"release"`
+	Consumes   map[string]JobConsumes `yaml:"consumes,omitempty"`
+	Properties map[string]interface{} `yaml:"properties,omitempty"`
 }
 
-// JobConsumes declares cross-deployment link resolution for a runtime config addon job.
-// When a job-spec-overlay entry sets from or deployment, kiln includes it in the
-// addon job's consumes map in the generated metadata.
 type JobConsumes struct {
 	From       string `yaml:"from,omitempty"`
 	Deployment string `yaml:"deployment,omitempty"`

--- a/internal/carvel/models/metadata.go
+++ b/internal/carvel/models/metadata.go
@@ -18,5 +18,23 @@ type Metadata struct {
 	CompatibleKubernetesDistributions []ProductVersion         `yaml:"compatible_kubernetes_distributions,omitempty"`
 	SupportsParallelDeploys           bool                     `yaml:"supports_parallel_deploys,omitempty"`
 	RequiresProductVersions           []RequiredProductVersion `yaml:"requires_product_versions,omitempty"`
-	UsesKubernetesFeatures            []KubernetesFeature      `yaml:"uses_kubernetes_features,omitempty"`
+    UsesKubernetesFeatures            []KubernetesFeature      `yaml:"uses_kubernetes_features,omitempty"`
+	AdditionalReleases []AdditionalRelease `yaml:"additional_releases,omitempty"`
+	PreInstallHooks  []HookDeclaration `yaml:"pre_install_hooks,omitempty"`
+	PostInstallHooks []HookDeclaration `yaml:"post_install_hooks,omitempty"`
+}
+
+type HookDeclaration struct {
+	Name string `yaml:"name"`
+	Command string `yaml:"command"`
+}
+
+type AdditionalRelease struct {
+	Name string `yaml:"name"`
+	Jobs []AdditionalJob `yaml:"jobs"`
+}
+
+type AdditionalJob struct {
+	Name       string                 `yaml:"name"`
+	Properties map[string]interface{} `yaml:"properties,omitempty"`
 }

--- a/internal/commands/carvel_bake.go
+++ b/internal/commands/carvel_bake.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/kiln/internal/carvel"
 	"github.com/pivotal-cf/kiln/internal/commands/flags"
+	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
 
 type CarvelBake struct {
@@ -19,9 +20,12 @@ type CarvelBake struct {
 
 type CarvelBakeOptions struct {
 	flags.Standard
-	SourceDirectory string `short:"s" long:"source-directory" description:"path to the Carvel tile source directory (defaults to current directory)"`
-	OutputFile      string `short:"o" long:"output-file"      description:"path to where the tile will be output" required:"true"`
-	Verbose         bool   `short:"v" long:"verbose"           description:"enable verbose output"`
+	SourceDirectory   string `short:"s"   long:"source-directory"   description:"path to the Carvel tile source directory (defaults to current directory)"`
+	OutputFile        string `short:"o"   long:"output-file"        description:"path to where the tile will be output" required:"true"`
+	Verbose           bool   `short:"v"   long:"verbose"            description:"enable verbose output"`
+	ReleasesDirectory string `short:"rd"  long:"releases-directory" default:"releases" description:"path to a directory containing/receiving additional_releases tarballs"`
+	SkipFetchReleases bool   `short:"sfr" long:"skip-fetch"         description:"skip fetching additional_releases; expect them already present in --releases-directory"`
+	FromLockfile      bool   `long:"from-lockfile" description:"use a cached copy of the tile's OWN release from Kilnfile.lock instead of regenerating it from source (narrow, explicit opt-in — see docs)"`
 }
 
 func NewCarvelBake(outLogger, errLogger *log.Logger) CarvelBake {
@@ -54,18 +58,58 @@ func (c CarvelBake) Execute(args []string) error {
 	}
 
 	kilnfilePath := resolveKilnfilePath(c.Options.Kilnfile, sourcePath)
-	lockfilePath := kilnfilePath + ".lock"
-	if _, statErr := os.Stat(lockfilePath); statErr == nil {
-		c.Options.Kilnfile = kilnfilePath
-		kilnfile, kilnfileLock, loadErr := c.Options.LoadKilnfiles(nil, nil)
-		if loadErr != nil {
-			return fmt.Errorf("failed to load Kilnfiles: %w", loadErr)
-		}
+	c.Options.Kilnfile = kilnfilePath
 
+	var kilnfile cargo.Kilnfile
+	var kilnfileLock cargo.KilnfileLock
+
+	_, lockfileStatErr := os.Stat(c.Options.KilnfileLockPath())
+	lockfilePresent := lockfileStatErr == nil
+
+	kf, kl, loadErr := c.Options.LoadKilnfiles(nil, nil)
+	if loadErr == nil {
+		kilnfile = kf
+		kilnfileLock = kl
+	} else {
+		kfOnly, kfErr := loadKilnfileOnly(c.Options.Standard)
+		if kfErr != nil {
+			return fmt.Errorf("failed to load Kilnfile: %w", kfErr)
+		}
+		kilnfile = kfOnly
+
+		if lockfilePresent {
+			return fmt.Errorf("failed to load Kilnfile.lock: %w", loadErr)
+		} else if c.Options.FromLockfile {
+			return fmt.Errorf("failed to load Kilnfiles (required for --from-lockfile): %w", loadErr)
+		} else {
+			c.outLogger.Printf("No Kilnfile.lock found — proceeding without additional_releases support")
+		}
+	}
+
+	var useLockfile bool
+	if c.Options.FromLockfile {
+		useLockfile = true
+	} else if lockfilePresent && loadErr == nil {
+		if err := baker.ParseMetadata(sourcePath); err == nil {
+			if _, err := kilnfileLock.FindBOSHReleaseWithName(baker.GetBoshReleaseName()); err == nil {
+				useLockfile = true
+			}
+		}
+	}
+
+	if useLockfile {
 		if len(kilnfileLock.Releases) == 0 {
 			return fmt.Errorf("no releases found in Kilnfile.lock")
 		}
-		releaseLock := kilnfileLock.Releases[0]
+		
+		if err := baker.ParseMetadata(sourcePath); err != nil {
+			return fmt.Errorf("failed to parse metadata: %w", err)
+		}
+		
+		releaseLock, err := kilnfileLock.FindBOSHReleaseWithName(baker.GetBoshReleaseName())
+		if err != nil {
+			return fmt.Errorf("release %q not found in Kilnfile.lock", baker.GetBoshReleaseName())
+		}
 
 		tmpDir, tmpErr := os.MkdirTemp("", "carvel-bake-*")
 		if tmpErr != nil {
@@ -73,17 +117,24 @@ func (c CarvelBake) Execute(args []string) error {
 		}
 		defer func() { _ = os.RemoveAll(tmpDir) }()
 
-		localTarball, dlErr := downloadCarvelRelease(c.outLogger, kilnfile, kilnfileLock, tmpDir)
+		localTarball, dlErr := downloadCarvelRelease(c.outLogger, kilnfile, kilnfileLock, tmpDir, baker.GetBoshReleaseName())
 		if dlErr != nil {
 			return fmt.Errorf("failed to download release from Artifactory: %w", dlErr)
 		}
 
-		err = baker.BakeFromLockfile(sourcePath, releaseLock, localTarball)
+		err = baker.BakeFromLockfile(sourcePath, kilnfile, kilnfileLock, releaseLock, localTarball, carvel.BakeOptions{
+			SkipFetch:         c.Options.SkipFetchReleases,
+			ReleasesDirectory: c.Options.ReleasesDirectory,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to prepare Carvel tile from lockfile: %w", err)
 		}
 	} else {
-		err = baker.Bake(sourcePath)
+		opts := carvel.BakeOptions{
+			SkipFetch:         c.Options.SkipFetchReleases,
+			ReleasesDirectory: c.Options.ReleasesDirectory,
+		}
+		err = baker.Bake(sourcePath, kilnfile, kilnfileLock, opts)
 		if err != nil {
 			return fmt.Errorf("failed to prepare Carvel tile: %w", err)
 		}

--- a/internal/commands/carvel_bake_test.go
+++ b/internal/commands/carvel_bake_test.go
@@ -102,5 +102,62 @@ var _ = Describe("CarvelBake", func() {
 				Expect(outputPath).To(BeAnExistingFile())
 			})
 		})
+
+		When("a Kilnfile.lock is present but --from-lockfile is not set", func() {
+			It("successfully bakes a tile from source (ignoring the lockfile for the tile's own release)", func() {
+				if !boshInstalled() {
+					Skip("bosh CLI not installed - skipping integration test")
+				}
+				if !kilnInstalled() {
+					Skip("kiln CLI not installed - skipping integration test")
+				}
+
+				err := os.WriteFile(filepath.Join(inputPath, "Kilnfile"), []byte(`---
+release_sources: []
+`), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = os.WriteFile(filepath.Join(inputPath, "Kilnfile.lock"), []byte(`---
+releases:
+- name: some-other-release
+  version: 1.2.3
+`), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = command.Execute([]string{
+					"--source-directory", inputPath,
+					"--output-file", outputPath,
+					"--verbose",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(outputPath).To(BeAnExistingFile())
+			})
+		})
+
+		When("a Kilnfile.lock is present but fails to parse", func() {
+			It("fails loudly instead of silently baking without additional_releases support", func() {
+				err := os.WriteFile(filepath.Join(inputPath, "Kilnfile"), []byte(`---
+release_sources: []
+`), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = os.WriteFile(filepath.Join(inputPath, "Kilnfile.lock"), []byte(`---
+releases:
+- name: cf-cli
+  version: "1.0.0"
+ - name: smoke-tests
+   version: "2.0.0"
+`), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = command.Execute([]string{
+					"--source-directory", inputPath,
+					"--output-file", outputPath,
+					"--verbose",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(outputPath).NotTo(BeAnExistingFile())
+			})
+		})
 	})
 })

--- a/internal/commands/carvel_helpers.go
+++ b/internal/commands/carvel_helpers.go
@@ -41,12 +41,16 @@ func findArtifactorySource(kilnfile cargo.Kilnfile) (cargo.ReleaseSourceConfig, 
 	return cargo.ReleaseSourceConfig{}, fmt.Errorf("no artifactory release source found in Kilnfile")
 }
 
-func downloadCarvelRelease(logger *log.Logger, kilnfile cargo.Kilnfile, lock cargo.KilnfileLock, destDir string) (string, error) {
+func downloadCarvelRelease(logger *log.Logger, kilnfile cargo.Kilnfile, lock cargo.KilnfileLock, destDir string, releaseName string) (string, error) {
 	if len(lock.Releases) == 0 {
 		return "", fmt.Errorf("no releases found in Kilnfile.lock")
 	}
 
-	releaseLock := lock.Releases[0]
+	releaseLock, err := lock.FindBOSHReleaseWithName(releaseName)
+	if err != nil {
+		return "", fmt.Errorf("release %q not found in Kilnfile.lock", releaseName)
+	}
+
 	sources := component.NewReleaseSourceRepo(kilnfile)
 
 	logger.Printf("Downloading %s %s from %s", releaseLock.Name, releaseLock.Version, releaseLock.RemoteSource)
@@ -64,23 +68,42 @@ func downloadCarvelRelease(logger *log.Logger, kilnfile cargo.Kilnfile, lock car
 }
 
 func writeStandardKilnfileLock(lockfilePath string, releaseName, releaseVersion, remotePath, remoteSourceID, sha1 string) error {
-	lock := cargo.KilnfileLock{
-		Releases: []cargo.BOSHReleaseTarballLock{
-			{
-				Name:         releaseName,
-				Version:      releaseVersion,
-				RemotePath:   remotePath,
-				RemoteSource: remoteSourceID,
-				SHA1:         sha1,
-			},
-		},
-		Stemcell: cargo.Stemcell{
-			OS:      "ubuntu-jammy",
-			Version: "1.446",
-		},
+	var lock cargo.KilnfileLock
+
+	data, err := os.ReadFile(lockfilePath)
+	switch {
+	case err == nil:
+		if err := yaml.Unmarshal(data, &lock); err != nil {
+			return fmt.Errorf("failed to parse existing Kilnfile.lock: %w", err)
+		}
+	case os.IsNotExist(err):
+		// No existing lockfile to preserve — fine, we're creating one.
+	default:
+		// A permissions/IO error is not the same as "no lockfile exists yet";
+		// treating it that way would silently overwrite a lockfile we simply
+		// failed to read, losing whatever was in it.
+		return fmt.Errorf("failed to read existing Kilnfile.lock: %w", err)
 	}
 
-	data, err := yaml.Marshal(&lock)
+	newEntry := cargo.BOSHReleaseTarballLock{
+		Name:         releaseName,
+		Version:      releaseVersion,
+		RemotePath:   remotePath,
+		RemoteSource: remoteSourceID,
+		SHA1:         sha1,
+	}
+	if err := (&lock).UpdateBOSHReleaseTarballLockWithName(releaseName, newEntry); err != nil {
+		return fmt.Errorf("failed to update Kilnfile.lock: %w", err)
+	}
+
+	if lock.Stemcell.OS == "" {
+		lock.Stemcell = cargo.Stemcell{
+			OS:      "ubuntu-jammy",
+			Version: "1.446",
+		}
+	}
+
+	data, err = yaml.Marshal(&lock)
 	if err != nil {
 		return fmt.Errorf("failed to marshal Kilnfile.lock: %w", err)
 	}

--- a/internal/commands/carvel_helpers_test.go
+++ b/internal/commands/carvel_helpers_test.go
@@ -1,0 +1,74 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pivotal-cf/kiln/pkg/cargo"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestWriteStandardKilnfileLock_PreservesExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+	lockfilePath := filepath.Join(tmpDir, "Kilnfile.lock")
+
+	initialLock := cargo.KilnfileLock{
+		Releases: []cargo.BOSHReleaseTarballLock{
+			{Name: "cf-cli", Version: "1.0.0"},
+			{Name: "smoke-tests", Version: "2.0.0"},
+		},
+	}
+	data, err := yaml.Marshal(&initialLock)
+	require.NoError(t, err)
+	err = os.WriteFile(lockfilePath, data, 0644)
+	require.NoError(t, err)
+
+	err = writeStandardKilnfileLock(lockfilePath, "ear-k8s-runtime", "3.0.0", "path/to/remote", "my-source", "fake-sha1")
+	require.NoError(t, err)
+
+	data, err = os.ReadFile(lockfilePath)
+	require.NoError(t, err)
+
+	var updatedLock cargo.KilnfileLock
+	err = yaml.Unmarshal(data, &updatedLock)
+	require.NoError(t, err)
+
+	require.Len(t, updatedLock.Releases, 3)
+	require.Equal(t, "cf-cli", updatedLock.Releases[0].Name)
+	require.Equal(t, "smoke-tests", updatedLock.Releases[1].Name)
+	require.Equal(t, "ear-k8s-runtime", updatedLock.Releases[2].Name)
+	require.Equal(t, "3.0.0", updatedLock.Releases[2].Version)
+	require.Equal(t, "path/to/remote", updatedLock.Releases[2].RemotePath)
+	require.Equal(t, "my-source", updatedLock.Releases[2].RemoteSource)
+	require.Equal(t, "fake-sha1", updatedLock.Releases[2].SHA1)
+}
+
+func TestWriteStandardKilnfileLock_FailsRatherThanOverwriteUnreadableFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root bypasses file permission checks")
+	}
+
+	tmpDir := t.TempDir()
+	lockfilePath := filepath.Join(tmpDir, "Kilnfile.lock")
+
+	initialLock := cargo.KilnfileLock{
+		Releases: []cargo.BOSHReleaseTarballLock{
+			{Name: "cf-cli", Version: "1.0.0"},
+		},
+	}
+	data, err := yaml.Marshal(&initialLock)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(lockfilePath, data, 0644))
+	require.NoError(t, os.Chmod(lockfilePath, 0000))
+	defer func() { _ = os.Chmod(lockfilePath, 0644) }()
+
+	err = writeStandardKilnfileLock(lockfilePath, "ear-k8s-runtime", "3.0.0", "path/to/remote", "my-source", "fake-sha1")
+	require.Error(t, err, "an unreadable (not missing) lockfile must not be silently treated as absent")
+
+	require.NoError(t, os.Chmod(lockfilePath, 0644))
+	onDisk, err := os.ReadFile(lockfilePath)
+	require.NoError(t, err)
+	require.Equal(t, data, onDisk)
+}

--- a/internal/commands/carvel_publish.go
+++ b/internal/commands/carvel_publish.go
@@ -25,11 +25,13 @@ type CarvelPublish struct {
 
 type CarvelPublishOptions struct {
 	flags.Standard
-	SourceDirectory string `short:"s" long:"source-directory" description:"path to the Carvel tile source directory (defaults to current directory)"`
-	OutputFile      string `short:"o" long:"output-file"      description:"path to where the tile will be output" required:"true"`
-	Version         string `          long:"version"           description:"tile version for the final release"`
-	IsFinal         bool   `          long:"final"             description:"create a bake record for this build"`
-	Verbose         bool   `short:"v" long:"verbose"           description:"enable verbose output"`
+	SourceDirectory   string `short:"s" long:"source-directory" description:"path to the Carvel tile source directory (defaults to current directory)"`
+	OutputFile        string `short:"o" long:"output-file"      description:"path to where the tile will be output" required:"true"`
+	Version           string `          long:"version"           description:"tile version for the final release"`
+	IsFinal           bool   `          long:"final"             description:"create a bake record for this build"`
+	Verbose           bool   `short:"v" long:"verbose"           description:"enable verbose output"`
+	SkipFetch         bool   `short:"sfr" long:"skip-fetch"        description:"skip fetching additional releases (assumes they are already in the releases directory)"`
+	ReleasesDirectory string `short:"rd"  long:"releases-directory" description:"path to the releases directory" default:"releases"`
 }
 
 func NewCarvelPublish(outLogger, errLogger *log.Logger) CarvelPublish {
@@ -72,10 +74,21 @@ func (c CarvelPublish) Execute(args []string) error {
 		return fmt.Errorf("failed to load Kilnfiles: %w", err)
 	}
 
+	b := carvel.NewBaker()
+	if c.Options.Verbose {
+		b.SetWriter(os.Stdout)
+	}
+	if err := b.ParseMetadata(sourcePath); err != nil {
+		return fmt.Errorf("failed to parse metadata: %w", err)
+	}
+
 	if len(kilnfileLock.Releases) == 0 {
 		return fmt.Errorf("no releases found in Kilnfile.lock: run 'kiln carvel upload' first")
 	}
-	releaseLock := kilnfileLock.Releases[0]
+	releaseLock, err := kilnfileLock.FindBOSHReleaseWithName(b.GetBoshReleaseName())
+	if err != nil {
+		return fmt.Errorf("release %q not found in Kilnfile.lock", b.GetBoshReleaseName())
+	}
 
 	tmpDir, err := os.MkdirTemp("", "carvel-publish-*")
 	if err != nil {
@@ -84,17 +97,15 @@ func (c CarvelPublish) Execute(args []string) error {
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	c.outLogger.Printf("Publishing Carvel tile from %s", sourcePath)
-	localTarball, err := downloadCarvelRelease(c.outLogger, kilnfile, kilnfileLock, tmpDir)
+	localTarball, err := downloadCarvelRelease(c.outLogger, kilnfile, kilnfileLock, tmpDir, b.GetBoshReleaseName())
 	if err != nil {
 		return fmt.Errorf("failed to download release from Artifactory: %w", err)
 	}
 
-	b := carvel.NewBaker()
-	if c.Options.Verbose {
-		b.SetWriter(os.Stdout)
-	}
-
-	err = b.BakeFromLockfile(sourcePath, releaseLock, localTarball)
+	err = b.BakeFromLockfile(sourcePath, kilnfile, kilnfileLock, releaseLock, localTarball, carvel.BakeOptions{
+		SkipFetch:         c.Options.SkipFetch,
+		ReleasesDirectory: c.Options.ReleasesDirectory,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to prepare Carvel tile from lockfile: %w", err)
 	}

--- a/internal/commands/carvel_publish_test.go
+++ b/internal/commands/carvel_publish_test.go
@@ -108,7 +108,7 @@ var _ = Describe("CarvelPublish", func() {
 
 				b := carvel.NewBaker()
 				b.SetWriter(GinkgoWriter)
-				Expect(b.Bake(inputPath)).To(Succeed())
+				Expect(b.Bake(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, carvel.BakeOptions{})).To(Succeed())
 				tarball, err := b.GetReleaseTarball()
 				Expect(err).NotTo(HaveOccurred())
 				tarballData, err := os.ReadFile(tarball)

--- a/internal/commands/carvel_rebake.go
+++ b/internal/commands/carvel_rebake.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pivotal-cf/kiln/internal/carvel"
 	"github.com/pivotal-cf/kiln/internal/commands/flags"
 	"github.com/pivotal-cf/kiln/pkg/bake"
+	"github.com/pivotal-cf/kiln/pkg/cargo"
 )
 
 type CarvelReBake struct {
@@ -86,18 +87,38 @@ func (c CarvelReBake) Execute(args []string) error {
 	}
 
 	kilnfilePath := resolveKilnfilePath(c.Options.Kilnfile, sourcePath)
+	c.Options.Kilnfile = kilnfilePath
+	var kilnfile cargo.Kilnfile
+	var kilnfileLock cargo.KilnfileLock
+
+	kf, kl, loadErr := c.Options.LoadKilnfiles(nil, nil)
+	if loadErr == nil {
+		kilnfile = kf
+		kilnfileLock = kl
+	} else {
+		kfOnly, kfErr := loadKilnfileOnly(c.Options.Standard)
+		if kfErr != nil {
+			return fmt.Errorf("failed to load Kilnfile: %w", kfErr)
+		}
+		kilnfile = kfOnly
+	}
+
 	lockfilePath := kilnfilePath + ".lock"
 	if _, statErr := os.Stat(lockfilePath); statErr == nil {
-		c.Options.Kilnfile = kilnfilePath
-		kilnfile, kilnfileLock, loadErr := c.Options.LoadKilnfiles(nil, nil)
 		if loadErr != nil {
-			return fmt.Errorf("failed to load Kilnfiles: %w", loadErr)
+			return fmt.Errorf("failed to load Kilnfile.lock: %w", loadErr)
 		}
 
+		if err := b.ParseMetadata(sourcePath); err != nil {
+			return fmt.Errorf("failed to parse metadata: %w", err)
+		}
 		if len(kilnfileLock.Releases) == 0 {
 			return fmt.Errorf("no releases found in Kilnfile.lock")
 		}
-		releaseLock := kilnfileLock.Releases[0]
+		releaseLock, err := kilnfileLock.FindBOSHReleaseWithName(b.GetBoshReleaseName())
+		if err != nil {
+			return fmt.Errorf("release %q not found in Kilnfile.lock", b.GetBoshReleaseName())
+		}
 
 		tmpDir, tmpErr := os.MkdirTemp("", "carvel-rebake-*")
 		if tmpErr != nil {
@@ -106,15 +127,21 @@ func (c CarvelReBake) Execute(args []string) error {
 		defer func() { _ = os.RemoveAll(tmpDir) }()
 
 		c.outLogger.Printf("Re-baking Carvel tile from %s using lockfile", sourcePath)
-		localTarball, dlErr := downloadCarvelRelease(c.outLogger, kilnfile, kilnfileLock, tmpDir)
+		localTarball, dlErr := downloadCarvelRelease(c.outLogger, kilnfile, kilnfileLock, tmpDir, b.GetBoshReleaseName())
 		if dlErr != nil {
 			return fmt.Errorf("failed to download release from Artifactory: %w", dlErr)
 		}
 
-		err = b.BakeFromLockfile(sourcePath, releaseLock, localTarball)
+		err = b.BakeFromLockfile(sourcePath, kilnfile, kilnfileLock, releaseLock, localTarball, carvel.BakeOptions{
+			SkipFetch:         false,
+			ReleasesDirectory: "releases",
+		})
 	} else {
 		c.outLogger.Printf("Re-baking Carvel tile from %s", sourcePath)
-		err = b.Bake(sourcePath)
+		err = b.Bake(sourcePath, kilnfile, kilnfileLock, carvel.BakeOptions{
+			SkipFetch:         false,
+			ReleasesDirectory: "releases",
+		})
 	}
 	if err != nil {
 		return fmt.Errorf("failed to prepare Carvel tile: %w", err)

--- a/internal/commands/carvel_rebake_test.go
+++ b/internal/commands/carvel_rebake_test.go
@@ -160,7 +160,7 @@ var _ = Describe("CarvelReBake", func() {
 
 				b := carvel.NewBaker()
 				b.SetWriter(GinkgoWriter)
-				Expect(b.Bake(inputPath)).To(Succeed())
+				Expect(b.Bake(inputPath, cargo.Kilnfile{}, cargo.KilnfileLock{}, carvel.BakeOptions{})).To(Succeed())
 				tarball, err := b.GetReleaseTarball()
 				Expect(err).NotTo(HaveOccurred())
 				tarballData, err := os.ReadFile(tarball)

--- a/internal/commands/carvel_upload.go
+++ b/internal/commands/carvel_upload.go
@@ -27,10 +27,12 @@ type CarvelUpload struct {
 
 type CarvelUploadOptions struct {
 	flags.Standard
-	SourceDirectory string `short:"s" long:"source-directory" description:"path to the Carvel tile source directory (defaults to current directory)"`
-	OutputFile      string `short:"o" long:"output-file"      description:"also bake the tile to this path"`
-	PathTemplate    string `          long:"path-template"     description:"remote path template override" default:"bosh-releases/{{.Name}}/{{.Name}}-{{.Version}}.tgz"`
-	Verbose         bool   `short:"v" long:"verbose"           description:"enable verbose output"`
+	SourceDirectory   string `short:"s" long:"source-directory" description:"path to the Carvel tile source directory (defaults to current directory)"`
+	OutputFile        string `short:"o" long:"output-file"      description:"also bake the tile to this path"`
+	PathTemplate      string `          long:"path-template"     description:"remote path template override" default:"bosh-releases/{{.Name}}/{{.Name}}-{{.Version}}.tgz"`
+	Verbose           bool   `short:"v" long:"verbose"           description:"enable verbose output"`
+	SkipFetch         bool   `short:"sfr" long:"skip-fetch"        description:"skip fetching additional releases (assumes they are already in the releases directory)"`
+	ReleasesDirectory string `short:"rd"  long:"releases-directory" description:"path to the releases directory" default:"releases"`
 }
 
 func NewCarvelUpload(outLogger, errLogger *log.Logger) CarvelUpload {
@@ -58,9 +60,17 @@ func (c CarvelUpload) Execute(args []string) error {
 	}
 
 	c.Options.Kilnfile = kilnfilePath
-	kilnfile, err := loadKilnfileOnly(c.Options.Standard)
+	kilnfile, kilnfileLock, err := c.Options.LoadKilnfiles(nil, nil)
 	if err != nil {
-		return fmt.Errorf("failed to load Kilnfile: %w", err)
+		kf, kfErr := loadKilnfileOnly(c.Options.Standard)
+		if kfErr != nil {
+			return fmt.Errorf("failed to load Kilnfile: %w", kfErr)
+		}
+		kilnfile = kf
+
+		if _, lockStatErr := os.Stat(c.Options.KilnfileLockPath()); lockStatErr == nil {
+			return fmt.Errorf("failed to load Kilnfile.lock: %w", err)
+		}
 	}
 
 	artConfig, err := findArtifactorySource(kilnfile)
@@ -74,7 +84,10 @@ func (c CarvelUpload) Execute(args []string) error {
 	}
 
 	c.outLogger.Printf("Baking Carvel tile from %s", sourcePath)
-	err = baker.Bake(sourcePath)
+	err = baker.Bake(sourcePath, kilnfile, kilnfileLock, carvel.BakeOptions{
+		SkipFetch:         c.Options.SkipFetch,
+		ReleasesDirectory: c.Options.ReleasesDirectory,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to prepare Carvel tile: %w", err)
 	}

--- a/internal/commands/update_release.go
+++ b/internal/commands/update_release.go
@@ -48,14 +48,14 @@ func (u UpdateRelease) Execute(args []string) error {
 
 	releaseLock, err := kilnfileLock.FindBOSHReleaseWithName(u.Options.Name)
 	if err != nil {
-		return fmt.Errorf(
-			"no release named %q exists in your Kilnfile.lock - try removing the -release, -boshrelease, or -bosh-release suffix if present",
-			u.Options.Name,
-		)
+		releaseLock = cargo.BOSHReleaseTarballLock{Name: u.Options.Name}
 	}
 	releaseSpec, err := kilnfile.BOSHReleaseTarballSpecification(u.Options.Name)
 	if err != nil {
-		return err
+		return fmt.Errorf(
+			"%w - try removing the -release, -boshrelease, or -bosh-release suffix if present",
+			err,
+		)
 	}
 
 	releaseVersionConstraint := releaseSpec.Version
@@ -118,7 +118,7 @@ func (u UpdateRelease) Execute(args []string) error {
 	releaseLock.RemoteSource = newSourceID
 	releaseLock.RemotePath = newRemotePath
 
-	_ = kilnfileLock.UpdateBOSHReleaseTarballLockWithName(u.Options.Name, releaseLock)
+	_ = (&kilnfileLock).UpdateBOSHReleaseTarballLockWithName(u.Options.Name, releaseLock)
 
 	err = u.Options.SaveKilnfileLock(u.filesystem, kilnfileLock)
 	if err != nil {

--- a/internal/commands/update_release_test.go
+++ b/internal/commands/update_release_test.go
@@ -281,7 +281,7 @@ var _ = Describe("UpdateRelease", func() {
 					"--version", newReleaseVersion,
 					"--releases-directory", releasesDir,
 				})
-				Expect(err).To(MatchError(ContainSubstring("no release named \"no-such-release\"")))
+				Expect(err).To(MatchError(ContainSubstring("no-such-release")))
 				Expect(err).To(MatchError(ContainSubstring("try removing the -release")))
 			})
 

--- a/pkg/cargo/kilnfile.go
+++ b/pkg/cargo/kilnfile.go
@@ -45,14 +45,23 @@ func (k KilnfileLock) FindBOSHReleaseWithName(name string) (BOSHReleaseTarballLo
 	return BOSHReleaseTarballLock{}, errors.New("not found")
 }
 
-func (k KilnfileLock) UpdateBOSHReleaseTarballLockWithName(name string, lock BOSHReleaseTarballLock) error {
+func (k *KilnfileLock) UpdateBOSHReleaseTarballLockWithName(name string, lock BOSHReleaseTarballLock) error {
+	if name == "" {
+		return errors.New("name must not be empty")
+	}
+	// Force the entry's Name to match name, so a caller can't silently
+	// rename/insert a mismatched entry by passing a lock.Name that differs
+	// from the name being updated.
+	lock.Name = name
+
 	for i, r := range k.Releases {
 		if r.Name == name {
 			k.Releases[i] = lock
 			return nil
 		}
 	}
-	return errors.New("not found")
+	k.Releases = append(k.Releases, lock)
+	return nil
 }
 
 type BOSHReleaseTarballSpecification struct {

--- a/pkg/cargo/kilnfile_test.go
+++ b/pkg/cargo/kilnfile_test.go
@@ -41,7 +41,30 @@ func TestKilnfileLock_UpdateBOSHReleaseTarballLockWithName(t *testing.T) {
 		args                         args
 		wantErr                      bool
 	}{
-		{name: "empty inputs", wantErr: true},
+		{
+			name:           "empty inputs",
+			KilnfileResult: KilnfileLock{},
+			wantErr:        true,
+		},
+
+		{
+			name: "lock with name not found",
+			KilnfileLock: KilnfileLock{
+				Releases: []BOSHReleaseTarballLock{
+					{Name: "banana"},
+				},
+			},
+			KilnfileResult: KilnfileLock{
+				Releases: []BOSHReleaseTarballLock{
+					{Name: "banana"},
+					{Name: "orange", Version: "some-version"},
+				},
+			},
+			args: args{
+				name: "orange", lock: BOSHReleaseTarballLock{Name: "orange", Version: "some-version"},
+			},
+			wantErr: false,
+		},
 
 		{
 			name: "lock with name found",
@@ -52,7 +75,25 @@ func TestKilnfileLock_UpdateBOSHReleaseTarballLockWithName(t *testing.T) {
 			},
 			KilnfileResult: KilnfileLock{
 				Releases: []BOSHReleaseTarballLock{
-					{Name: "orange", Version: "some-version"},
+					{Name: "banana", Version: "some-version"},
+				},
+			},
+			args: args{
+				name: "banana", lock: BOSHReleaseTarballLock{Name: "banana", Version: "some-version"},
+			},
+			wantErr: false,
+		},
+
+		{
+			name: "lock argument has a different name than the name argument",
+			KilnfileLock: KilnfileLock{
+				Releases: []BOSHReleaseTarballLock{
+					{Name: "banana"},
+				},
+			},
+			KilnfileResult: KilnfileLock{
+				Releases: []BOSHReleaseTarballLock{
+					{Name: "banana", Version: "some-version"},
 				},
 			},
 			args: args{


### PR DESCRIPTION
… tiles

- Add --from-lockfile, --skip-fetch, and --releases-directory flags to carvel bake
- Modify DownloadRelease to check local cache before fetching
- Update update-release to append new releases to Kilnfile.lock
- Allow carvel upload and publish to coexist with additional_releases
- Add skip-fetch flag to carvel upload and publish commands
- Fix additional_releases cache/skip-fetch lookup for s3/artifactory sources
- Fix silent swallowing of malformed Kilnfile errors when lockfile is absent