### PR TITLE
fix(carvel): allow carvel bake without Kilnfile

### DIFF
--- a/internal/acceptance/carvel/carvel_bake_test.go
+++ b/internal/acceptance/carvel/carvel_bake_test.go
@@ -154,6 +154,22 @@ var _ = Describe("carvel bake command", func() {
 		Eventually(verifySession.Out).Should(gbytes.Say("No errors detected"))
 	})
 
+	Context("when no Kilnfile is present", func() {
+		It("bakes successfully without additional_releases support", func() {
+			err := os.Remove(filepath.Join(inputPath, "Kilnfile"))
+			Expect(err).NotTo(HaveOccurred())
+
+			command := exec.Command(pathToMain, commandWithArgs...)
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session, "60s").Should(gexec.Exit(0))
+			Eventually(session.Out).Should(gbytes.Say("No Kilnfile found — proceeding without additional_releases support"))
+			Eventually(session.Out).Should(gbytes.Say("Done! Baked"))
+		})
+	})
+
 	Context("failure cases", func() {
 		Context("when the output-file flag is not provided", func() {
 			It("prints an error and exits 1", func() {
@@ -197,7 +213,7 @@ var _ = Describe("carvel bake command", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(session).Should(gexec.Exit(1))
-				Eventually(session.Err).Should(gbytes.Say("Kilnfile"))
+				Eventually(session.Err).Should(gbytes.Say("base.yml"))
 			})
 		})
 	})

--- a/internal/commands/carvel_bake.go
+++ b/internal/commands/carvel_bake.go
@@ -46,6 +46,10 @@ func (c CarvelBake) Execute(args []string) error {
 		return err
 	}
 
+	if _, err := os.Stat(sourcePath); err != nil {
+		return fmt.Errorf("source directory not found: %s", sourcePath)
+	}
+
 	targetPath, err := filepath.Abs(c.Options.OutputFile)
 	if err != nil {
 		return fmt.Errorf("failed to resolve output file path: %w", err)
@@ -66,11 +70,14 @@ func (c CarvelBake) Execute(args []string) error {
 	_, lockfileStatErr := os.Stat(c.Options.KilnfileLockPath())
 	lockfilePresent := lockfileStatErr == nil
 
+	_, kilnfileStatErr := os.Stat(kilnfilePath)
+	kilnfilePresent := kilnfileStatErr == nil
+
 	kf, kl, loadErr := c.Options.LoadKilnfiles(nil, nil)
 	if loadErr == nil {
 		kilnfile = kf
 		kilnfileLock = kl
-	} else {
+	} else if kilnfilePresent {
 		kfOnly, kfErr := loadKilnfileOnly(c.Options.Standard)
 		if kfErr != nil {
 			return fmt.Errorf("failed to load Kilnfile: %w", kfErr)
@@ -80,11 +87,19 @@ func (c CarvelBake) Execute(args []string) error {
 		if lockfilePresent {
 			return fmt.Errorf("failed to load Kilnfile.lock: %w", loadErr)
 		} else if c.Options.FromLockfile {
-			return fmt.Errorf("failed to load Kilnfiles (required for --from-lockfile): %w", loadErr)
+			return fmt.Errorf("failed to load Kilnfile.lock (required for --from-lockfile): %w", loadErr)
 		} else {
 			c.outLogger.Printf("No Kilnfile.lock found — proceeding without additional_releases support")
 		}
-	}
+		} else {
+			if c.Options.FromLockfile {
+				return fmt.Errorf("kilnfile not found at %s (required for --from-lockfile)", kilnfilePath)
+			}
+			if lockfilePresent {
+				return fmt.Errorf("kilnfile not found at %s but Kilnfile.lock is present; refusing to bake from source and silently ignore the pinned lock", kilnfilePath)
+			}
+			c.outLogger.Printf("No Kilnfile found — proceeding without additional_releases support")
+		}
 
 	var useLockfile bool
 	if c.Options.FromLockfile {

--- a/internal/commands/carvel_bake_test.go
+++ b/internal/commands/carvel_bake_test.go
@@ -159,5 +159,59 @@ releases:
 				Expect(outputPath).NotTo(BeAnExistingFile())
 			})
 		})
+
+		When("a --variables-file points at a missing path", func() {
+			It("fails loudly instead of misdiagnosing it as a missing Kilnfile", func() {
+				err := os.WriteFile(filepath.Join(inputPath, "Kilnfile"), []byte(`---
+release_sources: []
+`), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = command.Execute([]string{
+					"--source-directory", inputPath,
+					"--output-file", outputPath,
+					"--variables-file", filepath.Join(inputPath, "does-not-exist.yml"),
+					"--verbose",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Kilnfile"))
+				Expect(outputPath).NotTo(BeAnExistingFile())
+			})
+		})
+
+		When("the Kilnfile is absent but a Kilnfile.lock is present", func() {
+			It("hard-fails instead of silently baking from source and ignoring the pinned lock", func() {
+				Expect(os.Remove(filepath.Join(inputPath, "Kilnfile"))).To(Succeed())
+
+				err := os.WriteFile(filepath.Join(inputPath, "Kilnfile.lock"), []byte(`---
+releases:
+- name: some-release
+  version: 1.2.3
+`), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = command.Execute([]string{
+					"--source-directory", inputPath,
+					"--output-file", outputPath,
+					"--verbose",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Kilnfile.lock"))
+				Expect(outputPath).NotTo(BeAnExistingFile())
+			})
+		})
+
+		When("the --source-directory does not exist", func() {
+			It("fails fast with a clear error instead of misdiagnosing it as a missing Kilnfile", func() {
+				err := command.Execute([]string{
+					"--source-directory", filepath.Join(inputPath, "no", "such", "dir"),
+					"--output-file", outputPath,
+					"--verbose",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("source directory"))
+				Expect(outputPath).NotTo(BeAnExistingFile())
+			})
+		})
 	})
 })

--- a/internal/commands/carvel_rebake.go
+++ b/internal/commands/carvel_rebake.go
@@ -91,11 +91,14 @@ func (c CarvelReBake) Execute(args []string) error {
 	var kilnfile cargo.Kilnfile
 	var kilnfileLock cargo.KilnfileLock
 
+	_, kilnfileStatErr := os.Stat(kilnfilePath)
+	kilnfilePresent := kilnfileStatErr == nil
+
 	kf, kl, loadErr := c.Options.LoadKilnfiles(nil, nil)
 	if loadErr == nil {
 		kilnfile = kf
 		kilnfileLock = kl
-	} else {
+	} else if kilnfilePresent {
 		kfOnly, kfErr := loadKilnfileOnly(c.Options.Standard)
 		if kfErr != nil {
 			return fmt.Errorf("failed to load Kilnfile: %w", kfErr)

--- a/internal/commands/carvel_rebake_test.go
+++ b/internal/commands/carvel_rebake_test.go
@@ -124,6 +124,69 @@ var _ = Describe("CarvelReBake", func() {
 			})
 		})
 
+		When("a --variables-file points at a missing path", func() {
+			var (
+				inputPath  string
+				recordPath string
+			)
+
+			BeforeEach(func() {
+				var err error
+				inputPath, err = os.MkdirTemp("", "rebake-vars-*")
+				Expect(err).NotTo(HaveOccurred())
+				inputPath += "/tile"
+				err = os.CopyFS(inputPath, os.DirFS("../carvel/testdata/sample-tile"))
+				Expect(err).NotTo(HaveOccurred())
+
+				cmds := []*exec.Cmd{
+					exec.Command("git", "init"),
+					exec.Command("git", "add", "."),
+					exec.Command("git", "-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "initial commit"),
+				}
+				for _, cmd := range cmds {
+					cmd.Dir = inputPath
+					out, err := cmd.CombinedOutput()
+					Expect(err).NotTo(HaveOccurred(), "error invoking git: "+string(out))
+				}
+
+				headCmd := exec.Command("git", "rev-parse", "HEAD")
+				headCmd.Dir = inputPath
+				headOut, err := headCmd.CombinedOutput()
+				Expect(err).NotTo(HaveOccurred(), "error invoking git rev-parse: "+string(headOut))
+				headSHA := strings.TrimSpace(string(headOut))
+
+				record := bake.Record{
+					SourceRevision: headSHA,
+					Version:        "0.1.1",
+					TileDirectory:  inputPath,
+				}
+				buf, err := json.Marshal(record)
+				Expect(err).NotTo(HaveOccurred())
+
+				recordPath = filepath.Join(filepath.Dir(inputPath), "record.json")
+				err = os.WriteFile(recordPath, buf, 0644)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				if inputPath != "" {
+					_ = os.RemoveAll(filepath.Dir(inputPath))
+				}
+			})
+
+			It("fails loudly instead of misdiagnosing it as a missing Kilnfile", func() {
+				outputPath := filepath.Join(filepath.Dir(inputPath), "out.pivotal")
+				err := command.Execute([]string{
+					"--output-file", outputPath,
+					"--variables-file", filepath.Join(inputPath, "does-not-exist.yml"),
+					recordPath,
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Kilnfile"))
+				Expect(outputPath).NotTo(BeAnExistingFile())
+			})
+		})
+
 		When("a valid bake record and mock Artifactory are provided", func() {
 			var (
 				inputPath  string


### PR DESCRIPTION
Fixes a regression where `kiln carvel bake` would fail if a Kilnfile was not present in the tile directory. This restores backward compatibility for tiles that do not use `additional_releases`.

Also refines the error messages for the `--from-lockfile` flag and adds an acceptance test to lock in the expected behavior.

Fixes #677
JIRA-ID: TNZ-132681